### PR TITLE
fix(assessment): saved assessments restore correctly via per-id storage slots

### DIFF
--- a/docs/javascripts/assessment-app.js
+++ b/docs/javascripts/assessment-app.js
@@ -301,9 +301,35 @@
     var self = this;
     this._bindMaterialSearchGuard();
     this._injectPrintStyles();
+    this._migrateLegacySavedAssessments();
     this.loadData().then(function () {
       self.render();
     });
+  };
+
+  /**
+   * One-time migration: prior to the saved-list fix the SPA stored only the
+   * single most recently edited assessment in `STORAGE_KEY + "-current"`.
+   * Older entries shown in the welcome saved-assessments list pointed to
+   * data that did not exist, so clicking "Resume" silently no-op'd.
+   *
+   * Per-assessment slots at `STORAGE_KEY + "-data-" + id` are now the source
+   * of truth. On first run after deploy we copy the legacy `-current` blob
+   * into its per-id slot if the slot is empty. We deliberately leave
+   * `-current` in place so the migration is idempotent and a downgrade does
+   * not lose data.
+   */
+  AssessmentApp.prototype._migrateLegacySavedAssessments = function () {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY + "-current");
+      if (!raw) return;
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || !parsed.assessmentId) return;
+      var perIdKey = STORAGE_KEY + "-data-" + parsed.assessmentId;
+      if (localStorage.getItem(perIdKey) == null) {
+        localStorage.setItem(perIdKey, raw);
+      }
+    } catch (e) { /* migration is best-effort */ }
   };
 
   // Inject @page + print-only CSS once per page (spa-fix-print-hygiene).
@@ -890,7 +916,11 @@
     if (!this.state) return;
     this.state.updatedAt = new Date().toISOString();
     try {
-      localStorage.setItem(STORAGE_KEY + "-current", JSON.stringify(this.state));
+      var serialized = JSON.stringify(this.state);
+      // Per-assessment slot is the source of truth for restoration (iter3-2-001 P0).
+      localStorage.setItem(STORAGE_KEY + "-data-" + this.state.assessmentId, serialized);
+      // `-current` retained as a "most recently edited" pointer for back-compat.
+      localStorage.setItem(STORAGE_KEY + "-current", serialized);
       var list = this.getSavedList();
       var idx = list.findIndex(function (s) { return s.id === this.state.assessmentId; }.bind(this));
       var entry = {
@@ -932,7 +962,14 @@
 
   AssessmentApp.prototype.loadFromStorage = function (id) {
     try {
-      var data = JSON.parse(localStorage.getItem(STORAGE_KEY + "-current"));
+      // Prefer the per-assessment slot (iter3-2-001 P0); falls back to
+      // `-current` for assessments that pre-date the per-id slot OR when
+      // caller did not supply an id.
+      var raw = null;
+      if (id) raw = localStorage.getItem(STORAGE_KEY + "-data-" + id);
+      if (!raw) raw = localStorage.getItem(STORAGE_KEY + "-current");
+      if (!raw) return false;
+      var data = JSON.parse(raw);
       if (data && (!id || data.assessmentId === id) && this.validateState(data)) {
         this.state = data;
         return true;
@@ -943,15 +980,18 @@
 
   AssessmentApp.prototype.deleteSaved = function (id) {
     // spa-fix-destructive-gate: offer JSON export first if the target
-    // assessment has answered controls.
+    // assessment has answered controls. Reads from per-id slot (preferred)
+    // and falls back to `-current` for legacy state.
     try {
-      var current = JSON.parse(localStorage.getItem(STORAGE_KEY + "-current"));
-      if (current && current.assessmentId === id &&
-          current.responses && Object.keys(current.responses).length > 0) {
+      var rawTarget = localStorage.getItem(STORAGE_KEY + "-data-" + id) ||
+                       localStorage.getItem(STORAGE_KEY + "-current");
+      var target = rawTarget ? JSON.parse(rawTarget) : null;
+      if (target && target.assessmentId === id &&
+          target.responses && Object.keys(target.responses).length > 0) {
         if (typeof confirm === "function" &&
             confirm("This assessment has answered controls. Click OK to export it to JSON before deleting, or Cancel to delete without exporting.")) {
           var prevState = this.state;
-          this.state = current;
+          this.state = target;
           try { this.exportJSON(); } catch (_) { /* keep deleting even if export fails */ }
           this.state = prevState;
         }
@@ -960,6 +1000,8 @@
     var list = this.getSavedList().filter(function (s) { return s.id !== id; });
     localStorage.setItem(STORAGE_KEY + "-list", JSON.stringify(list));
     try {
+      // Always remove the per-id slot for the deleted assessment.
+      localStorage.removeItem(STORAGE_KEY + "-data-" + id);
       var cur2 = JSON.parse(localStorage.getItem(STORAGE_KEY + "-current"));
       if (cur2 && cur2.assessmentId === id) {
         localStorage.removeItem(STORAGE_KEY + "-current");

--- a/docs/version.json
+++ b/docs/version.json
@@ -1,0 +1,4 @@
+{
+  "sha": "c51bd7f7aa204b58ca6fe55c9dd22d5cbeec3444",
+  "builtAt": "2026-04-29T23:14:52Z"
+}

--- a/tests/spa/saved-list-multi-assessment.test.mjs
+++ b/tests/spa/saved-list-multi-assessment.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * Regression test for the "saved-list data loss" P0 bug (iter3-2-001).
+ *
+ * BEFORE FIX: saveToStorage wrote only to STORAGE_KEY+"-current"; loading any
+ * saved assessment that was not the most recently edited one silently failed
+ * because loadFromStorage(id) only consulted -current and required
+ * data.assessmentId === id. A consultant managing two clients lost access to
+ * the older one with no recovery path.
+ *
+ * AFTER FIX: per-assessment slot at STORAGE_KEY+"-data-"+id is the source of
+ * truth; -current is kept as a "most recently edited" pointer for back-compat;
+ * init() runs a one-time migration to copy a legacy -current blob into its
+ * per-id slot.
+ *
+ * SPA file: docs/javascripts/assessment-app.js
+ *   - saveToStorage (~L889)
+ *   - loadFromStorage (~L933)
+ *   - deleteSaved (~L944)
+ *   - _migrateLegacySavedAssessments (~L310)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { bootSPA } from "./_bootSpa.mjs";
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+
+async function makeApp() {
+  const { window } = bootSPA();
+  const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+  await app.loadData();
+  return { app, window };
+}
+
+function seedAssessment(app, id, name) {
+  app.state = app.newState();
+  app.state.assessmentId = id;
+  app.state.assessmentName = name;
+  app.state.scoping.organizationName = name;
+  app.state.scoping.zones = [1, 2, 3];
+  app.state.responses["1.1"] = { answer: "yes", notes: "", evidenceRef: "" };
+  app.saveToStorage();
+}
+
+describe("saved-list multi-assessment durability (iter3-2-001 P0)", () => {
+  beforeEach(() => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.clear === "function") {
+      globalThis.localStorage.clear();
+    }
+  });
+
+  it("persists each saved assessment under its own per-id slot", async () => {
+    const { app, window } = await makeApp();
+    seedAssessment(app, "id-A", "Acme Bank");
+    seedAssessment(app, "id-B", "Beta Brokers");
+
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-A")).not.toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-B")).not.toBeNull();
+
+    const list = app.getSavedList();
+    expect(list.map((s) => s.id).sort()).toEqual(["id-A", "id-B"]);
+  });
+
+  it("Resume on a non-current saved assessment loads the correct data", async () => {
+    const { app } = await makeApp();
+    seedAssessment(app, "id-A", "Acme Bank");
+    seedAssessment(app, "id-B", "Beta Brokers");
+
+    const ok = app.loadFromStorage("id-A");
+    expect(ok, "loadFromStorage('id-A') must succeed").toBe(true);
+    expect(app.state.assessmentId).toBe("id-A");
+    expect(app.state.assessmentName).toBe("Acme Bank");
+  });
+
+  it("deleteSaved removes only the targeted per-id slot", async () => {
+    const { app, window } = await makeApp();
+    seedAssessment(app, "id-A", "Acme Bank");
+    seedAssessment(app, "id-B", "Beta Brokers");
+
+    // deleteSaved may invoke confirm(); jsdom's default returns false (no export).
+    app.deleteSaved("id-A");
+
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-A")).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-id-B")).not.toBeNull();
+    expect(app.getSavedList().map((s) => s.id)).toEqual(["id-B"]);
+  });
+
+  it("init() migrates a pre-fix `-current` blob into its per-id slot", async () => {
+    const { window } = bootSPA();
+    const legacyState = {
+      assessmentId: "legacy-id",
+      assessmentName: "Legacy Assessment",
+      schemaVersion: "1.4.0",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scoping: { organizationName: "Legacy Org", assessorName: "L", zones: [1, 2, 3], roles: [] },
+      responses: { "1.1": { answer: "yes", notes: "", evidenceRef: "" } },
+      overrides: {},
+      drilldown: {},
+      currentStep: "phase1",
+      completedSteps: [],
+      assessmentStatus: "in-progress",
+    };
+    window.localStorage.setItem(STORAGE_KEY + "-current", JSON.stringify(legacyState));
+    expect(window.localStorage.getItem(STORAGE_KEY + "-data-legacy-id")).toBeNull();
+
+    const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+    app._migrateLegacySavedAssessments();
+
+    const migrated = window.localStorage.getItem(STORAGE_KEY + "-data-legacy-id");
+    expect(migrated, "migration must populate the per-id slot").not.toBeNull();
+    expect(JSON.parse(migrated).assessmentId).toBe("legacy-id");
+
+    // Idempotent: rerunning does NOT clobber a now-newer per-id slot.
+    window.localStorage.setItem(
+      STORAGE_KEY + "-data-legacy-id",
+      JSON.stringify(Object.assign({}, legacyState, { assessmentName: "Newer" }))
+    );
+    app._migrateLegacySavedAssessments();
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY + "-data-legacy-id")).assessmentName).toBe("Newer");
+  });
+});


### PR DESCRIPTION
Closes iter3-2-001 (P0). Rebased successor to closed PR #138 - integrated atop PR #142 (SPA hardening) which independently modified saveToStorage/loadFromStorage/deleteSaved.

## Bug
A consultant managing two clients sees both saved assessments in the welcome list, but clicking 'Resume' on the older one silently no-ops because saveToStorage wrote only to a single '-current' slot and loadFromStorage(id) required data.assessmentId === id. Perceived as data loss with no recovery.

## Fix
- saveToStorage writes to per-assessment slot 'STORAGE_KEY+\\-data-\\+id'; '-current' is retained as a 'most recently edited' pointer (back-compat). Quota-banner branch preserved.
- loadFromStorage(id) prefers the per-id slot, falls back to '-current'.
- deleteSaved removes the per-id slot; preserved destructive-gate now reads target from per-id slot.
- _migrateLegacySavedAssessments() in init() copies pre-fix '-current' blob into its per-id slot if absent. Idempotent. '-current' left in place so a downgrade does not lose data.

## Tests
4 vitest regressions in tests/spa/saved-list-multi-assessment.test.mjs:
1. Each saved assessment persisted under its own per-id slot.
2. Resume on a non-current assessment loads the correct data.
3. deleteSaved removes only the targeted per-id slot.
4. init() migrates a pre-fix '-current' blob; idempotent.

## Validation
- npm test -> 71 passed | 2 skipped
- mkdocs build --strict -> green