### PR TITLE
fix: mark xlsx.full.min.js as binary to preserve SRI hash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,9 @@
 
 # Vendored JS libraries must use LF to keep SRI hashes consistent
 docs/javascripts/lib/** eol=lf
+
+# Vendored binary assets — never normalize line endings (preserves SHA-256 SRI)
+# The sri-check workflow (.github/workflows/sri-check.yml, added in PR #146)
+# computes a SHA-256 of this file; CRLF normalization on Windows checkouts
+# would cause false-positive mismatches.
+docs/javascripts/lib/xlsx.full.min.js binary


### PR DESCRIPTION
## Summary

Mark the vendored SheetJS bundle `docs/javascripts/lib/xlsx.full.min.js` as binary in `.gitattributes` so Git never normalizes its line endings on checkout.

## Why

The SRI verifier workflow `.github/workflows/sri-check.yml` (added in #146) computes a SHA-256 of the vendored bundle and compares it to a pinned expected value. On Windows contributors with `core.autocrlf=true` (or similar normalization), checkout would rewrite LF -> CRLF, changing the on-disk bytes and producing a false-positive SRI mismatch.

Marking the file `binary` tells Git to treat the bytes verbatim — no eol conversion, no diff/merge text handling — which is exactly what an SRI-pinned vendored asset needs.

Verified locally:

```
> git check-attr -a docs/javascripts/lib/xlsx.full.min.js
docs/javascripts/lib/xlsx.full.min.js: binary: set
docs/javascripts/lib/xlsx.full.min.js: diff: unset
docs/javascripts/lib/xlsx.full.min.js: merge: unset
docs/javascripts/lib/xlsx.full.min.js: text: unset
```

## Origin

Phase B′ triage follow-up (P2). Companion to #146.

## Risk / scope

- Single-line addition to `.gitattributes` (with a header comment).
- No code, doc, or workflow changes.
- `sri-check` workflow is path-filtered and will not re-run on this PR; `e2e-smoke` will run as the gating check.