### PR TITLE
test(e2e): 3 pure regression specs - saved-list, namespace migration, cold-start import

### DIFF
--- a/tests/e2e/03b-saved-list-multi-assessment.spec.mjs
+++ b/tests/e2e/03b-saved-list-multi-assessment.spec.mjs
@@ -1,0 +1,204 @@
+import { test } from "@playwright/test";
+import {
+  clearPageStorage,
+  expect,
+  navClick,
+} from "./_harness.mjs";
+
+/**
+ * 03b — Saved-list multi-assessment durability (E2E regression)
+ *
+ * E2E counterpart to tests/spa/saved-list-multi-assessment.test.mjs (PR #144,
+ * iter3-2-001 P0). Verifies the per-id storage slot behaviour end-to-end
+ * through the real browser localStorage:
+ *
+ *   - Each saved assessment lives in its own STORAGE_KEY+"-data-<id>" slot.
+ *   - Resuming a non-current saved assessment loads the correct data.
+ *   - Deleting one assessment leaves the other intact + resumable.
+ *
+ * BEFORE PR #144: saveToStorage wrote only to STORAGE_KEY+"-current", so the
+ * older of two saved assessments silently lost its data and "Resume" no-op'd.
+ * This spec is the regression net for that bug at the UI level — if it
+ * regresses, this spec fails before the unit-level vitest does.
+ *
+ * SPA literal STORAGE_KEY value (docs/javascripts/assessment-app.js L16):
+ *   "fsi-agentgov-assessment"
+ */
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+
+/** Helpers -------------------------------------------------------- */
+
+/** Read the SPA's app instance state via the per-id slot in localStorage. */
+async function readPerIdSlot(page, id) {
+  return await page.evaluate(
+    ([k, theId]) => {
+      const raw = localStorage.getItem(k + "-data-" + theId);
+      return raw ? JSON.parse(raw) : null;
+    },
+    [STORAGE_KEY, id],
+  );
+}
+
+async function readCurrentAssessmentId(page) {
+  return await page.evaluate((k) => {
+    const raw = localStorage.getItem(k + "-current");
+    if (!raw) return null;
+    try { return JSON.parse(raw).assessmentId || null; } catch { return null; }
+  }, STORAGE_KEY);
+}
+
+async function listDataSlotKeys(page) {
+  return await page.evaluate(() =>
+    Object.keys(localStorage).filter((k) => k.includes("-data-")),
+  );
+}
+
+/** Drive: welcome → scoping → Phase 1 with custom org name. */
+async function startNewAndScope(page, organizationName) {
+  await page.getByRole("button", { name: "Start New Assessment" }).dispatchEvent("click");
+  await page.getByRole("heading", { name: "Assessment Scoping" }).waitFor();
+  await page.getByLabel("Organization Name").fill(organizationName);
+  await page.getByLabel("Assessor Name").fill("Test Assessor");
+  await page.getByLabel("Institution Type", { exact: true }).selectOption("bank");
+  const zoneFieldset = page.getByRole("group", { name: "Active Governance Zones" });
+  const zone1 = zoneFieldset.locator('input[type="checkbox"][value="1"]');
+  if (!(await zone1.isChecked())) await zone1.check();
+  await page.getByRole("button", { name: "Begin Assessment" }).dispatchEvent("click");
+  await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+}
+
+/** Click the "Yes" / "Partial" / "No" / "N/A" answer for one control. */
+async function answerControl(page, controlId, label) {
+  const card = page.locator(`[data-control-id="${controlId}"]`);
+  await card.first().waitFor({ state: "attached" });
+  // Expand pillar group if collapsed.
+  const pillar = card.locator('xpath=ancestor::div[contains(@class,"ag-pillar-controls")]');
+  if ((await pillar.count()) > 0) {
+    const collapsed = await pillar.first().evaluate((el) => el.classList.contains("collapsed"));
+    if (collapsed) {
+      const header = pillar.locator(
+        'xpath=preceding-sibling::div[contains(@class,"ag-pillar-header")][1]',
+      );
+      if ((await header.count()) > 0) await header.first().click();
+    }
+  }
+  await card.getByRole("button", { name: label, exact: true }).click();
+}
+
+/** Force a synchronous flush of the debounced save by going Phase1→Scoping→Back. */
+async function navigateBackToWelcome(page) {
+  // Wait for the 500ms debounced save to flush.
+  await page.waitForTimeout(700);
+  await page.getByRole("button", { name: "Back to Scoping" }).dispatchEvent("click");
+  await page.getByRole("heading", { name: "Assessment Scoping" }).waitFor();
+  await page.getByRole("button", { name: "Back", exact: true }).dispatchEvent("click");
+  // The mkdocs page itself emits an h1 with the same text as the SPA's
+  // welcome h2; scope inside the SPA container to disambiguate.
+  await page
+    .locator("#assessment-app")
+    .getByRole("heading", { name: "Governance Readiness Assessment" })
+    .waitFor();
+}
+
+test.describe("saved-list multi-assessment @regression", () => {
+  test("two assessments persist independently, resume + delete are isolated @regression", async ({ page }) => {
+    // Default dialog handler: dismiss any incidental confirm() prompts (e.g.
+    // the Phase 1 "save before results" prompt). The destructive-gate flow
+    // in step "Delete Bank A" is handled with explicit one-shot hooks
+    // installed AFTER removing this default — see comment below.
+    const defaultDialogHandler = (d) => { d.dismiss().catch(() => {}); };
+    page.on("dialog", defaultDialogHandler);
+
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
+    await clearPageStorage(page);
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    // -- Assessment A -------------------------------------------------
+    await startNewAndScope(page, "Bank A");
+    await answerControl(page, "1.1", "Yes");
+    await answerControl(page, "1.2", "Partial");
+    const idA = await readCurrentAssessmentId(page);
+    expect(idA, "assessment A id should exist after first save").toBeTruthy();
+    await navigateBackToWelcome(page);
+
+    // -- Assessment B (different org) ---------------------------------
+    await startNewAndScope(page, "Bank B");
+    await answerControl(page, "1.3", "No");
+    await answerControl(page, "1.4", "Yes");
+    await answerControl(page, "1.5", "Partial");
+    const idB = await readCurrentAssessmentId(page);
+    expect(idB, "assessment B id should exist after first save").toBeTruthy();
+    expect(idB).not.toBe(idA);
+
+    // -- Resume A: assert A's 2 answers, NOT B's ---------------------
+    await navigateBackToWelcome(page);
+    // Resume buttons are labelled "Resume <assessmentName>" where the
+    // assessmentName is "<org> — <YYYY-MM-DD>" (set by Begin Assessment).
+    // We match by prefix to stay date-agnostic.
+    await page.getByRole("button", { name: /^Resume Bank A/ }).dispatchEvent("click");
+    await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+    const slotA = await readPerIdSlot(page, idA);
+    expect(slotA, "Per-id slot for A must exist").not.toBeNull();
+    expect(slotA.responses["1.1"]?.answer).toBe("yes");
+    expect(slotA.responses["1.2"]?.answer).toBe("partial");
+    // A must NOT contain B's responses.
+    expect(slotA.responses["1.3"]).toBeUndefined();
+    expect(slotA.responses["1.4"]).toBeUndefined();
+    expect(slotA.responses["1.5"]).toBeUndefined();
+    expect(slotA.scoping?.organizationName).toBe("Bank A");
+
+    // -- Resume B: assert B's 3 answers, A's absent -------------------
+    await navigateBackToWelcome(page);
+    await page.getByRole("button", { name: /^Resume Bank B/ }).dispatchEvent("click");
+    await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+    const slotB = await readPerIdSlot(page, idB);
+    expect(slotB, "Per-id slot for B must exist").not.toBeNull();
+    expect(slotB.responses["1.3"]?.answer).toBe("no");
+    expect(slotB.responses["1.4"]?.answer).toBe("yes");
+    expect(slotB.responses["1.5"]?.answer).toBe("partial");
+    expect(slotB.responses["1.1"]).toBeUndefined();
+    expect(slotB.responses["1.2"]).toBeUndefined();
+    expect(slotB.scoping?.organizationName).toBe("Bank B");
+
+    // -- Delete A: B remains intact, list shows only B ----------------
+    await navigateBackToWelcome(page);
+
+    // Two confirm() prompts fire on a Delete with answered controls:
+    //   1. Welcome-level "Delete this assessment?" → accept (proceed).
+    //   2. deleteSaved's destructive-gate "export to JSON before deleting?"
+    //      → DISMISS (skip export so we don't trigger a stray download).
+    // Multiple page.on("dialog") listeners all race to handle the same
+    // dialog and only the first .accept/.dismiss call wins, so we must
+    // remove the default dismiss-all listener before installing this
+    // counted handler.
+    page.off("dialog", defaultDialogHandler);
+    let dialogIdx = 0;
+    const dialogHandler = (d) => {
+      dialogIdx += 1;
+      if (dialogIdx === 1) return d.accept().catch(() => {});
+      return d.dismiss().catch(() => {});
+    };
+    page.on("dialog", dialogHandler);
+    await page.getByRole("button", { name: /^Delete Bank A/ }).dispatchEvent("click");
+    await page.waitForTimeout(500); // settle async dialog + delete + re-render
+    page.off("dialog", dialogHandler);
+    page.on("dialog", defaultDialogHandler);
+
+    // Welcome list now shows only B.
+    await expect(page.getByRole("button", { name: /^Resume Bank A/ })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^Resume Bank B/ })).toHaveCount(1);
+
+    // localStorage: exactly one -data- slot remains, and it's B's.
+    const remainingDataKeys = await listDataSlotKeys(page);
+    expect(remainingDataKeys).toEqual([STORAGE_KEY + "-data-" + idB]);
+
+    // B is still resumable end-to-end.
+    await page.getByRole("button", { name: /^Resume Bank B/ }).dispatchEvent("click");
+    await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+    const slotBAfterDelete = await readPerIdSlot(page, idB);
+    expect(slotBAfterDelete.responses["1.3"]?.answer).toBe("no");
+    expect(slotBAfterDelete.responses["1.4"]?.answer).toBe("yes");
+    expect(slotBAfterDelete.responses["1.5"]?.answer).toBe("partial");
+  });
+});

--- a/tests/e2e/11b-cold-start-full-import.spec.mjs
+++ b/tests/e2e/11b-cold-start-full-import.spec.mjs
@@ -1,0 +1,195 @@
+import { test } from "@playwright/test";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import {
+  clearAllStorage,
+  clearPageStorage,
+  expect,
+  freezeTime,
+} from "./_harness.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(here, "fixtures", "exports", "full-cco-export.json");
+
+/**
+ * 11b — Cold-start full-assessment import (E2E regression)
+ *
+ * Sibling to 11-import-roundtrip. That spec exports → re-imports the SAME
+ * JSON in the SAME browser. This one verifies the COLD-start import flow:
+ *
+ *   - No prior `state` (importState falls into the `!this.state` branch).
+ *   - Empty resume list on welcome.
+ *   - User imports a JSON they received from elsewhere.
+ *
+ * Catches regressions in any code path that incorrectly assumes a "current
+ * assessment" exists pre-import (the destructive-gate confirm in
+ * importState relies on `this.state && this.state.responses`; a regression
+ * making `this.state` mandatory would break cold-start imports).
+ *
+ * Fixture: tests/e2e/fixtures/exports/full-cco-export.json — see the
+ * sibling README.md for the regen procedure. The fixture matches the
+ * full-cco persona's scoping + a representative spread of Phase 1 answers.
+ */
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+
+test.describe("cold-start full-assessment import @regression", () => {
+  test("imports JSON into fresh browser, persists across reload, collision is non-corrupting @regression", async ({
+    page,
+    context,
+  }) => {
+    page.on("dialog", (d) => d.accept().catch(() => {}));
+    await freezeTime(page);
+
+    // -- Phase 1: COLD-START IMPORT -----------------------------------
+    await clearAllStorage(context);
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
+    await clearPageStorage(page);
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    // Welcome must be visible AND empty: no resume list, no current state.
+    // The mkdocs page has its own h1 with the same text as the SPA welcome
+    // h2; scope inside #assessment-app to disambiguate.
+    await page
+      .locator("#assessment-app")
+      .getByRole("heading", { name: "Governance Readiness Assessment" })
+      .waitFor({ timeout: 15_000 });
+    await expect(page.locator(".ag-saved-list")).toHaveCount(0);
+
+    // Confirm fixture is well-formed before we feed it to the SPA.
+    const exported = JSON.parse(readFileSync(FIXTURE, "utf8"));
+    expect(exported.assessmentId).toBeTruthy();
+    expect(exported.scoping?.organizationName).toBe("Globex Financial");
+    expect(Object.keys(exported.responses).length).toBeGreaterThanOrEqual(5);
+
+    // Import via the welcome "Resume or Import Saved Assessment" button.
+    const chooserPromise = page.waitForEvent("filechooser");
+    await page
+      .getByRole("button", { name: "Resume or Import Saved Assessment" })
+      .dispatchEvent("click");
+    const chooser = await chooserPromise;
+    await chooser.setFiles(FIXTURE);
+
+    // After a successful cold-start import the SPA navigates to Phase 1.
+    await page
+      .getByRole("heading", { name: /Phase 1: Control-Level Assessment/ })
+      .waitFor();
+
+    // localStorage now reflects the imported state (under the per-id slot).
+    const importedId = exported.assessmentId;
+    const slot = await page.evaluate(
+      ([k, id]) => {
+        const raw = localStorage.getItem(k + "-data-" + id);
+        return raw ? JSON.parse(raw) : null;
+      },
+      [STORAGE_KEY, importedId],
+    );
+    expect(slot, "per-id slot for imported assessment must exist").not.toBeNull();
+    expect(slot.assessmentId).toBe(importedId);
+    expect(slot.scoping.organizationName).toBe("Globex Financial");
+    expect(slot.responses["1.1"]?.answer).toBe("yes");
+    expect(slot.responses["1.7"]?.answer).toBe("no");
+
+    // -- Phase 2: PERSISTENCE ACROSS RELOAD ----------------------------
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page
+      .locator("#assessment-app")
+      .getByRole("heading", { name: "Governance Readiness Assessment" })
+      .waitFor({ timeout: 15_000 });
+
+    // Welcome list shows the imported assessment as resumable.
+    const resumeBtn = page.getByRole("button", {
+      name: "Resume " + (exported.assessmentName || "Untitled"),
+    });
+    await expect(resumeBtn).toHaveCount(1);
+
+    // -- Phase 3: COLLISION PROBE --------------------------------------
+    // Import a SECOND JSON whose assessmentId equals the existing one but
+    // whose responses differ. Goal: prove the post-import state is the
+    // new payload's responses verbatim — not a Frankenstein merge of the
+    // two — and that the SPA does not silently corrupt either side.
+    //
+    // Observed SPA behaviour (assessment-app.js L1037-L1050, importState):
+    //   - importingDifferent = (parsed.assessmentId !== this.state.assessmentId)
+    //   - On a same-id collision, importingDifferent is FALSE, so the
+    //     destructive-gate confirm() is NOT shown. The state is replaced
+    //     wholesale by the validated/sanitised parsed payload — overrides
+    //     and responses keys from the prior import are GONE in the new
+    //     `clean` object (importState builds clean.responses fresh).
+    //   - Net effect: deterministic full-overwrite, no merge, no prompt.
+    //   - This is the documented "Same-id round-trip is not destructive"
+    //     contract. A future change toward a merge strategy would have to
+    //     update both the SPA comment and this spec's expectation.
+    const collisionDir = join(tmpdir(), "fsi-agentgov-e2e");
+    mkdirSync(collisionDir, { recursive: true });
+    const collisionPath = join(collisionDir, "full-cco-collision.json");
+    const collidingPayload = {
+      ...exported,
+      assessmentName: "Globex Financial — collision",
+      updatedAt: "2026-02-01T00:00:00.000Z",
+      responses: {
+        // Different answer set from the first import.
+        "1.1": { answer: "no", notes: "collision-1.1", evidenceRef: "" },
+        "2.1": { answer: "yes", notes: "collision-2.1", evidenceRef: "" },
+      },
+    };
+    writeFileSync(collisionPath, JSON.stringify(collidingPayload, null, 2));
+
+    // Resume the original first so importState has `this.state` set.
+    await resumeBtn.dispatchEvent("click");
+    await page
+      .getByRole("heading", { name: /Phase 1: Control-Level Assessment/ })
+      .waitFor();
+
+    // Trigger a second import. Since this.state has answered controls and
+    // the parsed.assessmentId matches, importingDifferent is false → no
+    // confirm() prompt is expected. We still keep the dialog handler in
+    // place (set at top of test) for safety.
+    const chooser2Promise = page.waitForEvent("filechooser");
+    // Navigate back to welcome to re-trigger triggerImport. Use the
+    // back-to-scoping → back-to-welcome path used elsewhere in the suite.
+    await page.getByRole("button", { name: "Back to Scoping" }).dispatchEvent("click");
+    await page.getByRole("heading", { name: "Assessment Scoping" }).waitFor();
+    await page.getByRole("button", { name: "Back", exact: true }).dispatchEvent("click");
+    await page
+      .locator("#assessment-app")
+      .getByRole("heading", { name: "Governance Readiness Assessment" })
+      .waitFor();
+    await page
+      .getByRole("button", { name: "Resume or Import Saved Assessment" })
+      .dispatchEvent("click");
+    const chooser2 = await chooser2Promise;
+    await chooser2.setFiles(collisionPath);
+
+    await page
+      .getByRole("heading", { name: /Phase 1: Control-Level Assessment/ })
+      .waitFor();
+
+    // Post-collision state: the per-id slot reflects the SECOND payload
+    // exclusively. No keys from the original imported responses survive.
+    const postCollision = await page.evaluate(
+      ([k, id]) => {
+        const raw = localStorage.getItem(k + "-data-" + id);
+        return raw ? JSON.parse(raw) : null;
+      },
+      [STORAGE_KEY, importedId],
+    );
+    expect(postCollision, "per-id slot must still exist after collision").not.toBeNull();
+    expect(postCollision.assessmentId).toBe(importedId);
+
+    // Consistent single-source state — keys from the first import are gone.
+    const responseKeys = Object.keys(postCollision.responses).sort();
+    expect(responseKeys).toEqual(["1.1", "2.1"]);
+    expect(postCollision.responses["1.1"].answer).toBe("no");
+    expect(postCollision.responses["1.1"].notes).toBe("collision-1.1");
+    expect(postCollision.responses["2.1"].answer).toBe("yes");
+
+    // No Frankenstein: the discarded original keys (1.7, 1.4, 1.11, ...)
+    // must NOT be present.
+    expect(postCollision.responses["1.7"]).toBeUndefined();
+    expect(postCollision.responses["1.4"]).toBeUndefined();
+    expect(postCollision.responses["1.11"]).toBeUndefined();
+  });
+});

--- a/tests/e2e/30-storage-namespace-migration.spec.mjs
+++ b/tests/e2e/30-storage-namespace-migration.spec.mjs
@@ -1,0 +1,174 @@
+import { test } from "@playwright/test";
+import { expect } from "./_harness.mjs";
+
+/**
+ * 30 — Storage namespace migration (E2E regression)
+ *
+ * Verifies AssessmentApp.prototype._migrateLegacySavedAssessments (PR #144,
+ * iter3-2-001) runs at SPA boot and lifts a pre-fix legacy `-current` blob
+ * into its per-id slot (STORAGE_KEY+"-data-<id>"). Also asserts:
+ *
+ *   - After migration, the user can Resume the legacy assessment from the
+ *     welcome screen and see their original answers/scoping.
+ *   - Re-running the migration is idempotent: a second SPA boot does not
+ *     clobber, duplicate, or corrupt the migrated slot. The natural guard
+ *     is the `if (perIdKey == null)` check (assessment-app.js L329) — this
+ *     spec proves that guard holds end-to-end.
+ *
+ * SEED STRATEGY: page.addInitScript runs BEFORE every page load, including
+ * before the SPA's init() executes the migration. We use it to plant the
+ * legacy-only state shape (a `-current` blob + a `-list` entry, but NO
+ * `-data-<id>` slot — the exact shape produced by the pre-fix SPA).
+ *
+ * SPA literal STORAGE_KEY value (docs/javascripts/assessment-app.js L16):
+ *   "fsi-agentgov-assessment"
+ */
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+const LEGACY_ID = "legacy-001";
+
+/** A minimum-viable legacy state shape: passes validateState, has answers. */
+function buildLegacyState() {
+  return {
+    assessmentId: LEGACY_ID,
+    assessmentName: "Legacy Bank — 2025-09-01",
+    schemaVersion: "1.4.0",
+    createdAt: "2025-09-01T10:00:00.000Z",
+    updatedAt: "2025-09-01T10:30:00.000Z",
+    scoping: {
+      organizationName: "Legacy Bank",
+      assessorName: "Pre-PR-144 User",
+      assessorRole: "AI Governance Lead",
+      institutionType: "bank",
+      zones: [1, 2],
+      adoptionPhase: 0,
+      regulations: [],
+      scope: "full",
+    },
+    responses: {
+      "1.1": { answer: "yes", notes: "legacy-note-11", evidenceRef: "" },
+      "1.5": { answer: "partial", notes: "", evidenceRef: "" },
+    },
+    drilldown: {},
+    overrides: {},
+    completedSteps: ["scoping"],
+    selectedSector: "",
+    roleFilter: "",
+    priorityMode: "full",
+    priorityExpanded: false,
+    assessmentStatus: "in-progress",
+  };
+}
+
+/** A legacy `-list` entry (welcome's saved-assessments list pre-PR-144). */
+function buildLegacyListEntry(legacyState) {
+  return [{
+    id: legacyState.assessmentId,
+    name: legacyState.assessmentName,
+    updatedAt: legacyState.updatedAt,
+    createdAt: legacyState.createdAt,
+    progress: 3,
+  }];
+}
+
+async function readAllRelevantStorage(page) {
+  return await page.evaluate((k) => ({
+    current: localStorage.getItem(k + "-current"),
+    list: localStorage.getItem(k + "-list"),
+    perId: localStorage.getItem(k + "-data-legacy-001"),
+    allKeys: Object.keys(localStorage)
+      .filter((key) => key.startsWith(k))
+      .sort(),
+  }), STORAGE_KEY);
+}
+
+test.describe("storage namespace migration @regression", () => {
+  test("legacy `-current` is migrated to per-id slot, idempotently @regression", async ({ page }) => {
+    page.on("dialog", (d) => d.dismiss().catch(() => {}));
+
+    const legacyState = buildLegacyState();
+    const legacyJson = JSON.stringify(legacyState);
+    const legacyList = buildLegacyListEntry(legacyState);
+
+    // Plant pre-PR-144 legacy state BEFORE the SPA boots. addInitScript
+    // re-runs on every page load, so reload() below also re-applies it
+    // — but the migration's idempotence guard (perIdKey == null) means
+    // re-applying does not corrupt the post-migration state because we
+    // ALSO re-plant the per-id slot via the same script's check.
+    //
+    // Critical: we want the FIRST page load to see ONLY the legacy keys
+    // (no per-id slot) so the migration runs. On the SECOND load we want
+    // to preserve the post-migration state to assert idempotence — the
+    // SPA itself will have written the per-id slot after first init().
+    // We do NOT clear localStorage between reloads; the addInitScript
+    // only seeds when keys are missing.
+    await page.addInitScript(({ k, json, listJson, legacyKey }) => {
+      // Only seed legacy keys if they are absent AND the per-id slot is
+      // also absent — i.e., a truly fresh fixture. After the SPA's first
+      // run it will have populated the per-id slot; we leave it alone.
+      try {
+        if (!localStorage.getItem(k + "-current") &&
+            !localStorage.getItem(legacyKey)) {
+          localStorage.setItem(k + "-current", json);
+          localStorage.setItem(k + "-list", listJson);
+        }
+      } catch (_) { /* ignore in non-storage contexts */ }
+    }, {
+      k: STORAGE_KEY,
+      json: legacyJson,
+      listJson: JSON.stringify(legacyList),
+      legacyKey: STORAGE_KEY + "-data-" + LEGACY_ID,
+    });
+
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
+    // Wait for the SPA to hydrate: the welcome heading is rendered post-init.
+    // mkdocs emits its own h1 with the same text — scope to #assessment-app.
+    await page
+      .locator("#assessment-app")
+      .getByRole("heading", { name: "Governance Readiness Assessment" })
+      .waitFor({ timeout: 15_000 });
+
+    // Migration assertions ------------------------------------------------
+    const after1 = await readAllRelevantStorage(page);
+    expect(after1.perId, "per-id slot must be populated by migration").not.toBeNull();
+    const migrated = JSON.parse(after1.perId);
+    expect(migrated.assessmentId).toBe(LEGACY_ID);
+    expect(migrated.scoping.organizationName).toBe("Legacy Bank");
+    expect(migrated.responses["1.1"]?.answer).toBe("yes");
+
+    // `-current` is intentionally retained as a "most recently edited"
+    // pointer (back-compat) per assessment-app.js L319.
+    expect(after1.current).not.toBeNull();
+    const current = JSON.parse(after1.current);
+    expect(current.assessmentId).toBe(LEGACY_ID);
+
+    // -- Idempotence: reload → migration runs again, state unchanged -----
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page
+      .locator("#assessment-app")
+      .getByRole("heading", { name: "Governance Readiness Assessment" })
+      .waitFor({ timeout: 15_000 });
+
+    const after2 = await readAllRelevantStorage(page);
+    expect(after2.perId).toBe(after1.perId);
+    expect(after2.current).toBe(after1.current);
+    expect(after2.list).toBe(after1.list);
+    expect(after2.allKeys).toEqual(after1.allKeys);
+
+    // -- Resume legacy-001 from welcome --------------------------------
+    await page.getByRole("button", { name: "Resume " + legacyState.assessmentName })
+      .dispatchEvent("click");
+    await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ })
+      .waitFor();
+
+    // Confirm the loaded state has the legacy answers/scoping.
+    const loaded = await page.evaluate((k) => {
+      const raw = localStorage.getItem(k + "-current");
+      return raw ? JSON.parse(raw) : null;
+    }, STORAGE_KEY);
+    expect(loaded.assessmentId).toBe(LEGACY_ID);
+    expect(loaded.scoping.organizationName).toBe("Legacy Bank");
+    expect(loaded.responses["1.1"]?.answer).toBe("yes");
+    expect(loaded.responses["1.5"]?.answer).toBe("partial");
+  });
+});

--- a/tests/e2e/fixtures/exports/README.md
+++ b/tests/e2e/fixtures/exports/README.md
@@ -1,0 +1,33 @@
+# E2E export fixtures
+
+These JSON files are full-assessment exports captured from real SPA runs.
+They are used by `tests/e2e/11b-cold-start-full-import.spec.mjs` and any
+other spec that needs a known-good import payload.
+
+## Regenerating a fixture
+
+To recapture from a current SPA build (e.g. after a schema change in
+`exportJSON()` / `_metadata`):
+
+```pwsh
+# 1. Boot the SPA via the test harness
+npx playwright test tests/e2e/11-import-roundtrip.spec.mjs --project chromium --headed
+
+# 2. In the live SPA, scope+answer per the persona at
+#    tests/e2e/fixtures/personas/<name>.json, click "Export Results" →
+#    "Export as Full Assessment", and save the downloaded JSON to
+#    tests/e2e/fixtures/exports/<name>-export.json.
+```
+
+The schema is stable enough that hand-edits are safe for date/id fields,
+but the canonical procedure is to capture a real export so the fixture
+tracks any future `exportSchemaVersion` bumps in
+`docs/javascripts/assessment-app.js`.
+
+The schema contract that consuming tests rely on:
+
+- `_metadata.exportSchemaVersion`, `_metadata.exportedAt`
+- `assessmentId` (string, used as the per-id storage slot key)
+- `scoping.{organizationName,institutionType,zones[]}`
+- `responses[<controlId>].answer` ∈ { yes, partial, no, na }
+- `assessmentName` (string, drives the "Resume <name>" button label)

--- a/tests/e2e/fixtures/exports/full-cco-export.json
+++ b/tests/e2e/fixtures/exports/full-cco-export.json
@@ -1,0 +1,49 @@
+{
+  "_metadata": {
+    "exportSchemaVersion": 1,
+    "schemaType": "full",
+    "frameworkVersion": "1.4.0",
+    "manifestSchemaVersion": null,
+    "exportedAt": "2026-01-15T12:00:00.000Z",
+    "exportedBy": "Maria Chen"
+  },
+  "_computedScores": {
+    "overall": null,
+    "perPillar": { "1": null, "2": null, "3": null, "4": null },
+    "perControl": {}
+  },
+  "assessmentStatus": "in-progress",
+  "assessmentId": "fixture-full-cco-2026-01-15",
+  "assessmentName": "Globex Financial — 2026-01-15",
+  "schemaVersion": "1.4.0",
+  "createdAt": "2026-01-15T12:00:00.000Z",
+  "updatedAt": "2026-01-15T12:00:00.000Z",
+  "scoping": {
+    "organizationName": "Globex Financial",
+    "assessorName": "Maria Chen",
+    "assessorRole": "Chief Compliance Officer",
+    "institutionType": "broker-dealer",
+    "zones": [1, 2, 3],
+    "adoptionPhase": 1,
+    "regulations": ["FINRA-4511", "FINRA-3110", "SEC-17a-4"],
+    "scope": "full"
+  },
+  "responses": {
+    "1.1": { "answer": "yes",     "notes": "DLP policy enabled tenant-wide.", "evidenceRef": "" },
+    "1.2": { "answer": "partial", "notes": "Sensitivity labels piloted.",     "evidenceRef": "" },
+    "1.4": { "answer": "yes",     "notes": "",                                "evidenceRef": "" },
+    "1.5": { "answer": "partial", "notes": "",                                "evidenceRef": "" },
+    "1.7": { "answer": "no",      "notes": "Pending Q2 deployment.",          "evidenceRef": "" },
+    "1.11":{ "answer": "yes",     "notes": "",                                "evidenceRef": "" },
+    "2.1": { "answer": "partial", "notes": "Reviewing environment policies.", "evidenceRef": "" },
+    "2.5": { "answer": "yes",     "notes": "",                                "evidenceRef": "" },
+    "3.1": { "answer": "no",      "notes": "Audit retention not yet mapped.", "evidenceRef": "" }
+  },
+  "drilldown": {},
+  "overrides": {},
+  "completedSteps": ["scoping"],
+  "selectedSector": "",
+  "roleFilter": "",
+  "priorityMode": "full",
+  "priorityExpanded": false
+}


### PR DESCRIPTION
Closes phase-c-spec-saved-list-e2e, phase-c-spec-namespace-migration, phase-c-spec-cold-start-import.

Three pure-spec PRs (no SPA changes) authoring E2E regression nets for behaviors fixed in PR #144.

## Specs added

- `tests/e2e/03b-saved-list-multi-assessment.spec.mjs` (@regression) — E2E counterpart to `tests/spa/saved-list-multi-assessment.test.mjs`. Drives two independent assessments through the real SPA + browser localStorage; asserts per-id slot isolation, resume correctness across assessments, and that delete only removes the targeted `-data-<id>` slot.
- `tests/e2e/30-storage-namespace-migration.spec.mjs` (@regression) — Plants pre-PR-144 legacy state via `page.addInitScript` (a `-current` blob + `-list` entry, no `-data-<id>`) before the SPA boots, asserts `_migrateLegacySavedAssessments` lifts the blob into the per-id slot, that a reload is idempotent (state unchanged), and that the user can Resume the legacy assessment with original answers/scoping intact.
- `tests/e2e/11b-cold-start-full-import.spec.mjs` (@regression) — Sibling to `11-import-roundtrip`: imports a JSON in a fresh browser (no current assessment, empty resume list), asserts navigation to Phase 1, persistence across reload, and a same-id collision probe documenting the SPA's deterministic-overwrite behaviour (no Frankenstein merge).

## Fixture

- `tests/e2e/fixtures/exports/full-cco-export.json` (~2 KB) — full-cco persona export shape used by 11b. Sibling `README.md` documents the regen procedure.

## Verification

- All 3 specs pass: `npx playwright test 03b-saved-list-multi-assessment 30-storage-namespace-migration 11b-cold-start-full-import --project chromium` → 3/3 pass.
- `npx playwright test --grep '@smoke' --project chromium --workers=1` → 5/5 pass (matches CI's `workers: isCI ? 1` config).
- `npm test` → 83 passed, 1 skipped (matches baseline).
- `mkdocs build --strict` → green.

## Caveats

No edits to `docs/javascripts/assessment-app.js`. The collision-probe block in 11b documents the observed SPA behaviour (deterministic full-overwrite, no prompt for same-id imports — matches the L1037-L1050 `importingDifferent` short-circuit). If a future SPA change moves toward a merge strategy, both that comment and the spec assertion will need to update together.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>