### PR TITLE
ci(prod-smoke): fix flow-mapping YAML parse error

### DIFF
--- a/.github/workflows/prod-smoke-scheduled.yml
+++ b/.github/workflows/prod-smoke-scheduled.yml
@@ -36,7 +36,8 @@ jobs:
         run: npx playwright test tests/e2e/prod-probe.spec.mjs
       - name: Ensure label exists
         if: failure()
-        env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh label create prod-smoke-fail --color B60205 --description "Production smoke probe failed" --force || true
       - name: Open issue on failure
         if: failure()


### PR DESCRIPTION
Follow-up to #160. The inline `env: { GH_TOKEN: ... }` flow-style with a `\$\{\{ ... \}\}` expression inside is invalid YAML — the `{{` collides with the flow-mapping `{`. GitHub failed to parse the workflow on the merge commit. Switching to block-style `env:` fixes registration.