### PR TITLE
fix(csp): remove ignored frame-ancestors meta + allow api.github.com connect-src

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -6,9 +6,30 @@
      - style-src  'unsafe-inline'      : mkdocs-material inlines critical CSS.
      - style-src  https://fonts.googleapis.com : mkdocs-material default font CSS.
      - font-src   https://fonts.gstatic.com    : mkdocs-material default font files.
-     - img-src    data:                : inlined SVG/data-URL icons. #}
+     - img-src    data:                : inlined SVG/data-URL icons.
+     - connect-src https://api.github.com : mkdocs-material announce-bar release-version fetch.
+
+   NOTE: `frame-ancestors` is intentionally NOT set via <meta>. Per the CSP
+   spec, browsers ignore `frame-ancestors` when delivered via meta-CSP — it
+   MUST be sent as an HTTP response header. GitHub Pages does not allow
+   custom response headers (no _headers file, no .htaccess), so we ship a
+   small inline JS frame-busting guard below as defense-in-depth. If hosting
+   ever moves off GitHub Pages, add `frame-ancestors 'none'` as an HTTP
+   header on the origin. #}
 {% block extrahead %}
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'">
+  <script>
+    if (window.top !== window.self) {
+      // Frame-busting: refuse to render inside an iframe.
+      // CSP frame-ancestors must be sent as HTTP header for full coverage,
+      // but GitHub Pages does not let us set custom response headers.
+      // This JS guard is a defense-in-depth layer.
+      try { window.top.location = window.self.location; } catch (_) {
+        document.documentElement.style.display = "none";
+        document.body && (document.body.innerHTML = "<p>This page cannot be displayed inside a frame.</p>");
+      }
+    }
+  </script>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://api.github.com; base-uri 'self'; form-action 'self'">
 {% endblock %}
 
 {% block announce %}

--- a/tests/e2e/25-zero-pageerror.spec.mjs
+++ b/tests/e2e/25-zero-pageerror.spec.mjs
@@ -18,34 +18,16 @@ import {
  * focused assertion that runs first in CI for fast feedback when a
  * deploy ships a JS regression.
  *
- * KNOWN DEFECTS this canary surfaces (NOT introduced by this PR):
- *   1. mkdocs-material's announce-bar wires a release-notes fetch to
- *      `https://api.github.com/repos/judeper/FSI-AgentGov/releases/latest`
- *      and `…/repos/judeper/FSI-AgentGov`. The site's CSP
- *      `connect-src 'self'` blocks both, producing two console errors
- *      per page navigation. This is a real CSP regression that should
- *      either (a) add api.github.com to connect-src + the allowlist
- *      fixture, or (b) disable the announce-bar release widget. Logged
- *      as follow-up.
- *   2. `frame-ancestors` is declared on the meta-CSP, but per spec
- *      meta-CSP cannot deliver `frame-ancestors`; Chromium emits a
- *      console warning. This directive should move to an HTTP header
- *      (Pages config) or be dropped from the meta. Logged as follow-up.
- *
- * Until those are fixed, the spec is wrapped in `test.fail` per the
- * batch caveat ("If a spec catches a real bug … use `test.fail` with
- * documentation, NOT a silent skip"). When the underlying defects land,
- * remove the `test.fail` wrapper and the canary returns to fail-loud.
+ * Previously surfaced two CSP defects (now fixed in fix/csp-meta-defects):
+ *   1. api.github.com blocked by connect-src 'self' — fixed by allow-listing
+ *      https://api.github.com in overrides/main.html and csp-allowed.json.
+ *   2. frame-ancestors via meta-CSP (browser-ignored) — removed from meta;
+ *      replaced with inline JS frame-busting guard at top of <head>.
  */
 test.describe("zero pageerror canary @smoke", () => {
   test("happy path produces zero pageerrors / console errors @smoke", async ({
     page,
   }) => {
-    // Mark as expected-to-fail until the two CSP defects above are fixed.
-    test.fail(
-      true,
-      "Surfacing pre-existing CSP violations (api.github.com connect-src + frame-ancestors via meta). Remove when fixed.",
-    );
     const pageErrors = [];
     const consoleErrors = [];
     page.on("pageerror", (err) => {

--- a/tests/e2e/fixtures/csp-allowed.json
+++ b/tests/e2e/fixtures/csp-allowed.json
@@ -5,8 +5,7 @@
     "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
     "font-src": ["'self'", "https://fonts.gstatic.com"],
     "img-src": ["'self'", "data:"],
-    "connect-src": ["'self'"],
-    "frame-ancestors": ["'none'"],
+    "connect-src": ["'self'", "https://api.github.com"],
     "base-uri": ["'self'"],
     "form-action": ["'self'"]
   },
@@ -27,6 +26,12 @@
       "directive": "script-src",
       "value": "'unsafe-inline'",
       "reason": "mkdocs-material inline init scripts",
+      "expiresISO": "2026-12-31"
+    },
+    {
+      "directive": "connect-src",
+      "value": "https://api.github.com",
+      "reason": "mkdocs-material announce-bar release-version fetch (latest release + repo metadata)",
       "expiresISO": "2026-12-31"
     }
   ]


### PR DESCRIPTION
Closes triage-fix-csp-meta-defects (Phase B' P1 finding from PR #164 triage report).

Two real CSP defects fixed; spec 25 `test.fail()` wrapper removed.

## Defects fixed

1. **frame-ancestors via `<meta>` is browser-ignored** (CSP spec). Removed from meta directive; added inline JS frame-busting guard at top of `<head>` as defense-in-depth. GitHub Pages does not support custom HTTP response headers, so JS guard is the pragmatic shipping option.
2. **api.github.com blocked by connect-src 'self'.** mkdocs-material announce-bar release-version fetch was failing silently. Added `https://api.github.com` to connect-src in `overrides/main.html` and to `tests/e2e/fixtures/csp-allowed.json`.

## Verification

- Local: spec 25 (zero-pageerror canary) passes naturally without `test.fail` wrapper (1 passed, 11.2s)
- Awaiting CI `e2e-smoke` + `sri-check` for full gating