### PR TITLE
ci(e2e): use python -m pip in Playwright container

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,8 +59,10 @@ jobs:
 
       # Mirror smoke workflow's mkdocs install for consistency.
       # Pip install of mkdocs-material typically completes in <60s in this container.
+      # Use `python -m pip` because actions/setup-python doesn't update PATH
+      # inside the Playwright container (only sets pythonLocation env).
       - name: Install MkDocs and Material Theme
-        run: pip install 'mkdocs-material>=9.5,<10'
+        run: python -m pip install 'mkdocs-material>=9.5,<10'
 
       - name: Generate Assessment Data
         run: python scripts/extract_assessment_data.py


### PR DESCRIPTION
Follow-up to #150. First post-merge run of `e2e-full` failed at the MkDocs install step:

```\n/__w/_temp/...sh: 1: pip: not found\nProcess completed with exit code 127.\n```\n
`actions/setup-python@v5` sets `pythonLocation` env vars inside the Playwright container but does not update `PATH` for subsequent steps when running as `--user 1001`. Using `python -m pip` resolves correctly via the interpreter.

Failing run: https://github.com/judeper/FSI-AgentGov/actions/runs/25140573001