### PR TITLE
test(spa): add 7 vitest contract specs per Theme 5 pyramid correction

### DIFF
--- a/tests/spa/_bootSpa.mjs
+++ b/tests/spa/_bootSpa.mjs
@@ -1,0 +1,105 @@
+/**
+ * Shared bootSPA() helper for vitest contract specs.
+ *
+ * Mirrors the boot pattern in export-shape.test.mjs: spins up jsdom with a
+ * fetch shim that serves the local manifest and a Blob/anchor shim that
+ * captures download payloads in-memory. Returns { window, captured }; tests
+ * then construct `new window.AssessmentApp(...)` and drive it directly.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { JSDOM } from "jsdom";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const APP_PATH = join(repoRoot, "docs", "javascripts", "assessment-app.js");
+const MANIFEST_PATH = join(repoRoot, "assessment", "manifest", "controls.json");
+
+function buildAssessmentDataStub(manifest) {
+  const controls = manifest.map(m => ({
+    id: m.id,
+    title: m.title,
+    pillar: m.pillar,
+    zones: m.zonesApplicable && m.zonesApplicable.length ? m.zonesApplicable : [1, 2, 3],
+    regulations: Array.isArray(m.regulatory) ? m.regulatory : [],
+    automation: m.automation || "manual",
+  }));
+  return {
+    pillars: [
+      { num: 1, name: "Security" },
+      { num: 2, name: "Management" },
+      { num: 3, name: "Reporting" },
+      { num: 4, name: "SharePoint" },
+    ],
+    controls,
+    regulatoryMappings: {},
+    roleAssignments: {},
+    adoptionPhases: [],
+  };
+}
+
+export function bootSPA() {
+  const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const dataStub = buildAssessmentDataStub(manifest);
+  const solutionsLockStub = { schemaVersion: "1.4.0", solutions: {} };
+
+  const dom = new JSDOM("<!doctype html><html><body><div id='ag-app'></div></body></html>", {
+    url: "http://localhost/assessment/",
+    runScripts: "outside-only",
+  });
+  const { window } = dom;
+
+  window.fetch = async (url) => {
+    const u = String(url);
+    let body;
+    if (u.endsWith("assessment-data.json")) body = dataStub;
+    else if (u.endsWith("controls.json")) body = manifest;
+    else if (u.endsWith("solutions-lock.json")) body = solutionsLockStub;
+    else if (u.endsWith("/i18n/en.json")) body = {};
+    else throw new Error("unexpected fetch: " + u);
+    return { ok: true, status: 200, json: async () => body };
+  };
+
+  const blobsByUrl = new Map();
+  let urlCounter = 0;
+  window.URL.createObjectURL = (blob) => {
+    const u = "blob:stub#" + (++urlCounter);
+    blobsByUrl.set(u, blob);
+    return u;
+  };
+  window.URL.revokeObjectURL = () => {};
+  const captured = [];
+  window.HTMLAnchorElement.prototype.click = function () {
+    const blob = blobsByUrl.get(this.href);
+    captured.push({ name: this.download, blob });
+  };
+  const RealBlob = window.Blob;
+  function WrappedBlob(parts, opts) {
+    const b = new RealBlob(parts, opts);
+    b.__parts = parts;
+    b.__text = parts.map(p => (typeof p === "string" ? p : "")).join("");
+    return b;
+  }
+  WrappedBlob.prototype = RealBlob.prototype;
+  window.Blob = WrappedBlob;
+
+  const code = readFileSync(APP_PATH, "utf8");
+  window.eval(code);
+  return { window, captured, manifest };
+}
+
+/** Boot, instantiate, load data, and prep a usable state. */
+export async function bootApp({ answerControls = [] } = {}) {
+  const { window, captured, manifest } = bootSPA();
+  const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+  await app.loadData();
+  app.state = app.newState();
+  app.state.scoping.organizationName = "Test Org";
+  app.state.scoping.assessorName = "Tester";
+  app.state.scoping.zones = [1, 2, 3];
+  for (const { id, answer } of answerControls) {
+    app.state.responses[id] = { answer, notes: "", evidenceRef: "" };
+  }
+  return { window, captured, app, manifest };
+}

--- a/tests/spa/csv-escape.test.mjs
+++ b/tests/spa/csv-escape.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * CSV cell escape / formula-injection contract tests.
+ *
+ * The SPA sanitizes CSV cells via `sanitizeCell` (module-private) and the
+ * inline `csvField` helper inside exportCSV. We test through the public
+ * exportCSV path: inject a known-bad value into state, run exportCSV, then
+ * parse the captured Blob.
+ *
+ * Cases marked [XFAIL] document the *desired* behavior of the upcoming
+ * spa-fix-formula-injection patch and skip cleanly until it ships.
+ */
+import { describe, it, expect } from "vitest";
+import { bootApp } from "./_bootSpa.mjs";
+
+async function exportCsvWithNotes(notesByControl) {
+  const answerControls = Object.keys(notesByControl).map(id => ({ id, answer: "no" }));
+  const { app, captured } = await bootApp({ answerControls });
+  for (const [id, notes] of Object.entries(notesByControl)) {
+    app.state.responses[id].notes = notes;
+  }
+  app.exportCSV();
+  return captured[captured.length - 1].blob.__text;
+}
+
+/** Quote-aware CSV row parser. */
+function parseCsvRow(line) {
+  const fields = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+      else if (ch === '"') { inQuotes = false; }
+      else { cur += ch; }
+    } else {
+      if (ch === ",") { fields.push(cur); cur = ""; }
+      else if (ch === '"' && cur === "") { inQuotes = true; }
+      else { cur += ch; }
+    }
+  }
+  fields.push(cur);
+  return fields;
+}
+
+/** Returns the notes column value for a given control id from the CSV. */
+function notesFor(csv, controlId) {
+  const lines = csv.split("\n");
+  for (const line of lines.slice(1)) {
+    const fields = parseCsvRow(line);
+    if (fields[0] === controlId) return fields[fields.length - 1];
+  }
+  return null;
+}
+
+/** Returns the raw CSV line for a control id (before quote/comma parsing). */
+function rawLineFor(csv, controlId) {
+  const lines = csv.split("\n");
+  return lines.find(l => l.startsWith(controlId + ",") || l.startsWith('"' + controlId + '"'));
+}
+
+/** Match either of the two formula-prefix conventions (apostrophe or TAB). */
+const FORMULA_PREFIX_RE = /^['\t]/;
+
+describe("CSV cell escape / formula injection", () => {
+  it("field with comma is double-quoted", async () => {
+    const csv = await exportCsvWithNotes({ "1.1": "hello, world" });
+    expect(rawLineFor(csv, "1.1")).toContain('"hello, world"');
+    expect(notesFor(csv, "1.1")).toBe("hello, world");
+  });
+
+  it("field with embedded quote has internal quotes doubled", async () => {
+    const csv = await exportCsvWithNotes({ "1.1": 'a"b' });
+    expect(rawLineFor(csv, "1.1")).toContain('"a""b"');
+    expect(notesFor(csv, "1.1")).toBe('a"b');
+  });
+
+  it("field with newline is double-quoted (CR/LF flattened to space)", async () => {
+    const csv = await exportCsvWithNotes({ "1.1": "line1\nline2" });
+    expect(rawLineFor(csv, "1.1")).toContain('"line1 line2"');
+  });
+
+  it("field with carriage return is double-quoted", async () => {
+    const csv = await exportCsvWithNotes({ "1.1": "before\rafter" });
+    expect(rawLineFor(csv, "1.1")).toContain('"');
+  });
+
+  it("formula-injection leading chars (=, +, -, @, TAB, CR) are prefixed", async () => {
+    // Run each case in isolation so a misordered field can't masquerade as
+    // another control's notes.
+    for (const note of ["=cmd|'/c calc'!A1", "+1+1", "-2+3", "@SUM(A1)", "\tinjected", "\rinjected"]) {
+      const csv = await exportCsvWithNotes({ "1.1": note });
+      const got = notesFor(csv, "1.1");
+      expect(got, `note ${JSON.stringify(note)}`).toMatch(FORMULA_PREFIX_RE);
+    }
+  });
+
+  // [XFAIL: spa-fix-formula-injection] BOM/zero-width prefix stripping is a
+  // planned hardening. Today's sanitizeCell only inspects the FIRST char, so
+  // a leading \uFEFF bypasses the formula-prefix guard. Activate this test
+  // once the sanitizeCell rewrite (strip \uFEFF\u200B\u200C\u200D before the
+  // leading-char check) lands.
+  it.skip("[XFAIL: spa-fix-formula-injection] BOM / zero-width chars at start are stripped before formula-prefix check", async () => {
+    for (const note of ["\uFEFF=cmd", "\u200B=cmd", "\u200C+1+1", "\u200D-2+3"]) {
+      const csv = await exportCsvWithNotes({ "1.1": note });
+      const got = notesFor(csv, "1.1");
+      expect(got).toMatch(/^['\t][=+\-@]/);
+      expect(got.charCodeAt(0)).not.toBe(0xFEFF);
+    }
+  });
+});

--- a/tests/spa/filter-loop-perf.test.mjs
+++ b/tests/spa/filter-loop-perf.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * Filter-loop performance guardrail.
+ *
+ * Boots the SPA, populates state with all 78 controls answered, then calls
+ * getGapControls() 100 times in a loop. Asserts wall time < 500ms — generous
+ * enough that the current N²-ish behavior on 78 controls passes, but tight
+ * enough that a future regression (or removal of spa-fix-perf-loop) trips.
+ */
+import { describe, it, expect } from "vitest";
+import { bootApp } from "./_bootSpa.mjs";
+
+describe("getGapControls() performance guardrail", () => {
+  it("100 iterations on 78 fully-answered controls completes in < 500ms", async () => {
+    const { app } = await bootApp();
+    // Answer every control with a mix of answers so most/all become "gaps".
+    const answers = ["yes", "partial", "no", "yes", "no"];
+    app.data.controls.forEach((c, i) => {
+      app.state.responses[c.id] = { answer: answers[i % answers.length], notes: "", evidenceRef: "" };
+    });
+    // Apply a roleFilter that excludes ~30+ controls (per spec). The current
+    // SPA reads roleFilter from state; even if no controls match the filter
+    // string, getGapControls still returns a useful set so the loop is
+    // meaningful.
+    app.state.roleFilter = "Power Platform Admin";
+
+    const t0 = Date.now();
+    let lastLen = 0;
+    for (let i = 0; i < 100; i++) {
+      lastLen = app.getGapControls().length;
+    }
+    const elapsed = Date.now() - t0;
+
+    expect(lastLen).toBeGreaterThan(0);
+    expect(elapsed, `getGapControls x100 took ${elapsed}ms`).toBeLessThan(500);
+  });
+});

--- a/tests/spa/json-envelope-schema.test.mjs
+++ b/tests/spa/json-envelope-schema.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * JSON envelope schema contract tests.
+ *
+ * Validates the v1.4.1 export-JSON envelope shape. Uses ajv if installed for
+ * strict JSON-schema validation; otherwise falls back to hand-rolled
+ * assertions (which cover the same constraints).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { bootApp } from "./_bootSpa.mjs";
+
+let ajvAvailable = false;
+let Ajv;
+try {
+  Ajv = (await import(/* @vite-ignore */ "ajv")).default;
+  ajvAvailable = true;
+} catch {
+  ajvAvailable = false;
+}
+
+const envelopeSchema = {
+  type: "object",
+  required: ["_metadata", "_computedScores", "assessmentStatus", "assessmentId", "responses", "scoping", "completedSteps"],
+  properties: {
+    _metadata: {
+      type: "object",
+      required: ["frameworkVersion", "exportedAt"],
+      properties: {
+        frameworkVersion: { type: "string", minLength: 1 },
+        exportedAt: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}T" },
+      },
+    },
+    _computedScores: {
+      type: "object",
+      required: ["overall", "perPillar", "perControl"],
+      properties: {
+        perPillar: { type: "object" },
+        perControl: { type: "object" },
+      },
+    },
+    assessmentStatus: { type: "string", enum: ["draft", "in-progress", "final"] },
+  },
+};
+
+describe("export-JSON envelope schema", () => {
+  let envelope;
+
+  beforeAll(async () => {
+    const { app, captured } = await bootApp({
+      answerControls: [
+        { id: "1.1", answer: "yes" },
+        { id: "1.2", answer: "no" },
+        { id: "2.1", answer: "partial" },
+      ],
+    });
+    app.exportJSON();
+    envelope = JSON.parse(captured[captured.length - 1].blob.__text);
+  });
+
+  it("validates against the envelope JSON schema (ajv if available)", () => {
+    if (!ajvAvailable) {
+      console.warn("ajv not installed — falling back to hand-rolled assertions");
+      return;
+    }
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    const validate = ajv.compile(envelopeSchema);
+    const ok = validate(envelope);
+    if (!ok) console.error(validate.errors);
+    expect(ok).toBe(true);
+  });
+
+  it("_metadata.frameworkVersion is a non-empty string", () => {
+    expect(typeof envelope._metadata.frameworkVersion).toBe("string");
+    expect(envelope._metadata.frameworkVersion.length).toBeGreaterThan(0);
+  });
+
+  it("_metadata.exportedAt is ISO-8601", () => {
+    expect(envelope._metadata.exportedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/
+    );
+    const d = new Date(envelope._metadata.exportedAt);
+    expect(Number.isFinite(d.getTime())).toBe(true);
+  });
+
+  it("_metadata.frameworkVersion matches semver-like \\d+.\\d+.\\d+", () => {
+    expect(envelope._metadata.frameworkVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("_computedScores.overall is null or a number 0-100", () => {
+    const o = envelope._computedScores.overall;
+    if (o !== null) {
+      expect(typeof o).toBe("number");
+      expect(o).toBeGreaterThanOrEqual(0);
+      expect(o).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("_computedScores.perPillar covers pillars 1-4", () => {
+    const pp = envelope._computedScores.perPillar;
+    // The current SPA emits an OBJECT keyed "1".."4". The roadmap discusses
+    // an alternative array form with {pillar, score} entries; accept either.
+    if (Array.isArray(pp)) {
+      expect(pp).toHaveLength(4);
+      pp.forEach(entry => {
+        expect(entry).toHaveProperty("pillar");
+        expect(entry).toHaveProperty("score");
+      });
+    } else {
+      expect(Object.keys(pp).sort()).toEqual(["1", "2", "3", "4"]);
+    }
+  });
+
+  it("_computedScores.perControl is an object keyed by control id", () => {
+    expect(typeof envelope._computedScores.perControl).toBe("object");
+    expect(Array.isArray(envelope._computedScores.perControl)).toBe(false);
+    expect(envelope._computedScores.perControl).toHaveProperty("1.1");
+    expect(envelope._computedScores.perControl).toHaveProperty("1.2");
+  });
+
+  it("assessmentStatus is one of {draft, in-progress, final}", () => {
+    expect(["draft", "in-progress", "final"]).toContain(envelope.assessmentStatus);
+  });
+
+  it("preserves all original state keys at top level (importer back-compat)", () => {
+    for (const key of [
+      "assessmentId", "assessmentName", "createdAt", "updatedAt",
+      "scoping", "responses", "drilldown", "completedSteps",
+    ]) {
+      expect(envelope, `missing top-level key: ${key}`).toHaveProperty(key);
+    }
+  });
+});

--- a/tests/spa/md-escape.test.mjs
+++ b/tests/spa/md-escape.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * Markdown agenda cell escape contract tests.
+ *
+ * The current `_agendaMdCell` only escapes pipes and newlines (table-cell
+ * safety). Broader escaping (HTML tag chars, link syntax, backticks, emphasis)
+ * is *desired* but not yet implemented — those tests skip until a future
+ * spa-fix-md-escape patch lands.
+ *
+ * We test through the public `_buildAgendaMarkdown` helper.
+ */
+import { describe, it, expect } from "vitest";
+import { bootApp } from "./_bootSpa.mjs";
+
+let mdAvailable = false;
+let MarkdownIt;
+try {
+  MarkdownIt = (await import(/* @vite-ignore */ "markdown-it")).default;
+  mdAvailable = true;
+} catch {
+  mdAvailable = false;
+}
+
+async function buildAgenda({ id = "1.1", title = "Test Control", notes = "" } = {}) {
+  const { app } = await bootApp({ answerControls: [{ id, answer: "no" }] });
+  app.state.responses[id].notes = notes;
+  // Inject a malicious title via the manifest data already loaded.
+  const ctrl = app.data.controls.find(c => c.id === id);
+  if (ctrl) ctrl.title = title;
+  return app._buildAgendaMarkdown();
+}
+
+describe("agenda markdown cell escape", () => {
+  it("flattens newlines inside table cells", async () => {
+    const md = await buildAgenda({ title: "line1\nline2" });
+    expect(md).toMatch(/\| 1\.1 \| line1 line2 \|/);
+  });
+
+  it("escapes pipe characters inside table cells", async () => {
+    const md = await buildAgenda({ title: "a|b|c" });
+    expect(md).toContain("a\\|b\\|c");
+  });
+
+  // [XFAIL: spa-fix-md-escape] HTML / link / backtick / emphasis escaping
+  // isn't implemented yet — _agendaMdCell only neutralizes newlines and pipes
+  // (table-cell safety). Activate when the broader escape patch lands.
+  it.skip("[XFAIL: spa-fix-md-escape] escapes <script> tag chars", async () => {
+    const md = await buildAgenda({ title: "<script>alert(1)</script>" });
+    expect(md).not.toContain("<script>");
+    expect(md).toMatch(/&lt;|\\</);
+  });
+
+  it.skip("[XFAIL: spa-fix-md-escape] escapes [link](url) brackets/parens", async () => {
+    const md = await buildAgenda({ title: "[click](http://evil)" });
+    expect(md).toMatch(/\\\[click\\\]\\\(http:\/\/evil\\\)/);
+  });
+
+  it.skip("[XFAIL: spa-fix-md-escape] escapes backticks", async () => {
+    const md = await buildAgenda({ title: "`code`" });
+    expect(md).toContain("\\`code\\`");
+  });
+
+  it.skip("[XFAIL: spa-fix-md-escape] escapes underscore-only emphasis", async () => {
+    const md = await buildAgenda({ title: "_emph_" });
+    expect(md).toContain("\\_emph\\_");
+  });
+
+  it("markdown-it on safe agenda input does not produce HTML tags", async () => {
+    if (!mdAvailable) {
+      console.warn("markdown-it not installed — skipping rendered-output check");
+      return;
+    }
+    // This assertion holds today only for inputs that don't include raw HTML
+    // (newlines/pipes are already neutralized). For raw-HTML payloads, see
+    // the XFAIL block above.
+    const md = await buildAgenda({ title: "safe | text" });
+    const renderer = new MarkdownIt({ html: false });
+    const html = renderer.render(md);
+    expect(html).not.toMatch(/<script/i);
+  });
+});

--- a/tests/spa/persona-parity.test.mjs
+++ b/tests/spa/persona-parity.test.mjs
@@ -1,0 +1,68 @@
+/**
+ * Persona round-trip parity tests.
+ *
+ * For each persona fixture under tests/e2e/fixtures/personas/*.json:
+ *   1. Boot the SPA
+ *   2. Apply the persona's recorded answers
+ *   3. Call exportJSON()
+ *   4. Assert the resulting _computedScores matches the persona's recorded
+ *      scores within ±0.5 (round-trip parity)
+ *
+ * Personas haven't been generated yet (Phase C scaffold); this spec activates
+ * once `scripts/update-personas.mjs` lands and writes the fixtures.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { bootApp } from "./_bootSpa.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const PERSONAS_DIR = join(here, "..", "e2e", "fixtures", "personas");
+
+const haveFixtures = existsSync(PERSONAS_DIR);
+const personaFiles = haveFixtures
+  ? readdirSync(PERSONAS_DIR).filter(f => f.endsWith(".json"))
+  : [];
+
+describe("persona round-trip parity", () => {
+  if (!haveFixtures || personaFiles.length === 0) {
+    it.skip("personas not yet generated; run scripts/update-personas.mjs after Phase C scaffold lands", () => {});
+    return;
+  }
+
+  for (const file of personaFiles) {
+    describe(file, () => {
+      let persona, envelope;
+
+      beforeAll(async () => {
+        persona = JSON.parse(readFileSync(join(PERSONAS_DIR, file), "utf8"));
+        const answerControls = Object.entries(persona.responses || {})
+          .filter(([, r]) => r && r.answer)
+          .map(([id, r]) => ({ id, answer: r.answer }));
+        const { app, captured } = await bootApp({ answerControls });
+        if (persona.scoping) Object.assign(app.state.scoping, persona.scoping);
+        app.exportJSON();
+        envelope = JSON.parse(captured[captured.length - 1].blob.__text);
+      });
+
+      it("overall score matches recorded value within ±0.5", () => {
+        if (persona.expectedScores?.overall == null) return;
+        expect(Math.abs(envelope._computedScores.overall - persona.expectedScores.overall))
+          .toBeLessThanOrEqual(0.5);
+      });
+
+      it("per-pillar scores match recorded values within ±0.5", () => {
+        const expected = persona.expectedScores?.perPillar;
+        if (!expected) return;
+        for (const k of Object.keys(expected)) {
+          const got = Array.isArray(envelope._computedScores.perPillar)
+            ? envelope._computedScores.perPillar.find(p => String(p.pillar) === String(k))?.score
+            : envelope._computedScores.perPillar[k];
+          if (expected[k] == null || got == null) continue;
+          expect(Math.abs(got - expected[k])).toBeLessThanOrEqual(0.5);
+        }
+      });
+    });
+  }
+});

--- a/tests/spa/prototype-pollution-validator.test.mjs
+++ b/tests/spa/prototype-pollution-validator.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * Prototype-pollution validator contract tests.
+ *
+ * Desired behavior (spa-fix-prototype-pollution): importState must REJECT any
+ * payload containing __proto__, constructor, or prototype keys at any depth.
+ *
+ * Today's SPA defends *partially* — it only copies known keys into a fresh
+ * `clean` object — but it doesn't outright reject the import. The strict
+ * "rejects" assertions are therefore skipped (XFAIL) until the explicit deep-
+ * scan validator lands. The Object.prototype-not-polluted sanity checks ARE
+ * exercised today; that's the security-critical invariant we don't ever want
+ * to regress.
+ */
+import { describe, it, expect } from "vitest";
+import { bootApp } from "./_bootSpa.mjs";
+
+function baseValidPayload() {
+  return {
+    assessmentId: "test-1",
+    assessmentName: "test",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    scoping: {
+      organizationName: "X", assessorName: "Y", assessorRole: "",
+      institutionType: "", zones: [1, 2, 3], adoptionPhase: 0,
+      regulations: [], scope: "full",
+    },
+    responses: {},
+    drilldown: {},
+    completedSteps: [],
+  };
+}
+
+describe("import payload prototype-pollution validator", () => {
+  it("Object.prototype is NOT polluted after importing a __proto__ payload (sanity)", async () => {
+    const { app, window } = await bootApp();
+    window.alert = () => {};
+    const payload = baseValidPayload();
+    Object.defineProperty(payload, "__proto__", {
+      value: { polluted: true }, enumerable: true, configurable: true, writable: true,
+    });
+    try { app.importState(JSON.stringify(payload)); } catch { /* tolerated */ }
+    expect(({}).polluted).toBeUndefined();
+    expect(Object.prototype.polluted).toBeUndefined();
+  });
+
+  it("nested __proto__ payload also leaves Object.prototype untouched (sanity)", async () => {
+    const { app, window } = await bootApp();
+    window.alert = () => {};
+    const payload = baseValidPayload();
+    Object.defineProperty(payload.scoping, "__proto__", {
+      value: { polluted: true }, enumerable: true, configurable: true, writable: true,
+    });
+    try { app.importState(JSON.stringify(payload)); } catch { /* tolerated */ }
+    expect(({}).polluted).toBeUndefined();
+    expect(Object.prototype.polluted).toBeUndefined();
+  });
+
+  // [XFAIL: spa-fix-prototype-pollution] outright rejection of payloads with
+  // __proto__/constructor/prototype keys at any depth is the desired contract.
+  // Activate these once an explicit deep-scan validator is added to importState.
+  it.skip("[XFAIL: spa-fix-prototype-pollution] rejects payload with own __proto__ key at root", async () => {
+    const { app, window } = await bootApp();
+    window.alert = () => {};
+    const json = '{"__proto__":{"polluted":true},"assessmentId":"x","scoping":{},"responses":{},"completedSteps":[]}';
+    expect(app.importState(json)).toBe(false);
+  });
+
+  it.skip("[XFAIL: spa-fix-prototype-pollution] rejects payload with nested __proto__ key", async () => {
+    const { app, window } = await bootApp();
+    window.alert = () => {};
+    const json = '{"assessmentId":"x","scoping":{"__proto__":{"polluted":true}},"responses":{},"completedSteps":[]}';
+    expect(app.importState(json)).toBe(false);
+  });
+
+  it.skip("[XFAIL: spa-fix-prototype-pollution] rejects payload with constructor/prototype keys", async () => {
+    const { app, window } = await bootApp();
+    window.alert = () => {};
+    const json = '{"assessmentId":"x","scoping":{},"responses":{"1.1":{"constructor":{"prototype":{"x":1}},"answer":"yes"}},"completedSteps":[]}';
+    expect(app.importState(json)).toBe(false);
+  });
+});

--- a/tests/spa/xlsx-cell-shape.test.mjs
+++ b/tests/spa/xlsx-cell-shape.test.mjs
@@ -1,0 +1,37 @@
+/**
+ * XLSX export cell-shape contract tests.
+ *
+ * Boots the SPA, calls exportExcel(), captures the workbook Blob, and parses
+ * it with the `xlsx` package. Asserts sheet names + header rows.
+ *
+ * If `xlsx` is not installed (current dev-dep set), the suite skips with an
+ * actionable note. If the package IS installed but SheetJS isn't loaded into
+ * the SPA's window, the assertions skip.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { bootApp } from "./_bootSpa.mjs";
+
+let XLSX;
+let xlsxAvailable = false;
+try {
+  XLSX = await import(/* @vite-ignore */ "xlsx");
+  xlsxAvailable = true;
+} catch {
+  xlsxAvailable = false;
+}
+
+describe("XLSX export cell shape", () => {
+  if (!xlsxAvailable) {
+    it.skip("xlsx package not installed; install via `npm i -D xlsx` and re-run", () => {});
+    return;
+  }
+
+  // SheetJS is lazy-loaded by the SPA via a script tag relative to
+  // assessment-loader.js, which doesn't exist in the jsdom harness. We can
+  // inject XLSX onto the window, but exportExcel's internal helpers (e.g.
+  // workbook metadata access) still tickle uninitialized DOM properties.
+  // Skip until the SPA exposes a testable seam (or we can stub the loader).
+  it.skip("[deferred: needs SheetJS loader stub] exportExcel produces a parseable workbook", () => {});
+  it.skip("[deferred: needs SheetJS loader stub] Control Details first row is the header row with required columns", () => {});
+  it.skip("[deferred: needs SheetJS loader stub] Summary includes a row for each pillar", () => {});
+});


### PR DESCRIPTION
Adds 7 vitest contract specs under tests/spa/ covering JSON envelope schema, CSV escape / formula injection, MD escape, persona parity, XLSX cell shape, prototype-pollution validator, and filter-loop perf.

Specs that depend on future fixes (spa-fix-formula-injection BOM stripping, spa-fix-md-escape, spa-fix-prototype-pollution) or missing scaffold (e2e personas, SheetJS loader stub) skip cleanly with explanatory messages.

Latest local run: 52 passed | 11 skipped (active tests cover behavior on main today; XFAIL tests document desired post-fix contracts).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>