### PR TITLE
fix: escape markdown special chars in MD exporter customer header

### DIFF
--- a/docs/javascripts/assessment-app.js
+++ b/docs/javascripts/assessment-app.js
@@ -4172,7 +4172,9 @@
     // Section 1 — Header
     lines.push("# FSI Agent Governance Assessment \u2014 Next Session Agenda");
     lines.push("");
-    lines.push("**Customer:** " + (scoping.organizationName || "TBD"));
+    // spa-fix-md-escape: customer name is user-supplied; escape Markdown
+    // special chars so names containing *, _, [, `, etc. don't break rendering.
+    lines.push("**Customer:** " + _agendaMdCell(scoping.organizationName || "TBD"));
     lines.push("**Generated:** " + new Date().toISOString());
     lines.push("**Zone target:** " + zoneTarget);
     lines.push("**Sector:** " + (state.selectedSector || scoping.institutionType || "Not specified"));

--- a/tests/spa/md-escape.test.mjs
+++ b/tests/spa/md-escape.test.mjs
@@ -77,4 +77,11 @@ describe("agenda markdown cell escape", () => {
     const html = renderer.render(md);
     expect(html).not.toMatch(/<script/i);
   });
+
+  it("escapes markdown special chars in **Customer:** header line", async () => {
+    const { app } = await bootApp({ answerControls: [{ id: "1.1", answer: "no" }] });
+    app.state.scoping.organizationName = "Acme *Corp* [Test] _v1_";
+    const md = app._buildAgendaMarkdown();
+    expect(md).toContain("**Customer:** Acme \\*Corp\\* \\[Test\\] \\_v1\\_");
+  });
 });


### PR DESCRIPTION
## Summary

Phase B' triage P2 follow-up: customer names containing markdown special characters (`*`, `_`, `[`, `\`, backtick, etc.) were rendered as malformed markdown — or could inject formatting — in the agenda exporter's raw-source `**Customer:**` header line.

## Change

- `docs/javascripts/assessment-app.js`: wrap the customer-name interpolation in the existing `_agendaMdCell()` helper, which already implements the broader CommonMark escapable set (`\\`, `|`, `*_`+backtick`~#>`, `[](){}<>!`).
- `tests/spa/md-escape.test.mjs`: add a contract test asserting `Acme *Corp* [Test] _v1_` escapes to `Acme \\*Corp\\* \\[Test\\] \\_v1\\_` in the rendered `**Customer:**` line.

## Validation

- `npm test` → 94 passed / 1 skipped (incl. new test).
- No production behavior changes outside the agenda MD exporter.