### PR TITLE
chore(ci): bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/learn-monitor.yml
+++ b/.github/workflows/learn-monitor.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check markdown links
         uses: gaurav-nelson/github-action-markdown-link-check@v1
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Block internal artifacts under docs/
         shell: bash
@@ -62,7 +62,7 @@ jobs:
           done
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Block internal artifacts under docs/
         shell: bash
@@ -38,13 +38,13 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
           
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
       
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/regulatory-monitoring.yml
+++ b/.github/workflows/regulatory-monitoring.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/spa-tests.yml
+++ b/.github/workflows/spa-tests.yml
@@ -27,8 +27,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
Eliminates Node.js 20 deprecation warnings appearing in every workflow run.

## Bumps
| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-python | v5 | v6 |
| actions/cache | v4 | v5 |
| actions/setup-node | v4 | v5 |

## Files (CI-only, 12 refs in 5 workflows)
- .github/workflows/learn-monitor.yml
- .github/workflows/link-check.yml
- .github/workflows/publish_docs.yml
- .github/workflows/regulatory-monitoring.yml
- .github/workflows/spa-tests.yml

## Context
GitHub forces these actions onto Node.js 24 by 2026-06-02, and Node.js 20 is removed from runners on 2026-09-16. The new majors all use Node 24.

No behavioral changes. The PR itself exercises the upgrades via the link-check + control-consistency jobs.