### PR TITLE
infra(branch-protection): declare main protection in repo + apply script

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,18 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "e2e-smoke",
+      "sri-check"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}

--- a/scripts/apply-branch-protection.ps1
+++ b/scripts/apply-branch-protection.ps1
@@ -1,0 +1,33 @@
+#requires -Version 5.1
+[CmdletBinding()]
+param(
+  [string]$Branch = "main",
+  [string]$ConfigPath = ".github/branch-protection.json"
+)
+$ErrorActionPreference = "Stop"
+$repo = "judeper/FSI-AgentGov"
+
+if (!(Test-Path $ConfigPath)) { throw "Config not found: $ConfigPath" }
+
+# Switch to push-capable account
+$prior = (gh api user -q .login)
+if ($prior -ne "judeper") {
+  gh auth switch -u judeper | Out-Null
+}
+
+try {
+  $body = Get-Content $ConfigPath -Raw
+  Write-Host "Applying branch protection to $repo`:$Branch ..."
+  $resp = $body | gh api -X PUT "repos/$repo/branches/$Branch/protection" --input -
+  Write-Host "Response:`n$resp"
+  $applied = $resp | ConvertFrom-Json
+  $expectedCtx = (Get-Content $ConfigPath | ConvertFrom-Json).required_status_checks.contexts
+  $actualCtx = $applied.required_status_checks.contexts
+  $missing = $expectedCtx | Where-Object { $_ -notin $actualCtx }
+  if ($missing) { throw "Contexts missing from applied protection: $($missing -join ',')" }
+  Write-Host "OK: branch protection applied. Required contexts: $($actualCtx -join ', ')"
+} finally {
+  if ($prior -ne "judeper") {
+    gh auth switch -u $prior | Out-Null
+  }
+}


### PR DESCRIPTION
Closes branch-protection-json (Theme 1 / iter3-1-007).

Versions branch protection as code so any change to required status checks shows up in a PR diff.

## Required Status Checks (applied to main)
- `e2e-smoke`
- `sri-check`

## Configuration
- `enforce_admins: false` (intentional — leaves repo owner able to merge in emergencies; flip to `true` follow-up once suite is stable per plan v3.1)
- `strict: true` (require branches up-to-date)
- No required PR reviews / no restrictions / no linear-history requirement

## Deferred contexts
- **`mkdocs-build`**: planned but DEFERRED. No check-run by that name exists on main. The equivalent `mkdocs build --strict` step lives inside the `deploy` job of `publish_docs.yml`, which only triggers on `push` to main — it cannot serve as a PR-required check. Follow-up: split a dedicated PR-triggered `mkdocs-build` job, then add it to `contexts`.

## Not required (intentional)
- `e2e-full` is label-gated heavy suite per plan v3.1 Theme 5 — NOT a required check.

## Verified check-run names on main
`deploy`, `e2e-full`, `e2e-smoke`, `sri-check`, `test`

## Apply
```powershell
.\scripts\apply-branch-protection.ps1
```n
Already applied locally; this PR versions the source of truth.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>