### PR TITLE
chore(triage): Phase B″ triage report for v1.4.2

### DIFF
--- a/.planning/phase-b2-triage.md
+++ b/.planning/phase-b2-triage.md
@@ -1,0 +1,34 @@
+# Phase B″ Triage Report — v1.4.2 Cycle Close-out
+
+- **Scanned SHA:** `c262446d2df68d7539407860ca5f79e5b0441fa3` (origin/main)
+- **Timestamp:** 2026-04-30 ~08:00 local
+- **Cycle PRs covered:** #166 (CSP), #167 (changelog v1.4.1), #168 (md-escape), #169 (.gitattributes), #170 (e2e flake hardening)
+- **Comparison base:** `cdfc16a2` (v1.4.1 changelog cut)
+
+## Tools run
+
+| Tool | Command | Exit | Notes |
+|---|---|---|---|
+| mkdocs | `mkdocs build --strict` | 0 | Built in 124.67s. INFO-level link notices only; no warnings/errors. |
+| vitest | `npm test` | 0 | 16 files, 94 passed, 1 skipped, 15.5s. |
+| Playwright smoke | `npm run test:e2e:smoke` | **1** | 5 passed, 1 failed (spec 25). See F-1 below. |
+| axe (within smoke spec 09) | — | n/a | Smoke aborted before, but spec 09 ran in this batch — no critical/serious in output prior to spec 25 failure. |
+| `gh run list --branch main --limit 10` | — | 0 | All recent runs ✓; in-flight runs for `c262446d` (Publish Docs, E2E Smoke, e2e) all green by completion. |
+| `gh pr checks 167-170` | — | mixed | #168 ✓ all green (3/3 + 1 skipped); #170 ✓ (1/1 + 1 skipped); #167 and #169 "no checks reported" because branches were deleted post-merge — expected. |
+| `gh pr view 154/156/157` (Dependabot) | — | 0 | All `OPEN`, mergeable `UNKNOWN`, GH Actions bumps; no security advisory tags. |
+| `git diff cdfc16a2..HEAD` | — | 0 | 5 files / 61 lines: `.gitattributes`, `assessment-app.js` (+3 lines, md-escape), 2 e2e specs, 1 spa test. No accidental deletions, no `console.log`/`debugger`, no out-of-scope changes. |
+| Live `/version.json` | `curl judeper.github.io/.../version.json` | 0 | Returns `sha:c262446d`, `builtAt:2026-04-30T12:00:21Z` — **fresh, matches main**. |
+
+## Findings
+
+| Severity | ID | File | Description | Evidence |
+|---|---|---|---|---|
+| **P2** | F-1 | `tests/e2e/25-zero-pageerror.spec.mjs` | Local smoke run failed with 4× `Failed to load resource: 403`. Likely unauthenticated `api.github.com` calls (allow-listed in #166) hitting anonymous rate limit from local network. **Not a release blocker:** CI E2E Smoke for this exact SHA is ✓ green (run 25164116981, 2m23s); prod-smoke ✓ green twice within last 12 min. Spec is environment-brittle when local IP is rate-limited. | Local stderr: `console.error: Failed to load resource: ... 403 (×4)`; CI run 25164116981 ✓; spec 25 doc-comment confirms intent to surface CSP/JS regressions. |
+| **P3** | F-2 | `docs/version.json` | Committed file is stale (`sha:c51bd7f7`, `builtAt:2026-04-29`, last touched in PR #144). Cosmetic only — `mkdocs gh-deploy --force` writes the live `version.json` at deploy time, and the live one matches HEAD. No user impact, no prod-smoke breakage. | `git log -1 -- docs/version.json` → PR #144; live `/version.json` → matches `c262446d`. |
+| **P3** | F-3 | Dependabot #154/#156/#157 | Open major-version bumps for `actions/upload-artifact` (4→7), `actions/setup-node` (4→6), `actions/setup-python` (5→6). No security advisories. Defer. | `gh pr view`: all `OPEN`, labels `dependencies/github_actions`, no security label. |
+
+**P2/P3 summary:** 1 P2 (local-only smoke flake on api.github.com 403; CI green), 2 P3 (cosmetic version.json drift, deferred Dependabot bumps). No new code issues introduced by #166/#168/#169/#170.
+
+## Recommendation
+
+**Ship changelog now.** Zero P0/P1. The cycle's 4 PRs are clean: mkdocs strict ✓, vitest ✓, CI E2E Smoke ✓ on `c262446d`, prod-smoke ✓ on the live deploy. F-1 is a known-class environment flake (anonymous GitHub API rate limit from local IP) that does not reproduce in CI and is bounded by the existing #170 hardening pattern; can be tracked as a follow-up todo to mock `api.github.com` in spec 25.


### PR DESCRIPTION
Phase B″ triage scan of SHA `c262446d` (post-cycle PRs #166-#170).

**Result: 0 P0, 0 P1, 1 P2, 2 P3. Recommendation: ship changelog now.**

- mkdocs `--strict` ✓ (124.67s)
- vitest ✓ (94/95, 1 skipped)
- CI E2E Smoke ✓ on `c262446d`  (run 25164116981)
- prod-smoke ✓ (live `/version.json` matches main)

Findings:
- **P2 F-1:** local spec 25 surfaced 4× `api.github.com` 403s (likely anon rate-limit from local IP); CI for same SHA is green. Track as follow-up to mock api.github.com in spec 25.
- **P3 F-2:** committed `docs/version.json` is stale; live one is regenerated by `mkdocs gh-deploy`. Cosmetic.
- **P3 F-3:** Dependabot #154/#156/#157 — defer.

Full report: `.planning/phase-b2-triage.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>