### PR TITLE
fix(assessment): saved assessments restore correctly via per-id storage slots

### DIFF
--- a/docs/javascripts/assessment-app.js
+++ b/docs/javascripts/assessment-app.js
@@ -209,9 +209,34 @@
   AssessmentApp.prototype.init = function () {
     var self = this;
     this._bindMaterialSearchGuard();
+    this._migrateLegacySavedAssessments();
     this.loadData().then(function () {
       self.render();
     });
+  };
+
+  /**
+   * One-time migration: prior to the saved-list fix the SPA stored only the
+   * single most recently edited assessment in `STORAGE_KEY + "-current"`.
+   * Older entries shown in the welcome saved-assessments list pointed to
+   * data that did not exist, so clicking "Resume" silently no-op'd.
+   *
+   * The fix introduces per-assessment slots at `STORAGE_KEY + "-data-" + id`.
+   * On first run after the deploy we copy the legacy `-current` blob into its
+   * per-id slot if the slot is empty. We deliberately leave `-current` in
+   * place so the migration is idempotent and a downgrade does not lose data.
+   */
+  AssessmentApp.prototype._migrateLegacySavedAssessments = function () {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY + "-current");
+      if (!raw) return;
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || !parsed.assessmentId) return;
+      var perIdKey = STORAGE_KEY + "-data-" + parsed.assessmentId;
+      if (localStorage.getItem(perIdKey) == null) {
+        localStorage.setItem(perIdKey, raw);
+      }
+    } catch (e) { /* migration is best-effort */ }
   };
 
   /**
@@ -739,8 +764,11 @@
     if (!this.state) return;
     this.state.updatedAt = new Date().toISOString();
     try {
-      // Save current assessment
-      localStorage.setItem(STORAGE_KEY + "-current", JSON.stringify(this.state));
+      var serialized = JSON.stringify(this.state);
+      // Per-assessment slot is the source of truth for restoration.
+      localStorage.setItem(STORAGE_KEY + "-data-" + this.state.assessmentId, serialized);
+      // `-current` retained as a "most recently edited" pointer for back-compat.
+      localStorage.setItem(STORAGE_KEY + "-current", serialized);
       // Update saved list
       var list = this.getSavedList();
       var idx = list.findIndex(function (s) { return s.id === this.state.assessmentId; }.bind(this));
@@ -769,7 +797,13 @@
 
   AssessmentApp.prototype.loadFromStorage = function (id) {
     try {
-      var data = JSON.parse(localStorage.getItem(STORAGE_KEY + "-current"));
+      // Prefer the per-assessment slot; falls back to `-current` for assessments
+      // that pre-date the per-id slot OR when caller did not supply an id.
+      var raw = null;
+      if (id) raw = localStorage.getItem(STORAGE_KEY + "-data-" + id);
+      if (!raw) raw = localStorage.getItem(STORAGE_KEY + "-current");
+      if (!raw) return false;
+      var data = JSON.parse(raw);
       if (data && (!id || data.assessmentId === id) && this.validateState(data)) {
         this.state = data;
         return true;
@@ -782,6 +816,7 @@
     var list = this.getSavedList().filter(function (s) { return s.id !== id; });
     localStorage.setItem(STORAGE_KEY + "-list", JSON.stringify(list));
     try {
+      localStorage.removeItem(STORAGE_KEY + "-data-" + id);
       var current = JSON.parse(localStorage.getItem(STORAGE_KEY + "-current"));
       if (current && current.assessmentId === id) {
         localStorage.removeItem(STORAGE_KEY + "-current");

--- a/tests/spa/saved-list-multi-assessment.test.mjs
+++ b/tests/spa/saved-list-multi-assessment.test.mjs
@@ -1,0 +1,186 @@
+/**
+ * Regression test for the "saved-list data loss" P0 bug.
+ *
+ * BEFORE FIX:
+ *   - saveToStorage wrote only to `STORAGE_KEY + "-current"` (single slot)
+ *   - loadFromStorage(id) read only `-current` and required data.assessmentId === id
+ *   - Result: a consultant managing two clients sees both in the saved list, but
+ *     clicking "Resume" on the OLDER one silently no-ops because `-current` only
+ *     holds the most recently edited assessment.
+ *
+ * AFTER FIX:
+ *   - saveToStorage writes per-assessment slot `STORAGE_KEY + "-data-" + id`
+ *     and keeps `-current` as a "most recently edited" pointer.
+ *   - loadFromStorage(id) prefers the per-id slot, falls back to `-current`.
+ *   - init() runs a one-time migration that copies legacy `-current` into the
+ *     per-id slot if the slot is empty.
+ *
+ * SPA region: docs/javascripts/assessment-app.js : saveToStorage (~L740),
+ *             loadFromStorage (~L770), deleteSaved (~L790),
+ *             _migrateLegacySavedAssessments (~L218).
+ * Regresses: iter3-2-001 (P0).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { JSDOM } from "jsdom";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const APP_PATH = join(repoRoot, "docs", "javascripts", "assessment-app.js");
+const MANIFEST_PATH = join(repoRoot, "assessment", "manifest", "controls.json");
+
+function buildAssessmentDataStub(manifest) {
+  const controls = manifest.map((m) => ({
+    id: m.id,
+    title: m.title,
+    pillar: m.pillar,
+    zones: m.zonesApplicable && m.zonesApplicable.length ? m.zonesApplicable : [1, 2, 3],
+    regulations: Array.isArray(m.regulatory) ? m.regulatory : [],
+    automation: m.automation || "manual",
+  }));
+  return {
+    pillars: [
+      { num: 1, name: "Security" },
+      { num: 2, name: "Management" },
+      { num: 3, name: "Reporting" },
+      { num: 4, name: "SharePoint" },
+    ],
+    controls,
+    regulatoryMappings: {},
+    roleAssignments: {},
+    adoptionPhases: [],
+  };
+}
+
+function bootSPA() {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const dataStub = buildAssessmentDataStub(manifest);
+  const solutionsLockStub = { schemaVersion: "1.4.0", solutions: {} };
+
+  const dom = new JSDOM("<!doctype html><html><body><div id='ag-app'></div></body></html>", {
+    url: "http://localhost/assessment/",
+    runScripts: "outside-only",
+  });
+  const { window } = dom;
+
+  window.fetch = async (url) => {
+    const u = String(url);
+    let body;
+    if (u.endsWith("assessment-data.json")) body = dataStub;
+    else if (u.endsWith("controls.json")) body = manifest;
+    else if (u.endsWith("solutions-lock.json")) body = solutionsLockStub;
+    else if (u.endsWith("/i18n/en.json")) body = {};
+    else throw new Error("unexpected fetch: " + u);
+    return { ok: true, status: 200, json: async () => body };
+  };
+
+  const code = readFileSync(APP_PATH, "utf8");
+  window.eval(code);
+  return { window };
+}
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+
+async function makeApp() {
+  const { window } = bootSPA();
+  const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+  await app.loadData();
+  return { app, window };
+}
+
+function seedAssessment(app, id, name) {
+  app.state = app.newState();
+  app.state.assessmentId = id;
+  app.state.assessmentName = name;
+  app.state.scoping.organizationName = name;
+  app.state.scoping.zones = [1, 2, 3];
+  app.state.responses["1.1"] = { answer: "yes", notes: "", evidenceRef: "" };
+  app.saveToStorage();
+}
+
+describe("saved-list multi-assessment durability (iter3-2-001 P0)", () => {
+  beforeEach(() => {
+    // Fresh storage for each test.
+    if (globalThis.localStorage) globalThis.localStorage.clear();
+  });
+
+  it("persists each saved assessment under its own per-id slot", async () => {
+    const { app, window } = await makeApp();
+
+    seedAssessment(app, "id-A", "Acme Bank");
+    seedAssessment(app, "id-B", "Beta Brokers");
+
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-A")).not.toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-B")).not.toBeNull();
+
+    const list = app.getSavedList();
+    expect(list.map((s) => s.id).sort()).toEqual(["id-A", "id-B"]);
+  });
+
+  it("Resume on a non-current saved assessment loads the correct data", async () => {
+    const { app } = await makeApp();
+
+    seedAssessment(app, "id-A", "Acme Bank"); // older
+    seedAssessment(app, "id-B", "Beta Brokers"); // most recently edited; `-current` points here
+
+    // Simulate user clicking "Resume" on the OLDER entry.
+    const ok = app.loadFromStorage("id-A");
+    expect(ok, "loadFromStorage('id-A') must succeed").toBe(true);
+    expect(app.state.assessmentId).toBe("id-A");
+    expect(app.state.assessmentName).toBe("Acme Bank");
+  });
+
+  it("deleteSaved removes only the targeted per-id slot", async () => {
+    const { app, window } = await makeApp();
+
+    seedAssessment(app, "id-A", "Acme Bank");
+    seedAssessment(app, "id-B", "Beta Brokers");
+
+    app.deleteSaved("id-A");
+
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-A")).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-B")).not.toBeNull();
+    expect(app.getSavedList().map((s) => s.id)).toEqual(["id-B"]);
+  });
+
+  it("init() migrates a pre-fix `-current` blob into its per-id slot", async () => {
+    // Simulate a customer who saved an assessment with the OLD code: only
+    // `-current` exists and there is no per-id slot.
+    const { window } = bootSPA();
+    const legacyState = {
+      assessmentId: "legacy-id",
+      assessmentName: "Legacy Assessment",
+      schemaVersion: "1.4.0",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scoping: { organizationName: "Legacy Org", assessorName: "L", zones: [1, 2, 3], roles: [] },
+      responses: { "1.1": { answer: "yes", notes: "", evidenceRef: "" } },
+      overrides: {},
+      drilldown: {},
+      currentStep: "phase1",
+      completedSteps: [],
+      assessmentStatus: "in-progress",
+    };
+    window.localStorage.setItem(STORAGE_KEY + "-current", JSON.stringify(legacyState));
+    // No `-data-legacy-id` yet.
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-legacy-id")).toBeNull();
+
+    // Boot the SPA fresh and run init() (the migration step).
+    const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+    app._migrateLegacySavedAssessments();
+
+    const migrated = window.localStorage.getItem(STORAGE_KEY + "-data-legacy-id");
+    expect(migrated, "migration must populate the per-id slot").not.toBeNull();
+    expect(JSON.parse(migrated).assessmentId).toBe("legacy-id");
+
+    // Migration is idempotent: running again does not clobber a now-newer per-id slot.
+    window.localStorage.setItem(
+      STORAGE_KEY + "-data-legacy-id",
+      JSON.stringify(Object.assign({}, legacyState, { assessmentName: "Newer" }))
+    );
+    app._migrateLegacySavedAssessments();
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY + "-data-legacy-id")).assessmentName).toBe("Newer");
+  });
+});


### PR DESCRIPTION
## P0: Saved-assessments list silently loses older assessments

Discovered by iter3 customer-adversary council critic (finding iter3-2-001) during the validation-harness planning session. **Confirmed in code at L743/L770/L781.**

### Bug

A consultant managing two clients sees both assessments in the welcome saved-list, but clicking **Resume** on the older one silently no-ops:

- `saveToStorage` writes only to a single `STORAGE_KEY + '-current'` slot.
- `loadFromStorage(id)` reads `-current` and requires `data.assessmentId === id`.
- Once the consultant edits Client B, `-current` holds B; clicking Resume on A returns false.

Perceived as **data loss with no recovery**.

### Fix

- `saveToStorage` now also writes to per-assessment slot `STORAGE_KEY + '-data-' + id`; `-current` is retained as a 'most recently edited' pointer for back-compat.
- `loadFromStorage(id)` prefers the per-id slot, falls back to `-current`.
- `deleteSaved` removes the per-id slot in addition to the list entry.
- New `_migrateLegacySavedAssessments()` in `init()` copies an existing pre-fix `-current` blob into its per-id slot if absent. Idempotent. `-current` left in place so a downgrade does not lose data.

### Tests

4 new vitest regressions in `tests/spa/saved-list-multi-assessment.test.mjs`:

1. Each saved assessment persisted under its own per-id slot.
2. Resume on a non-current assessment loads the correct data.
3. `deleteSaved` removes only the targeted per-id slot.
4. `init()` migrates a pre-fix `-current` blob into its per-id slot, idempotent.

### Validation

- `npm test` -> 40 passed | 1 skipped (pre-existing).
- `mkdocs build --strict` -> green.

### Follow-up

The broader validation harness plan (Playwright E2E + CI workflows + the remaining iter3 P1/P2 fixes - resume-restores-step, role/sector-filter-leak, namespace migration, CSP, perf budget, etc.) is tracked in the session plan and will land as subsequent batched PRs.