### PR TITLE
fix(spa): persist wizard step + namespace filter view-state per assessment

### DIFF
--- a/docs/javascripts/assessment-app.js
+++ b/docs/javascripts/assessment-app.js
@@ -322,13 +322,49 @@
   AssessmentApp.prototype._migrateLegacySavedAssessments = function () {
     try {
       var raw = localStorage.getItem(STORAGE_KEY + "-current");
-      if (!raw) return;
-      var parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== "object" || !parsed.assessmentId) return;
-      var perIdKey = STORAGE_KEY + "-data-" + parsed.assessmentId;
-      if (localStorage.getItem(perIdKey) == null) {
-        localStorage.setItem(perIdKey, raw);
+      if (raw) {
+        var parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && parsed.assessmentId) {
+          var perIdKey = STORAGE_KEY + "-data-" + parsed.assessmentId;
+          if (localStorage.getItem(perIdKey) == null) {
+            localStorage.setItem(perIdKey, raw);
+          }
+        }
       }
+    } catch (e) { /* migration is best-effort */ }
+    // spa-fix-filter-namespace: one-shot migration of legacy global filter
+    // keys (ROLE_FILTER_KEY, SECTOR_KEY) onto the per-assessment namespace
+    // for the most-recent current assessment. If there is no current
+    // assessment we discard the legacy keys to prevent leakage into a
+    // newly-created assessment. Guarded by a flag so we run at most once.
+    try {
+      var migFlag = STORAGE_KEY + "-filter-migration-v1";
+      if (localStorage.getItem(migFlag) === "1") return;
+      var legacyRole = localStorage.getItem(ROLE_FILTER_KEY);
+      var legacySector = localStorage.getItem(SECTOR_KEY);
+      var curRaw = localStorage.getItem(STORAGE_KEY + "-current");
+      var curId = null;
+      if (curRaw) {
+        try {
+          var cur = JSON.parse(curRaw);
+          if (cur && cur.assessmentId) curId = cur.assessmentId;
+        } catch (_) { /* */ }
+      }
+      if (curId) {
+        if (legacyRole != null &&
+            localStorage.getItem(ROLE_FILTER_KEY + "-" + curId) == null) {
+          localStorage.setItem(ROLE_FILTER_KEY + "-" + curId, legacyRole);
+        }
+        if (legacySector != null &&
+            localStorage.getItem(SECTOR_KEY + "-" + curId) == null) {
+          localStorage.setItem(SECTOR_KEY + "-" + curId, legacySector);
+        }
+      }
+      // Always remove the global keys after migration to stop them leaking
+      // into a freshly created assessment.
+      if (legacyRole != null) localStorage.removeItem(ROLE_FILTER_KEY);
+      if (legacySector != null) localStorage.removeItem(SECTOR_KEY);
+      localStorage.setItem(migFlag, "1");
     } catch (e) { /* migration is best-effort */ }
   };
 
@@ -879,12 +915,13 @@
      STATE MANAGEMENT
      ================================================================ */
   AssessmentApp.prototype.newState = function () {
+    // spa-fix-filter-namespace: filter view-state is now per-assessment
+    // (namespaced under ROLE_FILTER_KEY+"-"+id and SECTOR_KEY+"-"+id) so a
+    // brand-new assessment must NOT inherit the previous assessment's
+    // filter from the legacy global keys. Initialize empty; the user's
+    // most recent per-assessment filters are restored in loadFromStorage.
     var savedRole = "";
     var savedSector = "";
-    try {
-      savedRole = localStorage.getItem(ROLE_FILTER_KEY) || "";
-      savedSector = localStorage.getItem(SECTOR_KEY) || "";
-    } catch (e) { /* localStorage unavailable */ }
     return {
       assessmentId: uuid(),
       assessmentName: "",
@@ -915,6 +952,15 @@
   AssessmentApp.prototype.saveToStorage = function () {
     if (!this.state) return;
     this.state.updatedAt = new Date().toISOString();
+    // spa-fix-resume-step: persist the wizard step alongside answers so
+    // Resume restores the user to where they left off (scoping → phase1 →
+    // phase2 → results → export). Do NOT overwrite a previously-saved
+    // step with "welcome" — Resume by definition takes the user OUT of
+    // welcome, so persisting "welcome" would erase the user's actual
+    // working position when they click the welcome indicator.
+    if (this.step && this.step !== "welcome") {
+      this.state.step = this.step;
+    }
     try {
       var serialized = JSON.stringify(this.state);
       // Per-assessment slot is the source of truth for restoration (iter3-2-001 P0).
@@ -972,6 +1018,26 @@
       var data = JSON.parse(raw);
       if (data && (!id || data.assessmentId === id) && this.validateState(data)) {
         this.state = data;
+        // spa-fix-resume-step: restore wizard step from saved data. Only
+        // honor "completed analysis" steps (results, export) on Resume —
+        // for in-progress steps (welcome, scoping, phase1, phase2) Resume
+        // always lands on phase1 (the working area). This avoids surfacing
+        // half-filled scoping screens AND restores users who had reached
+        // results/export to where they left off.
+        var savedStep = (typeof data.step === "string") ? data.step : "";
+        this.step = (savedStep === "results" || savedStep === "export") ? savedStep : "phase1";
+        // spa-fix-filter-namespace: pull the assessment's per-id filter view
+        // state into transient state so the UI re-shows what the user had
+        // previously. Missing keys clear the filter (no leakage).
+        try {
+          var aid = data.assessmentId;
+          if (aid) {
+            var savedRole = localStorage.getItem(ROLE_FILTER_KEY + "-" + aid);
+            var savedSector = localStorage.getItem(SECTOR_KEY + "-" + aid);
+            this.state.roleFilter = savedRole || "";
+            this.state.selectedSector = savedSector || "";
+          }
+        } catch (_) { /* */ }
         return true;
       }
     } catch (e) { /* */ }
@@ -1002,6 +1068,9 @@
     try {
       // Always remove the per-id slot for the deleted assessment.
       localStorage.removeItem(STORAGE_KEY + "-data-" + id);
+      // spa-fix-filter-namespace: clear per-assessment filter view state.
+      localStorage.removeItem(ROLE_FILTER_KEY + "-" + id);
+      localStorage.removeItem(SECTOR_KEY + "-" + id);
       var cur2 = JSON.parse(localStorage.getItem(STORAGE_KEY + "-current"));
       if (cur2 && cur2.assessmentId === id) {
         localStorage.removeItem(STORAGE_KEY + "-current");
@@ -1641,6 +1710,11 @@
 
   AssessmentApp.prototype.goToStep = function (step) {
     this.step = step;
+    // spa-fix-resume-step: persist the step to storage immediately so a
+    // browser refresh / Resume restores the user to the same wizard step.
+    if (this.state) {
+      try { this.saveToStorage(); } catch (_) { /* */ }
+    }
     this.render();
     this.el.scrollIntoView({ behavior: "smooth", block: "start" });
   };
@@ -1826,7 +1900,10 @@
           onClick: function (e) {
             e.stopPropagation();
             if (self.loadFromStorage(s.id)) {
-              self.goToStep("phase1");
+              // spa-fix-resume-step: respect the saved step (welcome →
+              // scoping → phase1 → phase2 → results → export) instead of
+              // forcing every Resume back to phase1.
+              self.goToStep(self.step || "phase1");
             }
           }
         }, "Resume"));
@@ -2001,7 +2078,12 @@
     });
     sectorSel.addEventListener("change", function () {
       self.state.selectedSector = sectorSel.value;
-      try { localStorage.setItem(SECTOR_KEY, sectorSel.value); } catch (e) { /* */ }
+      // spa-fix-filter-namespace: persist sector under per-assessment slot
+      // so two saved assessments can hold different sectors without leaking.
+      try {
+        var aid = (self.state && self.state.assessmentId) || "unscoped";
+        localStorage.setItem(SECTOR_KEY + "-" + aid, sectorSel.value);
+      } catch (e) { /* */ }
       self._debouncedSave();
     });
     sectorWrap.appendChild(sectorSel);
@@ -2278,7 +2360,12 @@
     var countBadge = h("span", { className: "ag-role-filter-count", id: "ag-role-filter-count" }, "");
     filterSel.addEventListener("change", function () {
       self.state.roleFilter = filterSel.value;
-      try { localStorage.setItem(ROLE_FILTER_KEY, filterSel.value); } catch (e) { /* */ }
+      // spa-fix-filter-namespace: persist role filter under per-assessment
+      // slot to prevent leakage across assessments.
+      try {
+        var aid = (self.state && self.state.assessmentId) || "unscoped";
+        localStorage.setItem(ROLE_FILTER_KEY + "-" + aid, filterSel.value);
+      } catch (e) { /* */ }
       self._debouncedSave();
       self.applyRoleFilter();
     });

--- a/docs/javascripts/assessment-loader.js
+++ b/docs/javascripts/assessment-loader.js
@@ -86,6 +86,9 @@
     if (!container && appInstance) {
       try { appInstance.destroy(); } catch (e) { /* ignore */ }
       appInstance = null;
+      // spa-test-hook: keep window.__assessmentApp in sync so E2E tests
+      // observe the cleanup.
+      try { delete window.__assessmentApp; } catch (e) { window.__assessmentApp = null; }
       var css = document.getElementById("ag-assessment-css");
       if (css) css.remove();
       return;
@@ -104,6 +107,9 @@
         if (typeof window.AssessmentApp === "function") {
           appInstance = new window.AssessmentApp(el);
           appInstance.init();
+          // spa-test-hook: expose the live instance so Playwright @regression
+          // specs can read app.step / app.state without DOM scraping.
+          window.__assessmentApp = appInstance;
         } else {
           console.error("AssessmentApp not found after loading dependencies");
         }

--- a/tests/e2e/03c-resume-restores-step.spec.mjs
+++ b/tests/e2e/03c-resume-restores-step.spec.mjs
@@ -1,0 +1,161 @@
+import { test } from "@playwright/test";
+import {
+  clearPageStorage,
+  expect,
+} from "./_harness.mjs";
+
+/**
+ * 03c — Resume restores saved wizard step (E2E regression)
+ *
+ * E2E counterpart to tests/spa/resume-step-persistence.test.mjs
+ * (phase-c-spec-resume-step). Verifies that a user who reaches Results
+ * (or any later step) is taken back to that exact step on Resume —
+ * not bounced back to Phase 1.
+ *
+ * BEFORE FIX: the Resume click handler called goToStep("phase1")
+ *   unconditionally and saveToStorage did not persist this.step.
+ * AFTER FIX: saveToStorage writes this.step into state on every save;
+ *   loadFromStorage restores it; the Resume handler honors self.step.
+ *
+ * SPA literal STORAGE_KEY (docs/javascripts/assessment-app.js):
+ *   "fsi-agentgov-assessment"
+ */
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+
+async function readPerIdSlot(page, id) {
+  return await page.evaluate(
+    ([k, theId]) => {
+      const raw = localStorage.getItem(k + "-data-" + theId);
+      return raw ? JSON.parse(raw) : null;
+    },
+    [STORAGE_KEY, id],
+  );
+}
+
+async function readCurrentAssessmentId(page) {
+  return await page.evaluate((k) => {
+    const raw = localStorage.getItem(k + "-current");
+    if (!raw) return null;
+    try { return JSON.parse(raw).assessmentId || null; } catch { return null; }
+  }, STORAGE_KEY);
+}
+
+async function activeStep(page) {
+  return await page.evaluate(() => {
+    const app = window.__assessmentApp;
+    return app ? app.step : null;
+  });
+}
+
+async function startNewAndScope(page, organizationName) {
+  await page.getByRole("button", { name: "Start New Assessment" }).dispatchEvent("click");
+  await page.getByRole("heading", { name: "Assessment Scoping" }).waitFor();
+  await page.getByLabel("Organization Name").fill(organizationName);
+  await page.getByLabel("Assessor Name").fill("Test Assessor");
+  await page.getByLabel("Institution Type", { exact: true }).selectOption("bank");
+  const zoneFieldset = page.getByRole("group", { name: "Active Governance Zones" });
+  const zone1 = zoneFieldset.locator('input[type="checkbox"][value="1"]');
+  if (!(await zone1.isChecked())) await zone1.check();
+  await page.getByRole("button", { name: "Begin Assessment" }).dispatchEvent("click");
+  await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+}
+
+async function answerControl(page, controlId, label) {
+  const card = page.locator(`[data-control-id="${controlId}"]`);
+  await card.first().waitFor({ state: "attached" });
+  const pillar = card.locator('xpath=ancestor::div[contains(@class,"ag-pillar-controls")]');
+  if ((await pillar.count()) > 0) {
+    const collapsed = await pillar.first().evaluate((el) => el.classList.contains("collapsed"));
+    if (collapsed) {
+      const header = pillar.locator(
+        'xpath=preceding-sibling::div[contains(@class,"ag-pillar-header")][1]',
+      );
+      if ((await header.count()) > 0) await header.first().click();
+    }
+  }
+  await card.getByRole("button", { name: label, exact: true }).click();
+}
+
+async function navigateBackToWelcome(page) {
+  await page.waitForTimeout(700);
+  // Click the welcome step indicator (top nav) to return.
+  await page.locator(".ag-step-indicator").filter({ hasText: /Welcome/ }).first().click();
+  await page
+    .locator("#assessment-app")
+    .getByRole("heading", { name: "Governance Readiness Assessment" })
+    .waitFor();
+}
+
+test.describe("Resume restores saved wizard step @regression", () => {
+  test("Resume from Results lands back on Results, not Phase 1 @regression", async ({ page }) => {
+    page.on("dialog", (d) => { d.dismiss().catch(() => {}); });
+
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
+    await clearPageStorage(page);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    // Wait for SPA hydration (window.__assessmentApp).
+    await page.waitForFunction(() => !!window.__assessmentApp, null, { timeout: 15_000 });
+
+    await startNewAndScope(page, "Bank Resume");
+    await answerControl(page, "1.1", "Yes");
+    const id = await readCurrentAssessmentId(page);
+    expect(id).toBeTruthy();
+
+    // Navigate forward: Phase 1 → Results (no gaps means no Phase 2 button)
+    await page.getByRole("button", { name: "View Results", exact: true }).first().dispatchEvent("click");
+    await page.getByRole("heading", { name: /^Results/ }).waitFor();
+
+    // Sanity: app.step is "results" and the persisted slot reflects that.
+    expect(await activeStep(page)).toBe("results");
+    await page.waitForTimeout(700);
+    let slot = await readPerIdSlot(page, id);
+    expect(slot, "per-id slot must exist").not.toBeNull();
+    expect(slot.step).toBe("results");
+
+    // Go back to welcome and Resume.
+    await navigateBackToWelcome(page);
+    await page.getByRole("button", { name: /^Resume Bank Resume/ }).dispatchEvent("click");
+
+    // Assert Resume landed on Results (NOT Phase 1).
+    await page.getByRole("heading", { name: /^Results/ }).waitFor();
+    expect(await activeStep(page)).toBe("results");
+  });
+
+  test("legacy save without `step` defaults to Phase 1 @regression", async ({ page }) => {
+    page.on("dialog", (d) => { d.dismiss().catch(() => {}); });
+
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
+    await clearPageStorage(page);
+
+    // Plant a legacy assessment (no `step` field) directly into localStorage.
+    await page.evaluate((K) => {
+      const id = "legacy-resume-id";
+      const state = {
+        assessmentId: id,
+        assessmentName: "Legacy Org",
+        schemaVersion: "1.4.0",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scoping: { organizationName: "Legacy Org", assessorName: "L", zones: [1, 2, 3], roles: [] },
+        responses: { "1.1": { answer: "yes", notes: "", evidenceRef: "" } },
+        overrides: {}, drilldown: {}, currentStep: "phase1", completedSteps: [],
+        assessmentStatus: "in-progress",
+        // intentionally NO `step` field
+      };
+      localStorage.setItem(K + "-data-" + id, JSON.stringify(state));
+      localStorage.setItem(
+        K + "-list",
+        JSON.stringify([{ id, name: "Legacy Org — 2026-01-01", updatedAt: state.updatedAt, progress: 1 }]),
+      );
+    }, STORAGE_KEY);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => !!window.__assessmentApp, null, { timeout: 15_000 });
+
+    // Click Resume on the legacy assessment.
+    await page.getByRole("button", { name: /^Resume Legacy Org/ }).dispatchEvent("click");
+    await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+    expect(await activeStep(page)).toBe("phase1");
+  });
+});

--- a/tests/e2e/03d-filter-cross-assessment-leak.spec.mjs
+++ b/tests/e2e/03d-filter-cross-assessment-leak.spec.mjs
@@ -1,0 +1,169 @@
+import { test } from "@playwright/test";
+import {
+  clearPageStorage,
+  expect,
+} from "./_harness.mjs";
+
+/**
+ * 03d — Filter view-state does not leak across assessments (E2E regression)
+ *
+ * E2E counterpart to tests/spa/filter-namespace-isolation.test.mjs
+ * (phase-c-spec-filter-leak). Verifies role-filter and sector view-state
+ * are stored under per-assessment keys and never leak from assessment A
+ * into a freshly created assessment B.
+ *
+ * BEFORE FIX: filters were persisted under global keys ag.roleFilter and
+ *   ag.selectedSector; newState() seeded a new assessment from those
+ *   globals so a new assessment inherited the previous one's filter.
+ * AFTER FIX: filters write to ag.roleFilter-<id> / ag.selectedSector-<id>;
+ *   newState() does NOT read globals; loadFromStorage rehydrates
+ *   per-id values; deleteSaved cleans them up; init() runs a one-shot
+ *   migration of legacy globals onto the most-recent current assessment.
+ */
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+const ROLE_FILTER_KEY = "ag.roleFilter";
+const SECTOR_KEY = "ag.selectedSector";
+
+async function readCurrentAssessmentId(page) {
+  return await page.evaluate((k) => {
+    const raw = localStorage.getItem(k + "-current");
+    if (!raw) return null;
+    try { return JSON.parse(raw).assessmentId || null; } catch { return null; }
+  }, STORAGE_KEY);
+}
+
+async function startNewAndScope(page, organizationName) {
+  await page.getByRole("button", { name: "Start New Assessment" }).dispatchEvent("click");
+  await page.getByRole("heading", { name: "Assessment Scoping" }).waitFor();
+  await page.getByLabel("Organization Name").fill(organizationName);
+  await page.getByLabel("Assessor Name").fill("Test Assessor");
+  await page.getByLabel("Institution Type", { exact: true }).selectOption("bank");
+  const zoneFieldset = page.getByRole("group", { name: "Active Governance Zones" });
+  const zone1 = zoneFieldset.locator('input[type="checkbox"][value="1"]');
+  if (!(await zone1.isChecked())) await zone1.check();
+  await page.getByRole("button", { name: "Begin Assessment" }).dispatchEvent("click");
+  await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+}
+
+async function navigateBackToWelcome(page) {
+  await page.waitForTimeout(700);
+  await page.locator(".ag-step-indicator").filter({ hasText: /Welcome/ }).first().click();
+  await page
+    .locator("#assessment-app")
+    .getByRole("heading", { name: "Governance Readiness Assessment" })
+    .waitFor();
+}
+
+test.describe("Filter view-state is namespaced per assessment @regression", () => {
+  test("setting a role filter on A does not leak into a freshly-created B @regression", async ({ page }) => {
+    page.on("dialog", (d) => { d.dismiss().catch(() => {}); });
+
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
+    await clearPageStorage(page);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => !!window.__assessmentApp, null, { timeout: 15_000 });
+
+    // -- A: pick a non-default role filter --------------------------------
+    await startNewAndScope(page, "Bank A");
+    const idA = await readCurrentAssessmentId(page);
+    expect(idA).toBeTruthy();
+
+    const filterSelect = page.locator("#ag-role-filter-select");
+    await filterSelect.waitFor();
+    // Select first non-empty option.
+    const firstNonEmpty = await filterSelect.evaluate((el) => {
+      for (const o of el.options) if (o.value) return o.value;
+      return "";
+    });
+    expect(firstNonEmpty, "expected at least one non-empty role-filter option").toBeTruthy();
+    await filterSelect.selectOption(firstNonEmpty);
+    await page.waitForTimeout(700);
+
+    // Assert the filter was saved under per-id slot, not the global key.
+    const aFilter = await page.evaluate(([rk, sk, id]) => ({
+      perA: localStorage.getItem(rk + "-" + id),
+      perSectorA: localStorage.getItem(sk + "-" + id),
+      legacyRole: localStorage.getItem(rk),
+      legacySector: localStorage.getItem(sk),
+    }), [ROLE_FILTER_KEY, SECTOR_KEY, idA]);
+    expect(aFilter.perA).toBe(firstNonEmpty);
+    // Global legacy keys must NOT be written by the post-fix listener.
+    expect(aFilter.legacyRole).toBeNull();
+
+    // -- B: brand new assessment must NOT inherit A's filter ---------------
+    await navigateBackToWelcome(page);
+    await startNewAndScope(page, "Bank B");
+    const idB = await readCurrentAssessmentId(page);
+    expect(idB).toBeTruthy();
+    expect(idB).not.toBe(idA);
+
+    const stateB = await page.evaluate(() => {
+      const app = window.__assessmentApp;
+      return app && app.state ? { roleFilter: app.state.roleFilter || "", selectedSector: app.state.selectedSector || "" } : null;
+    });
+    expect(stateB).not.toBeNull();
+    expect(stateB.roleFilter).toBe("");
+
+    const filterSelectB = page.locator("#ag-role-filter-select");
+    await filterSelectB.waitFor();
+    expect(await filterSelectB.evaluate((el) => el.value)).toBe("");
+
+    // -- Resume A: filter still set ---------------------------------------
+    await navigateBackToWelcome(page);
+    await page.getByRole("button", { name: /^Resume Bank A/ }).dispatchEvent("click");
+    await page.getByRole("heading", { name: /Phase 1: Control-Level Assessment/ }).waitFor();
+    const filterSelectA = page.locator("#ag-role-filter-select");
+    await filterSelectA.waitFor();
+    expect(await filterSelectA.evaluate((el) => el.value)).toBe(firstNonEmpty);
+  });
+
+  test("legacy global filter keys migrate to current assessment on init @regression", async ({ page }) => {
+    page.on("dialog", (d) => { d.dismiss().catch(() => {}); });
+
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
+    await clearPageStorage(page);
+
+    // Plant a legacy current assessment + legacy global filter keys.
+    await page.evaluate(([K, RK, SK]) => {
+      const id = "legacy-filter-id";
+      const state = {
+        assessmentId: id,
+        assessmentName: "Legacy Filter Org",
+        schemaVersion: "1.4.0",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scoping: { organizationName: "Legacy Filter Org", assessorName: "L", zones: [1, 2, 3], roles: [] },
+        responses: {},
+        overrides: {}, drilldown: {}, currentStep: "phase1", completedSteps: [],
+        assessmentStatus: "in-progress",
+      };
+      localStorage.setItem(K + "-current", JSON.stringify(state));
+      localStorage.setItem(K + "-data-" + id, JSON.stringify(state));
+      localStorage.setItem(
+        K + "-list",
+        JSON.stringify([{ id, name: "Legacy Filter Org — 2026-01-01", updatedAt: state.updatedAt, progress: 0 }]),
+      );
+      localStorage.setItem(RK, "AI Governance Lead");
+      localStorage.setItem(SK, "broker-dealer");
+    }, [STORAGE_KEY, ROLE_FILTER_KEY, SECTOR_KEY]);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => !!window.__assessmentApp, null, { timeout: 15_000 });
+
+    // Init should have moved legacy globals onto the legacy id.
+    const after = await page.evaluate(([K, RK, SK, id]) => ({
+      perRole: localStorage.getItem(RK + "-" + id),
+      perSector: localStorage.getItem(SK + "-" + id),
+      legacyRole: localStorage.getItem(RK),
+      legacySector: localStorage.getItem(SK),
+      flag: localStorage.getItem(K + "-filter-migration-v1"),
+    }), [STORAGE_KEY, ROLE_FILTER_KEY, SECTOR_KEY, "legacy-filter-id"]);
+
+    expect(after.perRole).toBe("AI Governance Lead");
+    expect(after.perSector).toBe("broker-dealer");
+    expect(after.legacyRole).toBeNull();
+    expect(after.legacySector).toBeNull();
+    expect(after.flag).toBe("1");
+  });
+});

--- a/tests/e2e/_harness.mjs
+++ b/tests/e2e/_harness.mjs
@@ -163,9 +163,12 @@ export async function seedScoping(page, persona) {
   const zoneFieldset = page.getByRole("group", {
     name: "Active Governance Zones",
   });
-  for (const z of sc.zones || []) {
+  const wantedZones = new Set((sc.zones || []).map(Number));
+  for (const z of [1, 2, 3]) {
     const cb = zoneFieldset.locator(`input[type="checkbox"][value="${z}"]`);
-    if (!(await cb.isChecked())) await cb.check();
+    const checked = await cb.isChecked();
+    if (wantedZones.has(z) && !checked) await cb.check();
+    else if (!wantedZones.has(z) && checked) await cb.uncheck();
   }
 
   // Submit. The click handler synchronously re-renders the SPA, which

--- a/tests/spa/filter-namespace-isolation.test.mjs
+++ b/tests/spa/filter-namespace-isolation.test.mjs
@@ -1,0 +1,159 @@
+/**
+ * Regression test for the "filter view-state leaks across assessments" SPA
+ * bug (phase-c-spec-filter-leak).
+ *
+ * BEFORE FIX: ROLE_FILTER_KEY ("ag.roleFilter") and SECTOR_KEY
+ *   ("ag.selectedSector") were stored as global localStorage keys. Newly
+ *   created assessments inherited the previous assessment's filters via
+ *   newState(), and switching between two saved assessments overwrote the
+ *   single global slot.
+ * AFTER FIX: filters are persisted under per-assessment keys
+ *   (ROLE_FILTER_KEY+"-"+id, SECTOR_KEY+"-"+id). newState() does NOT read
+ *   any global filter keys. loadFromStorage hydrates state.roleFilter /
+ *   state.selectedSector from the per-id slot. deleteSaved clears them.
+ *   _migrateLegacySavedAssessments runs once to move legacy globals onto
+ *   the current assessment id (or discards them when none exists).
+ *
+ * SPA file: docs/javascripts/assessment-app.js
+ *   - newState                       (~L881)
+ *   - loadFromStorage                (~L988)
+ *   - deleteSaved                    (~L1004)
+ *   - _migrateLegacySavedAssessments (~L322)
+ *   - sector listener                (~L2034)
+ *   - role-filter listener           (~L2316)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { bootSPA } from "./_bootSpa.mjs";
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+const ROLE_FILTER_KEY = "ag.roleFilter";
+const SECTOR_KEY = "ag.selectedSector";
+
+async function makeApp() {
+  const { window } = bootSPA();
+  const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+  await app.loadData();
+  return { app, window };
+}
+
+function seed(app, window, id, name, roleFilter, sector) {
+  app.state = app.newState();
+  app.state.assessmentId = id;
+  app.state.assessmentName = name;
+  app.state.scoping.organizationName = name;
+  app.state.scoping.zones = [1, 2, 3];
+  app.state.roleFilter = roleFilter || "";
+  app.state.selectedSector = sector || "";
+  if (roleFilter) {
+    window.localStorage.setItem(ROLE_FILTER_KEY + "-" + id, roleFilter);
+  }
+  if (sector) {
+    window.localStorage.setItem(SECTOR_KEY + "-" + id, sector);
+  }
+  app.saveToStorage();
+}
+
+describe("filter view-state is namespaced per assessment (phase-c-spec-filter-leak)", () => {
+  beforeEach(() => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.clear === "function") {
+      globalThis.localStorage.clear();
+    }
+  });
+
+  it("newState does NOT inherit legacy global filter keys", async () => {
+    const { app, window } = await makeApp();
+    window.localStorage.setItem(ROLE_FILTER_KEY, "AI Governance Lead");
+    window.localStorage.setItem(SECTOR_KEY, "broker-dealer");
+    const fresh = app.newState();
+    expect(fresh.roleFilter).toBe("");
+    expect(fresh.selectedSector).toBe("");
+  });
+
+  it("loading assessment B does not see assessment A's filters", async () => {
+    const { app, window } = await makeApp();
+    seed(app, window, "id-A", "Acme Bank", "AI Governance Lead", "broker-dealer");
+    seed(app, window, "id-B", "Beta Brokers", "", "");
+
+    expect(app.loadFromStorage("id-B")).toBe(true);
+    expect(app.state.roleFilter || "").toBe("");
+    expect(app.state.selectedSector || "").toBe("");
+  });
+
+  it("loading assessment A retains its own filters even after B was active", async () => {
+    const { app, window } = await makeApp();
+    seed(app, window, "id-A", "Acme Bank", "AI Governance Lead", "broker-dealer");
+    seed(app, window, "id-B", "Beta Brokers", "Compliance Officer", "ria");
+
+    // Reload A
+    expect(app.loadFromStorage("id-A")).toBe(true);
+    expect(app.state.roleFilter).toBe("AI Governance Lead");
+    expect(app.state.selectedSector).toBe("broker-dealer");
+  });
+
+  it("deleteSaved removes per-id filter keys for the deleted assessment", async () => {
+    const { app, window } = await makeApp();
+    seed(app, window, "id-A", "Acme Bank", "AI Governance Lead", "broker-dealer");
+    seed(app, window, "id-B", "Beta Brokers", "Compliance Officer", "ria");
+
+    app.deleteSaved("id-A");
+
+    expect(window.localStorage.getItem(ROLE_FILTER_KEY + "-id-A")).toBeNull();
+    expect(window.localStorage.getItem(SECTOR_KEY + "-id-A")).toBeNull();
+    // B's keys must remain.
+    expect(window.localStorage.getItem(ROLE_FILTER_KEY + "-id-B")).toBe("Compliance Officer");
+    expect(window.localStorage.getItem(SECTOR_KEY + "-id-B")).toBe("ria");
+  });
+
+  it("_migrateLegacySavedAssessments moves legacy global filters onto the current assessment", async () => {
+    const { window } = bootSPA();
+    const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+    await app.loadData();
+
+    // Plant a legacy current assessment + legacy global filter keys.
+    const legacyState = {
+      assessmentId: "legacy-id", assessmentName: "Legacy",
+      schemaVersion: "1.4.0", createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scoping: { organizationName: "L", assessorName: "A", zones: [1, 2, 3], roles: [] },
+      responses: { "1.1": { answer: "yes", notes: "", evidenceRef: "" } },
+      overrides: {}, drilldown: {}, currentStep: "phase1", completedSteps: [],
+      assessmentStatus: "in-progress",
+    };
+    window.localStorage.setItem(STORAGE_KEY + "-current", JSON.stringify(legacyState));
+    window.localStorage.setItem(ROLE_FILTER_KEY, "AI Governance Lead");
+    window.localStorage.setItem(SECTOR_KEY, "broker-dealer");
+
+    app._migrateLegacySavedAssessments();
+
+    expect(window.localStorage.getItem(ROLE_FILTER_KEY + "-legacy-id")).toBe("AI Governance Lead");
+    expect(window.localStorage.getItem(SECTOR_KEY + "-legacy-id")).toBe("broker-dealer");
+    // Globals removed.
+    expect(window.localStorage.getItem(ROLE_FILTER_KEY)).toBeNull();
+    expect(window.localStorage.getItem(SECTOR_KEY)).toBeNull();
+    // Flag set.
+    expect(window.localStorage.getItem(STORAGE_KEY + "-filter-migration-v1")).toBe("1");
+
+    // Idempotent: second run is a no-op.
+    window.localStorage.setItem(ROLE_FILTER_KEY + "-legacy-id", "Compliance Officer");
+    app._migrateLegacySavedAssessments();
+    expect(window.localStorage.getItem(ROLE_FILTER_KEY + "-legacy-id")).toBe("Compliance Officer");
+  });
+
+  it("migration with no current assessment discards legacy filters", async () => {
+    const { window } = bootSPA();
+    const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+    await app.loadData();
+
+    window.localStorage.setItem(ROLE_FILTER_KEY, "AI Governance Lead");
+    window.localStorage.setItem(SECTOR_KEY, "broker-dealer");
+
+    app._migrateLegacySavedAssessments();
+
+    expect(window.localStorage.getItem(ROLE_FILTER_KEY)).toBeNull();
+    expect(window.localStorage.getItem(SECTOR_KEY)).toBeNull();
+    // No per-id slot was created (no current id existed).
+    const allKeys = Object.keys(window.localStorage);
+    expect(allKeys.some(k => k.startsWith(ROLE_FILTER_KEY + "-"))).toBe(false);
+    expect(allKeys.some(k => k.startsWith(SECTOR_KEY + "-"))).toBe(false);
+  });
+});

--- a/tests/spa/resume-step-persistence.test.mjs
+++ b/tests/spa/resume-step-persistence.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * Regression test for the "Resume always lands on phase1" SPA bug
+ * (phase-c-spec-resume-step).
+ *
+ * BEFORE FIX: saveToStorage did not persist this.step; the Resume click
+ *   handler always called goToStep("phase1"). A user on results/export
+ *   was bounced back to phase1 on Resume.
+ * AFTER FIX: saveToStorage writes this.step into state; loadFromStorage
+ *   restores it; the Resume click handler honors self.step. Legacy saves
+ *   without a step field default to "phase1" for safety.
+ *
+ * SPA file: docs/javascripts/assessment-app.js
+ *   - saveToStorage   (~L920)
+ *   - loadFromStorage (~L988)
+ *   - goToStep        (~L1696)
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { bootSPA } from "./_bootSpa.mjs";
+
+const STORAGE_KEY = "fsi-agentgov-assessment";
+
+async function makeApp() {
+  const { window } = bootSPA();
+  const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+  await app.loadData();
+  return { app, window };
+}
+
+function seed(app, id, name) {
+  app.state = app.newState();
+  app.state.assessmentId = id;
+  app.state.assessmentName = name;
+  app.state.scoping.organizationName = name;
+  app.state.scoping.zones = [1, 2, 3];
+  app.state.responses["1.1"] = { answer: "yes", notes: "", evidenceRef: "" };
+  app.saveToStorage();
+}
+
+describe("resume restores saved wizard step (phase-c-spec-resume-step)", () => {
+  beforeEach(() => {
+    if (globalThis.localStorage && typeof globalThis.localStorage.clear === "function") {
+      globalThis.localStorage.clear();
+    }
+  });
+
+  it("saveToStorage persists the current step into the per-id slot", async () => {
+    const { app, window } = await makeApp();
+    seed(app, "id-A", "Acme Bank");
+    app.step = "results";
+    app.saveToStorage();
+
+    const raw = window.localStorage.getItem(STORAGE_KEY + "-data-id-A");
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw).step).toBe("results");
+  });
+
+  it("loadFromStorage restores app.step from the saved data when it is results/export", async () => {
+    const { app } = await makeApp();
+    seed(app, "id-A", "Acme Bank");
+    app.step = "export";
+    app.saveToStorage();
+
+    // Simulate a fresh load
+    app.state = null;
+    app.step = "welcome";
+    const ok = app.loadFromStorage("id-A");
+    expect(ok).toBe(true);
+    expect(app.step).toBe("export");
+  });
+
+  it("legacy saves without a `step` field default to phase1", async () => {
+    const { window } = bootSPA();
+    const legacy = {
+      assessmentId: "legacy-id",
+      assessmentName: "Legacy",
+      schemaVersion: "1.4.0",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scoping: { organizationName: "L", assessorName: "A", zones: [1, 2, 3], roles: [] },
+      responses: { "1.1": { answer: "yes", notes: "", evidenceRef: "" } },
+      overrides: {}, drilldown: {}, currentStep: "phase1", completedSteps: [],
+      assessmentStatus: "in-progress",
+    };
+    window.localStorage.setItem(STORAGE_KEY + "-data-legacy-id", JSON.stringify(legacy));
+
+    const app = new window.AssessmentApp(window.document.getElementById("ag-app"));
+    await app.loadData();
+    app.step = "welcome";
+    expect(app.loadFromStorage("legacy-id")).toBe(true);
+    expect(app.step).toBe("phase1");
+  });
+
+  it("Resume only restores results/export; in-progress steps default to phase1", async () => {
+    const { app } = await makeApp();
+    seed(app, "id-A", "Acme Bank");
+    // Steps that should round-trip exactly:
+    for (const target of ["results", "export"]) {
+      app.step = target;
+      app.saveToStorage();
+      app.state = null;
+      app.step = "welcome";
+      app.loadFromStorage("id-A");
+      expect(app.step, "Resume should restore " + target).toBe(target);
+    }
+    // In-progress / pre-results steps always normalize to "phase1" on Resume:
+    for (const target of ["scoping", "phase1", "phase2"]) {
+      app.step = target;
+      app.saveToStorage();
+      app.state = null;
+      app.step = "welcome";
+      app.loadFromStorage("id-A");
+      expect(app.step, target + " should normalize to phase1 on Resume").toBe("phase1");
+    }
+  });
+});


### PR DESCRIPTION
Fixes two SPA regressions surfaced by Phase C `@regression` specs.

## Changes

1. **Resume restores wizard step** (`results`/`export` only; all other states default to `phase1`). `saveToStorage` persists `state.step`; `loadFromStorage` normalizes legacy/in-progress saves to `phase1`.
2. **Filter view-state namespaced per assessment**. Role filter and selected sector now stored under `ROLE_FILTER_KEY-<id>` and `SECTOR_KEY-<id>`; one-shot migration moves legacy global keys onto the current assessment id.
3. **Loader exposes `window.__assessmentApp`** on init (cleared on destroy) for E2E observability.
4. **`seedScoping` harness fix**: now unchecks zones not present in persona so `persona.zones=[1]` yields `state.zones=[1]`.

## Tests

- `tests/spa/resume-step-persistence.test.mjs` — 4 vitest
- `tests/spa/filter-namespace-isolation.test.mjs` — 6 vitest
- `tests/e2e/03c-resume-restores-step.spec.mjs` — 2 `@regression`
- `tests/e2e/03d-filter-cross-assessment-leak.spec.mjs` — 2 `@regression`

All 7 `@regression` and 5 `@smoke` specs green; vitest 93 passed/1 skipped.