### PR TITLE
feat(scripts): push-as-judeper, rollback-pages, persona regen, required-checks verifier

### DIFF
--- a/scripts/push-as-judeper.ps1
+++ b/scripts/push-as-judeper.ps1
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+  Push to origin as the 'judeper' GitHub account, with active-account guard
+  and post-push remote-SHA verification.
+
+.DESCRIPTION
+  The 'gh' CLI maintains a single "active" auth account per host, and that
+  active account can flip silently mid-session (for example, after another
+  tool runs `gh auth switch`, after `gh auth login`, or when an MCP/extension
+  refreshes credentials). AGENTS.md calls this out as a footgun: pushes can
+  end up authored or attributed to the wrong account if the active GH user
+  isn't asserted right before `git push`.
+
+  This wrapper:
+    1. Captures the currently-active gh account (so it can be restored).
+    2. Switches the active account to 'judeper' and asserts the switch
+       actually took effect (`gh api user -q .login`).
+    3. Runs `git push @args` (any pass-through args you supply).
+    4. Verifies the remote branch tip SHA matches local HEAD.
+    5. Restores the prior active account (only if it wasn't 'judeper').
+
+  No tokens are ever written to disk — auth flows entirely through the gh
+  CLI's credential store.
+
+.EXAMPLE
+  pwsh -File scripts/push-as-judeper.ps1
+  pwsh -File scripts/push-as-judeper.ps1 -u origin HEAD
+  pwsh -File scripts/push-as-judeper.ps1 origin infra/scripts-batch
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RestArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-ActiveGhAccount {
+    # gh auth status writes to stderr; capture both streams.
+    $raw = & gh auth status 2>&1 | Out-String
+    foreach ($line in ($raw -split "`r?`n")) {
+        if ($line -match 'account\s+(\S+)\s+\(active\)') {
+            return $Matches[1]
+        }
+        if ($line -match 'Logged in to [^ ]+ as (\S+).*\(active\)') {
+            return $Matches[1]
+        }
+    }
+    return $null
+}
+
+$priorAccount = Get-ActiveGhAccount
+if ($priorAccount) {
+    Write-Host "Prior active gh account: $priorAccount"
+} else {
+    Write-Host "Prior active gh account: <unknown>"
+}
+
+Write-Host "Switching active gh account to 'judeper'..."
+& gh auth switch -u judeper
+if ($LASTEXITCODE -ne 0) {
+    throw "gh auth switch -u judeper failed (exit $LASTEXITCODE)."
+}
+
+$current = (& gh api user -q .login).Trim()
+if ($current -ne 'judeper') {
+    throw "Active gh account is '$current', expected 'judeper'. Aborting push."
+}
+Write-Host "Verified active gh account: $current"
+
+$branch = (& git rev-parse --abbrev-ref HEAD).Trim()
+$localSha = (& git rev-parse HEAD).Trim()
+Write-Host "Local HEAD: $branch @ $localSha"
+
+try {
+    Write-Host "Running: git push $($RestArgs -join ' ')"
+    if ($RestArgs) {
+        & git push @RestArgs
+    } else {
+        & git push
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "git push failed (exit $LASTEXITCODE)."
+    }
+
+    Write-Host "Verifying remote SHA for refs/heads/$branch ..."
+    $remoteSha = (& gh api "repos/judeper/FSI-AgentGov/commits/$branch" -q .sha).Trim()
+    if ($remoteSha -ne $localSha) {
+        throw "Remote SHA mismatch: local=$localSha remote=$remoteSha"
+    }
+    Write-Host "Remote SHA matches local HEAD: $remoteSha"
+}
+finally {
+    if ($priorAccount -and $priorAccount -ne 'judeper') {
+        Write-Host "Restoring prior gh account: $priorAccount"
+        & gh auth switch -u $priorAccount | Out-Null
+    } else {
+        Write-Host "No prior-account restore needed."
+    }
+}

--- a/scripts/rollback-pages.ps1
+++ b/scripts/rollback-pages.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+  Re-deploy GitHub Pages from a prior known-good tag. Target MTTR ~2min.
+
+.DESCRIPTION
+  Operates on tags of the form 'pages-good-<SHA>'. By default rolls back to
+  the second-most-recent such tag (i.e. the previous good deploy). Triggers
+  the publish_docs.yml workflow at that ref via `gh workflow run`, then polls
+  the production /version.json until its SHA matches the rollback target's
+  commit SHA (or 5 minutes elapses).
+
+  NOTE: Auto-tagging 'pages-good-<SHA>' after each successful publish requires
+  a small edit to .github/workflows/publish_docs.yml (a final tag step on
+  success). This script is ready to use as soon as that lands; until then it
+  operates on whatever 'pages-good-*' tags exist in the repo.
+
+.PARAMETER Tag
+  Specific tag to roll back to. If omitted, defaults to the second-most-recent
+  'pages-good-*' tag by creation date.
+
+.EXAMPLE
+  pwsh -File scripts/rollback-pages.ps1
+  pwsh -File scripts/rollback-pages.ps1 -Tag pages-good-abc1234
+#>
+[CmdletBinding()]
+param(
+    [string]$Tag,
+    [string]$VersionUrl = 'https://judeper.github.io/FSI-AgentGov/version.json',
+    [int]$TimeoutSeconds = 300,
+    [int]$PollIntervalSeconds = 15
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Fetch tags + their creation dates, sort desc.
+& git fetch --tags --quiet
+$tagLines = & git for-each-ref --sort=-creatordate --format='%(refname:short)' 'refs/tags/pages-good-*'
+if (-not $tagLines) {
+    throw "No 'pages-good-*' tags found. (Hint: publish_docs.yml needs to auto-tag successful deploys.)"
+}
+$tags = @($tagLines)
+
+if (-not $Tag) {
+    if ($tags.Count -lt 2) {
+        throw "Need at least 2 'pages-good-*' tags to default to 'previous good'. Found: $($tags.Count). Pass -Tag explicitly."
+    }
+    $Tag = $tags[1]
+    Write-Host "Defaulting to previous-good tag: $Tag (most recent is $($tags[0]))"
+} else {
+    if ($tags -notcontains $Tag) {
+        throw "Tag '$Tag' is not in the pages-good-* set."
+    }
+    Write-Host "Rolling back to specified tag: $Tag"
+}
+
+$targetSha = (& git rev-list -n 1 $Tag).Trim()
+Write-Host "Target commit SHA: $targetSha"
+
+Write-Host "Triggering publish_docs.yml @ $Tag ..."
+& gh workflow run publish_docs.yml --ref $Tag
+if ($LASTEXITCODE -ne 0) {
+    throw "gh workflow run failed (exit $LASTEXITCODE)."
+}
+
+Write-Host "Polling $VersionUrl every ${PollIntervalSeconds}s up to ${TimeoutSeconds}s ..."
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$success = $false
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds $PollIntervalSeconds
+    try {
+        $resp = Invoke-RestMethod -Uri $VersionUrl -TimeoutSec 10 -Headers @{ 'Cache-Control' = 'no-cache' }
+        $liveSha = $null
+        foreach ($prop in 'sha','commit','commitSha','gitSha') {
+            if ($resp.PSObject.Properties.Name -contains $prop) { $liveSha = [string]$resp.$prop; break }
+        }
+        if ($liveSha) {
+            Write-Host "  live sha: $liveSha"
+            if ($liveSha.StartsWith($targetSha) -or $targetSha.StartsWith($liveSha)) {
+                $success = $true
+                break
+            }
+        } else {
+            Write-Host "  (version.json had no recognizable sha field)"
+        }
+    } catch {
+        Write-Host "  fetch failed: $($_.Exception.Message)"
+    }
+}
+
+if ($success) {
+    Write-Host "ROLLBACK SUCCESS: $VersionUrl now serves $targetSha (tag $Tag)."
+    exit 0
+}
+
+$body = @"
+Rollback to ``$Tag`` (commit ``$targetSha``) did not propagate to $VersionUrl within ${TimeoutSeconds}s.
+
+Triggered: ``gh workflow run publish_docs.yml --ref $Tag``
+
+Investigate the publish_docs.yml run and Pages deployment status.
+"@
+Write-Warning "Rollback did not verify within timeout. Opening tracking issue..."
+& gh issue create --title "rollback failed: $Tag" --body $body
+exit 1

--- a/scripts/update-personas.mjs
+++ b/scripts/update-personas.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * update-personas.mjs
+ *
+ * Re-emits persona JSON fixtures from the SPA's exportJSON() whenever the
+ * framework version advances. Personas live in tests/e2e/fixtures/personas/
+ * and are driven by tests/e2e/fixtures/personas/manifest.json (each entry
+ * provides the persona name plus the answer set to apply before exporting).
+ *
+ * SCAFFOLD STATUS:
+ *   tests/e2e/fixtures/personas/ does not exist yet (Phase C work). This
+ *   script is wired up so that as soon as that directory + manifest land,
+ *   regenerating fixtures is a single command. Until then it warns and
+ *   exits 0.
+ *
+ * Usage:
+ *   node scripts/update-personas.mjs
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+const PERSONAS_DIR = join(repoRoot, "tests", "e2e", "fixtures", "personas");
+const PERSONAS_MANIFEST = join(PERSONAS_DIR, "manifest.json");
+const CONTROLS_MANIFEST = join(repoRoot, "assessment", "manifest", "controls.json");
+const VERSION_JSON = join(repoRoot, "version.json");
+
+function readFrameworkVersion() {
+  if (existsSync(VERSION_JSON)) {
+    try {
+      const v = JSON.parse(readFileSync(VERSION_JSON, "utf8"));
+      if (v && (v.frameworkVersion || v.version)) {
+        return v.frameworkVersion || v.version;
+      }
+    } catch (e) {
+      console.warn(`warn: could not parse ${VERSION_JSON}: ${e.message}`);
+    }
+  }
+  if (existsSync(CONTROLS_MANIFEST)) {
+    try {
+      const m = JSON.parse(readFileSync(CONTROLS_MANIFEST, "utf8"));
+      // controls.json is currently a bare array; check for wrapper objects too.
+      if (m && !Array.isArray(m) && (m.frameworkVersion || m.version)) {
+        return m.frameworkVersion || m.version;
+      }
+    } catch (e) {
+      console.warn(`warn: could not parse ${CONTROLS_MANIFEST}: ${e.message}`);
+    }
+  }
+  return "unknown";
+}
+
+/**
+ * Boot the SPA in jsdom and return { window, exportJSON, applyAnswers }.
+ * Mirrors the boot pattern in tests/spa/export-shape.test.mjs. Implementation
+ * is intentionally deferred until the persona harness lands so we don't pin
+ * the boot helper to a stale shape.
+ */
+async function bootSPA() {
+  throw new Error("bootSPA() not yet wired — implement against tests/spa/export-shape.test.mjs once personas land.");
+}
+
+async function regeneratePersona(personaFile, answers) {
+  const { exportJSON, applyAnswers } = await bootSPA();
+  applyAnswers(answers);
+  const exported = exportJSON();
+  writeFileSync(personaFile, JSON.stringify(exported, null, 2) + "\n", "utf8");
+  const touched = exported && exported._computedScores && exported._computedScores.perControl
+    ? Object.keys(exported._computedScores.perControl).length
+    : 0;
+  return touched;
+}
+
+async function main() {
+  const frameworkVersion = readFrameworkVersion();
+  console.log(`Framework version: ${frameworkVersion}`);
+
+  if (!existsSync(PERSONAS_DIR)) {
+    console.warn(
+      "Personas directory not yet created (Phase C scaffold pending). " +
+      "Script ready for use once personas land."
+    );
+    process.exit(0);
+  }
+
+  if (!existsSync(PERSONAS_MANIFEST)) {
+    console.warn(
+      `No persona manifest at ${PERSONAS_MANIFEST}. ` +
+      "Script ready for use once personas land."
+    );
+    process.exit(0);
+  }
+
+  const manifest = JSON.parse(readFileSync(PERSONAS_MANIFEST, "utf8"));
+  const personas = Array.isArray(manifest) ? manifest : (manifest.personas || []);
+  if (!personas.length) {
+    console.warn("Persona manifest is empty. Nothing to regenerate.");
+    process.exit(0);
+  }
+
+  const existing = new Set(
+    readdirSync(PERSONAS_DIR).filter(f => f.endsWith(".json") && f !== "manifest.json")
+  );
+
+  let failed = 0;
+  for (const p of personas) {
+    const name = p.name || p.id;
+    const file = join(PERSONAS_DIR, p.file || `${name}.json`);
+    if (!existing.has(p.file || `${name}.json`)) {
+      console.warn(`${name}: target file not present yet — will be created`);
+    }
+    try {
+      const touched = await regeneratePersona(file, p.answers || {});
+      console.log(`${name}: updated (controls touched: ${touched})`);
+    } catch (e) {
+      failed += 1;
+      console.error(`${name}: FAILED — ${e.message}`);
+    }
+  }
+
+  if (failed > 0) {
+    console.error(`update-personas: ${failed} persona(s) failed.`);
+    process.exit(1);
+  }
+  console.log("update-personas: all personas re-emitted successfully.");
+}
+
+main().catch(err => {
+  console.error("update-personas: fatal:", err);
+  process.exit(1);
+});

--- a/scripts/verify-required-checks.mjs
+++ b/scripts/verify-required-checks.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * verify-required-checks.mjs
+ *
+ * Asserts that every context listed in
+ * .github/branch-protection.json -> required_status_checks.contexts
+ * matches a workflow job's *display name* (the `jobs.<key>.name` field, or
+ * the job key itself if no `name:` is set).
+ *
+ * GITHUB FOOTGUN:
+ *   Required status checks are matched against the job's display name. A
+ *   single typo in branch-protection.json (or renaming a job's `name:`
+ *   without updating protection) silently means "no check is required" —
+ *   the PR can be merged green without ever running CI for that context.
+ *   This verifier turns that silent failure into a loud one.
+ *
+ * LIMITATIONS:
+ *   We do not depend on js-yaml. Instead we extract `name:` lines that sit
+ *   under `jobs:` blocks via regex. This is "good enough" for the simple
+ *   single-document workflows in this repo (no anchors, no folded scalars
+ *   for job names). If we ever need stricter parsing, swap in js-yaml.
+ *
+ * Exit codes:
+ *   0 — all required contexts found (or branch-protection.json absent)
+ *   1 — at least one required context not matched
+ */
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..");
+const PROTECTION_FILE = join(repoRoot, ".github", "branch-protection.json");
+const WORKFLOWS_DIR = join(repoRoot, ".github", "workflows");
+
+if (!existsSync(PROTECTION_FILE)) {
+  console.log("branch-protection.json not yet created; nothing to verify.");
+  process.exit(0);
+}
+
+const protection = JSON.parse(readFileSync(PROTECTION_FILE, "utf8"));
+const required =
+  (protection.required_status_checks && protection.required_status_checks.contexts) ||
+  protection.contexts ||
+  [];
+
+if (!required.length) {
+  console.log("No required_status_checks.contexts listed; nothing to verify.");
+  process.exit(0);
+}
+
+if (!existsSync(WORKFLOWS_DIR)) {
+  console.error(`FAIL: ${WORKFLOWS_DIR} does not exist but contexts are required:\n  - ${required.join("\n  - ")}`);
+  process.exit(1);
+}
+
+const workflowFiles = readdirSync(WORKFLOWS_DIR)
+  .filter(f => f.endsWith(".yml") || f.endsWith(".yaml"))
+  .map(f => join(WORKFLOWS_DIR, f))
+  .filter(f => statSync(f).isFile());
+
+/**
+ * Extract job display names from a workflow YAML file.
+ * Strategy: find the top-level `jobs:` block, then for each job key
+ * (2-space indent under jobs:), capture an optional `name:` directive at
+ * 4-space indent. If no `name:` is present, the job key is the display name.
+ */
+function extractJobNames(yamlText) {
+  const lines = yamlText.split(/\r?\n/);
+  const names = [];
+  let inJobs = false;
+  let currentJobKey = null;
+  let currentJobName = null;
+
+  const flush = () => {
+    if (currentJobKey) {
+      names.push(currentJobName ?? currentJobKey);
+    }
+    currentJobKey = null;
+    currentJobName = null;
+  };
+
+  for (const raw of lines) {
+    const line = raw.replace(/\t/g, "  ");
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+    // A new top-level key (no leading space) ends the jobs block.
+    if (/^\S/.test(line) && !/^\s/.test(line) && line.trim().length) {
+      flush();
+      inJobs = false;
+      continue;
+    }
+    // Job key: exactly 2 spaces of indent, then `key:`
+    const jobKeyMatch = line.match(/^ {2}([A-Za-z0-9_\-]+):\s*$/);
+    if (jobKeyMatch) {
+      flush();
+      currentJobKey = jobKeyMatch[1];
+      currentJobName = null;
+      continue;
+    }
+    // Job-scoped name: 4 spaces of indent, then `name:`
+    const nameMatch = line.match(/^ {4}name:\s*(.+?)\s*$/);
+    if (nameMatch && currentJobKey && currentJobName === null) {
+      let val = nameMatch[1];
+      // Strip surrounding quotes.
+      if ((val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))) {
+        val = val.slice(1, -1);
+      }
+      currentJobName = val;
+    }
+  }
+  flush();
+  return names;
+}
+
+const allJobNames = new Map(); // displayName -> [files...]
+for (const wf of workflowFiles) {
+  const text = readFileSync(wf, "utf8");
+  const names = extractJobNames(text);
+  for (const n of names) {
+    if (!allJobNames.has(n)) allJobNames.set(n, []);
+    allJobNames.get(n).push(wf);
+  }
+}
+
+let failed = 0;
+for (const ctx of required) {
+  if (allJobNames.has(ctx)) {
+    const where = allJobNames.get(ctx).map(f => f.replace(repoRoot + "\\", "").replace(repoRoot + "/", "")).join(", ");
+    console.log(`OK    ${ctx}  (${where})`);
+  } else {
+    failed += 1;
+    console.error(`FAIL  ${ctx}  — no workflow job has this display name`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\nverify-required-checks: ${failed} unmatched context(s).`);
+  console.error("Tip: required status checks match jobs.<key>.name (or the job key if name is omitted).");
+  process.exit(1);
+}
+console.log(`\nverify-required-checks: all ${required.length} required context(s) matched.`);
+process.exit(0);


### PR DESCRIPTION
Adds 4 helper scripts (Themes 1/2/3, iter3-1-006/007):

- `scripts/push-as-judeper.ps1` - account-asserting + remote-SHA-verifying push wrapper. Closes the gh-CLI silent-flip footgun documented in AGENTS.md.
- `scripts/rollback-pages.ps1` - re-deploys a prior `pages-good-*` tag and polls /version.json. Target MTTR ~2min. Note: requires publish_docs.yml to auto-tag successful deploys; script is ready when that lands.
- `scripts/update-personas.mjs` - scaffolded persona-fixture regenerator keyed on FRAMEWORK_VERSION. Exits 0 with a clear message until `tests/e2e/fixtures/personas/` exists.
- `scripts/verify-required-checks.mjs` - asserts `.github/branch-protection.json` required contexts match a workflow `jobs.<key>.name`. Closes the silent-no-op CI footgun (typos = 'no check required'). Exits 0 if branch-protection.json absent.

Dogfooded: this branch was pushed via push-as-judeper.ps1 and SHA-verified successfully.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>