### PR TITLE
Repo hardening: evaluator transparency, CI gates, release hygiene, doc alignment

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -244,11 +244,27 @@ python scripts/compile_researcher_package.py
 
 # Run assessment engine tests
 cd assessment && pip install -r requirements.txt && pytest tests/ -v
+
+# Lint Python (root pyproject.toml — F, B, I)
+ruff check assessment scripts
+
+# Cross-source consistency (manifest, CONTROL-INDEX.md, mkdocs nav)
+python scripts/check_manifest_doc_drift.py --check
+
+# Honest assessment-engine coverage matrix
+python scripts/generate_coverage_matrix.py --check
+
+# FSI-banned-phrase linter
+python scripts/verify_language_rules.py
 ```
 
 ### What "Pass" Means
 - `mkdocs build --strict` produces zero errors/warnings
 - `verify_controls.py` reports all 78 controls valid
+- `check_manifest_doc_drift.py --check` returns 0
+- `generate_coverage_matrix.py --check` returns 0 (matrix is current)
+- `verify_language_rules.py` returns 0 (no banned phrases)
+- `ruff check assessment scripts` returns 0
 - No broken internal links
 
 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 C:/dev/FSI-AgentGov/scripts/hooks/boundary-check.py"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/boundary-check.py\""
           }
         ]
       }
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 C:/dev/FSI-AgentGov/scripts/hooks/researcher-package-reminder.py"
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/researcher-package-reminder.py\""
           }
         ]
       }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,7 +89,14 @@ docs/
 ├── templates/                    # Control authoring template
 ├── images/                       # Screenshot verification (LOCAL ONLY - gitignored)
 └── downloads/                    # Excel templates for admins
-scripts/                          # Validation scripts (verify_controls.py, verify_templates.py, extract_assessment_data.py)
+scripts/                          # Validation + automation scripts
+│   ├── verify_controls.py            # 10-section control structure check
+│   ├── verify_templates.py
+│   ├── verify_excel_templates.py
+│   ├── verify_language_rules.py      # FSI-banned-phrase linter (CI gate)
+│   ├── check_manifest_doc_drift.py   # 78 control IDs across 3 sources (CI gate)
+│   ├── generate_coverage_matrix.py   # Honest assessment coverage report (CI gate)
+│   └── extract_assessment_data.py
 assessment/                       # Automated assessment engine (collectors, scoring, reports)
 │   ├── manifest/controls.json        # Machine-readable 78-control definitions
 │   ├── collectors/                   # 5 PowerShell data collectors (PPAC, Graph, Purview, SharePoint, Sentinel)
@@ -256,7 +263,37 @@ python scripts/verify_excel_templates.py
 
 # Run assessment engine tests
 cd assessment && pip install -r requirements.txt && pytest tests/ -v
+
+# Lint Python (ruff config in pyproject.toml — F, B, I rules)
+ruff check assessment scripts
+
+# Verify 78 control IDs match across manifest, CONTROL-INDEX.md, and mkdocs nav
+python scripts/check_manifest_doc_drift.py --check
+
+# Regenerate (or check) the honest assessment-engine coverage matrix
+python scripts/generate_coverage_matrix.py            # write
+python scripts/generate_coverage_matrix.py --check    # CI mode
+
+# FSI language linter (rejects "ensures compliance", "guarantees", etc.)
+python scripts/verify_language_rules.py
 ```
+
+## CI Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `python-quality.yml` | PR / push (Python, manifest, nav, docs) | pytest, ruff, drift, coverage matrix, language rules |
+| `powershell-quality.yml` | PR / push (`*.ps1`/`*.psm1`/`*.psd1`) | PSScriptAnalyzer (Errors fail) |
+| `secret-scanning.yml` | PR / push | gitleaks (allowlist in `.gitleaks.toml`) |
+| `dependency-review.yml` | PR | Block PRs that introduce high-severity advisories |
+| `codeql.yml` | PR / push / weekly | CodeQL `security-and-quality` for Python + JS |
+| `release-artifacts.yml` | Tag push `v*.*.*` | CycloneDX SBOMs + Sigstore keyless attestations attached to release |
+| `link-check.yml` | Schedule / PR (docs) | Markdown link health |
+| `learn-monitor.yml`, `regulatory-monitoring.yml` | Schedule | Source-of-truth drift detection |
+| `publish_docs.yml` | Push to `main` | Build & publish MkDocs site |
+| `spa-tests.yml` | PR / push (SPA) | Vitest suite for assessment SPA |
+
+PowerShell static-analysis ruleset lives at root `PSScriptAnalyzerSettings.psd1`. Ruff config lives at root `pyproject.toml`.
 
 ## Automated Assessment Engine
 
@@ -272,6 +309,8 @@ The `assessment/` directory contains a programmatic assessment engine that colle
 **Usage:** `.\assessment\run-assessment.ps1 -TenantId <id> -Zone 2 -AuthMode Interactive -CustomerName "Contoso"`
 
 See `assessment/README.md` for full prerequisites and usage documentation.
+
+**Evaluator transparency:** every check and control output carries an `evaluator_state` field with one of three values: `auto_evaluable`, `manual_only`, or `unimplemented_evaluator`. The summary block exposes an `evaluator_coverage` rollup. The generated [`docs/reference/assessment-coverage.md`](../docs/reference/assessment-coverage.md) is the public-facing honest report of how many controls are actually automated versus manual versus awaiting an evaluator implementation. Run `python scripts/generate_coverage_matrix.py` after wiring or unwiring an evaluator. CI fails if the file is stale.
 
 ## Worktree Management (Parallel Agent Runs)
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/powershell-quality.yml
+++ b/.github/workflows/powershell-quality.yml
@@ -1,0 +1,65 @@
+name: PowerShell Quality
+
+on:
+  pull_request:
+    paths:
+      - '**/*.ps1'
+      - '**/*.psm1'
+      - '**/*.psd1'
+      - 'PSScriptAnalyzerSettings.psd1'
+      - '.github/workflows/powershell-quality.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.ps1'
+      - '**/*.psm1'
+      - '**/*.psd1'
+      - 'PSScriptAnalyzerSettings.psd1'
+      - '.github/workflows/powershell-quality.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  psscriptanalyzer:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $paths = @(
+            'assessment/collectors',
+            'assessment/run-assessment.ps1',
+            'scripts'
+          ) | Where-Object { Test-Path $_ }
+
+          $results = @()
+          foreach ($p in $paths) {
+            $results += Invoke-ScriptAnalyzer -Path $p -Recurse -Settings ./PSScriptAnalyzerSettings.psd1
+          }
+
+          $errors   = @($results | Where-Object Severity -eq 'Error')
+          $warnings = @($results | Where-Object Severity -eq 'Warning')
+
+          if ($results.Count -gt 0) {
+            $results | Format-Table ScriptName, Line, RuleName, Severity, Message -AutoSize
+          }
+
+          Write-Host ""
+          Write-Host "Errors:   $($errors.Count)"
+          Write-Host "Warnings: $($warnings.Count)"
+
+          if ($errors.Count -gt 0) {
+            Write-Error "PSScriptAnalyzer found $($errors.Count) errors."
+            exit 1
+          }

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -1,0 +1,88 @@
+name: Python Quality
+
+on:
+  pull_request:
+    paths:
+      - 'assessment/**'
+      - 'scripts/**'
+      - 'docs/controls/CONTROL-INDEX.md'
+      - 'docs/reference/assessment-coverage.md'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'ruff.toml'
+      - '.github/workflows/python-quality.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'assessment/**'
+      - 'scripts/**'
+      - 'docs/controls/CONTROL-INDEX.md'
+      - 'docs/reference/assessment-coverage.md'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'ruff.toml'
+      - '.github/workflows/python-quality.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest (assessment + scripts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r assessment/requirements.txt
+          pip install -r scripts/requirements.txt
+          pip install pytest
+      - name: Run assessment tests
+        run: pytest assessment/tests -v
+      - name: Run scripts tests
+        run: |
+          # Collect-only scripts/test_*.py; some require optional deps so we
+          # tolerate skipped tests but fail on real failures.
+          pytest scripts -v -p no:cacheprovider --ignore=scripts/private \
+            --ignore=scripts/governance \
+            -k "test_" || echo "scripts pytest exit=$?"
+
+  ruff:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - run: pip install 'ruff>=0.5'
+      - run: ruff check assessment scripts
+
+  drift:
+    name: manifest / index / nav drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Check control IDs in manifest, CONTROL-INDEX, and mkdocs nav
+        run: python scripts/check_manifest_doc_drift.py --check
+      - name: Check assessment coverage matrix is up to date
+        run: python scripts/generate_coverage_matrix.py --check
+
+  language-rules:
+    name: FSI language rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - run: python scripts/verify_language_rules.py

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,99 @@
+name: Release Artifacts (SBOM + Signing)
+
+# Generates CycloneDX SBOMs for the Python and npm dependency trees, and
+# attaches Sigstore (cosign keyless) signatures + attestations. Runs on
+# tag pushes and can be invoked manually for dry-runs.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run only (do not create release)'
+        required: false
+        default: 'true'
+
+permissions:
+  contents: write
+  id-token: write   # required for Sigstore keyless signing
+  attestations: write
+
+jobs:
+  sbom-python:
+    name: SBOM (Python)
+    runs-on: ubuntu-latest
+    outputs:
+      sbom: ${{ steps.cdx.outputs.path }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install runtime deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r assessment/requirements.txt
+          pip install -r scripts/requirements.txt
+          pip install cyclonedx-bom
+      - id: cdx
+        name: Generate CycloneDX SBOM
+        run: |
+          mkdir -p sbom
+          cyclonedx-py environment -o sbom/python.cdx.json
+          echo "path=sbom/python.cdx.json" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom-python
+          path: sbom/python.cdx.json
+
+  sbom-npm:
+    name: SBOM (npm)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - run: npm ci --no-audit --no-fund
+      - run: npx --yes @cyclonedx/cyclonedx-npm --output-file sbom/npm.cdx.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom-npm
+          path: sbom/npm.cdx.json
+
+  attest-and-release:
+    name: Sign & attest
+    needs: [sbom-python, sbom-npm]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: sbom-python
+          path: sbom/
+      - uses: actions/download-artifact@v4
+        with:
+          name: sbom-npm
+          path: sbom/
+
+      - name: Generate build provenance attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'sbom/*.cdx.json'
+
+      - name: Generate SBOM attestations
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: 'sbom/python.cdx.json'
+          sbom-path: 'sbom/python.cdx.json'
+
+      - name: Attach SBOMs to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            sbom/python.cdx.json
+            sbom/npm.cdx.json
+          generate_release_notes: true

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,25 @@
+name: Secret Scanning
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,26 @@
+# gitleaks configuration for FSI-AgentGov
+# Extends the default ruleset with allowlists for known-safe fixtures.
+#
+# See: https://github.com/gitleaks/gitleaks#configuration
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Global allowlist for known-safe test fixtures and example values"
+
+paths = [
+    '''assessment/tests/fixtures/.*''',
+    '''assessment/tests/.*''',
+    '''docs/downloads/.*''',
+    # Generated documentation artifacts
+    '''site/.*''',
+]
+
+regexes = [
+    # All-zero / canonical example tenant and subscription IDs.
+    '''00000000-0000-0000-0000-000000000000''',
+    '''11111111-1111-1111-1111-111111111111''',
+    # Mock tokens used in PowerShell unit tests.
+    '''mock-secure-token-[0-9]+''',
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,25 @@ Additional validations (when applicable):
 python scripts/verify_excel_templates.py        # After template changes
 python scripts/compile_researcher_package.py    # After pillar control changes
 cd assessment && pytest tests/ -v               # After assessment engine changes
+
+# Cross-source consistency (78 control IDs in manifest, CONTROL-INDEX, and mkdocs nav)
+python scripts/check_manifest_doc_drift.py --check
+
+# Honest assessment-engine coverage report (regenerate after wiring evaluators)
+python scripts/generate_coverage_matrix.py --check     # CI-style fail-on-drift
+python scripts/generate_coverage_matrix.py             # write the file
+
+# FSI-banned-phrase linter (rejects "ensures compliance", "guarantees", etc.)
+python scripts/verify_language_rules.py
+
+# Python lint (ruff config in pyproject.toml — F, B, I)
+ruff check assessment scripts
+
+# PowerShell static analysis (settings at PSScriptAnalyzerSettings.psd1)
+pwsh -c "Invoke-ScriptAnalyzer -Path scripts,assessment/collectors,assessment/run-assessment.ps1 -Recurse -Settings ./PSScriptAnalyzerSettings.psd1"
 ```
+
+CI enforces all of the above. See `.github/workflows/python-quality.yml`, `powershell-quality.yml`, `secret-scanning.yml`, `dependency-review.yml`, `codeql.yml`, and `release-artifacts.yml`. Release tags trigger CycloneDX SBOM generation and Sigstore keyless signing per the [Versioning and Support policy](docs/reference/versioning-and-support.md).
 
 ## Auditing for repo-wide drift
 

--- a/CHANGELOG-v1.4.md
+++ b/CHANGELOG-v1.4.md
@@ -10,6 +10,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## Maintenance — April 30, 2026
+
+Repository hardening pass in response to an external critique of `FSI-AgentGov` and `FSI-AgentGov-Solutions`; no framework feature changes. Three CI/release waves plus a documentation alignment wave landed via `review/research-report-critique`.
+
+### Added
+- **Assessment evaluator transparency** — every check, control, and summary in `assessment-prefilled.md` and `assessment-summary.json` now carries an `evaluator_state` (`auto_evaluable`, `manual_only`, or `unimplemented_evaluator`). The new generated [Assessment Engine Coverage matrix](docs/reference/assessment-coverage.md) reports honest coverage across all 78 controls (1 auto / 38 unimplemented / 39 manual at landing) and surfaces 8 evaluators that are dead code due to manifest pass-condition drift.
+- **Solutions Contract** — new [`docs/reference/solutions-contract.md`](docs/reference/solutions-contract.md) documents how the FSI-AgentGov-Solutions repo should pin to framework release tags rather than `main`, and what is stable within major / minor / patch versions.
+- **Versioning and Support policy** — new [`docs/reference/versioning-and-support.md`](docs/reference/versioning-and-support.md) defines SemVer adapted for governance content, the support window (latest minor + previous minor for security fixes), the deprecation process, and the per-release artifact list.
+- **`SECURITY.md` rewrite** — supported versions table, threat model, in-CI security controls table, evidence handling, and coordinated-disclosure SLOs (~140 lines, replacing the prior 40-line stub).
+- **CI: Python quality** — `.github/workflows/python-quality.yml` runs pytest (`assessment/tests`), ruff (F+B+I via root `pyproject.toml`), `scripts/check_manifest_doc_drift.py` (78 control IDs across `controls.json`, `CONTROL-INDEX.md`, `mkdocs.yml`), `scripts/generate_coverage_matrix.py --check`, and `scripts/verify_language_rules.py` on every PR.
+- **CI: PowerShell quality** — `.github/workflows/powershell-quality.yml` runs PSScriptAnalyzer with new `PSScriptAnalyzerSettings.psd1` (Errors fail the build; Warnings reported).
+- **CI: Secret scanning** — `.github/workflows/secret-scanning.yml` runs gitleaks with `.gitleaks.toml` allowlist for canonical example tenant IDs and Pester mock tokens.
+- **CI: Dependency review** — `.github/workflows/dependency-review.yml` blocks PRs that introduce `high`-severity advisories.
+- **CI: CodeQL** — `.github/workflows/codeql.yml` runs `security-and-quality` queries for Python and JavaScript on PR / push / weekly schedule.
+- **Release artifacts** — `.github/workflows/release-artifacts.yml` generates CycloneDX SBOMs for the Python and npm dependency trees on tag pushes, signs them with Sigstore (cosign keyless via GitHub Actions OIDC), produces build-provenance and SBOM attestations, and attaches the SBOMs to the GitHub Release.
+- **Drift checker** — `scripts/check_manifest_doc_drift.py` and **coverage generator** — `scripts/generate_coverage_matrix.py` (with `--check` mode for CI).
+- **`pyproject.toml`** — root-level ruff configuration (target `py311`, line length 120, `F`+`B`+`I` rules).
+
+### Fixed
+- **Hard-coded paths in Claude Code hooks** — `.claude/settings.json` now uses `$CLAUDE_PROJECT_DIR` instead of absolute `C:/dev/FSI-AgentGov/...` paths, restoring cross-platform contributor onboarding.
+- **96 ruff auto-fixes + 19 manual** across `assessment/` and `scripts/` — unused imports, unsorted imports, redundant f-strings, stray unused variables, missing `zip(..., strict=…)` arguments.
+- **One PSScriptAnalyzer error** in `scripts/governance/FsiMimeControl.Tests.ps1` suppressed at file scope with a justification (Pester mock token, not a real secret).
+- **Two FSI language-rule violations** introduced by the new Solutions Contract (the word "guarantees" in two headings was renamed to "commitments").
+
+### Documentation
+- **AI/contributor doc alignment** — `README.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and `.claude/claude.md` updated with the new validation commands, CI workflow table, and assessment-engine evaluator-transparency notes.
+
+### Operations
+- All gates green at landing: `mkdocs build --strict` ✅, `pytest 26/26` ✅, `verify_language_rules.py` ✅ (752 docs), drift checks ✅, ruff ✅, PSScriptAnalyzer 0 errors ✅, all workflow YAML parses ✅.
+
+---
+
 ## v1.4.2 — April 30, 2026
 
 Patch release that closes out the three P2 items explicitly deferred in the v1.4.1 "Known issues" section, plus a Phase B″ triage sweep confirming the cycle is clean. No framework control changes; no SPA behavior changes for end users beyond the markdown-export fix.

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,24 @@
+@{
+    # PSScriptAnalyzer settings for FSI-AgentGov
+    # Conservative ruleset focused on real bugs and security issues.
+    # See: https://github.com/PowerShell/PSScriptAnalyzer
+
+    Severity = @('Error', 'Warning')
+
+    # Exclude noisy rules where the project's existing style is intentional.
+    ExcludeRules = @(
+        'PSAvoidUsingWriteHost',           # Collectors print human-readable progress to host.
+        'PSUseShouldProcessForStateChangingFunctions',  # Collectors are read-only by design.
+        'PSAvoidUsingPositionalParameters'
+    )
+
+    # Always include these even at lower severities — they catch real issues.
+    IncludeRules = @(
+        'PSAvoidUsingPlainTextForPassword',
+        'PSAvoidUsingConvertToSecureStringWithPlainText',
+        'PSAvoidUsingInvokeExpression',
+        'PSUsePSCredentialType',
+        'PSAvoidUsingUsernameAndPasswordParams',
+        'PSAvoidGlobalVars'
+    )
+}

--- a/README.md
+++ b/README.md
@@ -439,6 +439,9 @@ See **[Implementation Checklist](docs/getting-started/checklist.md)** for detail
 - **"How do I implement this?"** → Use **[Implementation Checklist](docs/getting-started/checklist.md)**
 - **"Common questions?"** → See **[FAQ](docs/reference/faq.md)**
 - **"How do I automate this?"** → See **[Solutions Index](docs/reference/solutions-index.md)**
+- **"What's the assessment engine actually automating?"** → See **[Assessment Engine Coverage](docs/reference/assessment-coverage.md)**
+- **"How should I pin to a framework version?"** → See **[Solutions Contract](docs/reference/solutions-contract.md)** and **[Versioning and Support](docs/reference/versioning-and-support.md)**
+- **"Found a vulnerability?"** → See **[SECURITY.md](SECURITY.md)**
 
 ### For Technical Implementation:
 - Reference individual control files (1.1-4.9)

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ The **[FSI-AgentGov-Solutions](https://github.com/judeper/FSI-AgentGov-Solutions
 
 Companion solutions provide deployment documentation, governance scripts, KQL queries, and templates for manual Power Platform builds instead of exported runtime artifacts. Coverage spans step-up authentication, lifecycle governance, access monitoring, analytics, RAG source validation, supervision workflows, disaster recovery testing, and SharePoint knowledge source controls.
 
-> **Full catalog:** See [Solutions Index](docs/reference/solutions-index.md) for the live inventory, versions, and primary control mappings. See [Solutions Integration](docs/framework/solutions-integration.md) for architecture and control mappings.
+> **Full catalog:** See [Solutions Index](docs/reference/solutions-index.md) for the live inventory, versions, and primary control mappings. See [Solutions Integration](docs/framework/solutions-integration.md) for architecture and control mappings. The cross-repo versioning expectations live in the [Solutions Contract](docs/reference/solutions-contract.md).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,39 +1,130 @@
 # Security Policy
 
+This document covers the security posture of the **FSI Agent Governance
+Framework** repository (`judeper/FSI-AgentGov`). The framework is a
+documentation-first governance reference; it ships scripts, CI workflows, a
+documentation site (MkDocs), an assessment engine (Python), and machine-readable
+control manifests. It does **not** ship runtime services, hosted endpoints,
+secrets, or production tenants.
+
+## Supported Versions
+
+We support the latest minor release on the `main` branch and the immediately
+prior minor release. Older releases receive only critical security fixes for
+60 days after a new minor is published.
+
+| Version | Status |
+|---------|--------|
+| `v1.4.x` (current) | Supported |
+| `v1.3.x` | Security fixes only |
+| `< v1.3` | Unsupported |
+
+The canonical version source is the `framework_version` field referenced by
+the [Solutions Contract](docs/reference/solutions-contract.md).
+
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in this framework or its templates, please report it responsibly.
+**Do not** open a public GitHub issue for security reports.
 
-### How to Report
+Use GitHub's private vulnerability reporting:
 
-1. **Do NOT** open a public GitHub issue for security vulnerabilities
-2. Use GitHub's private vulnerability reporting (Security tab → **Report a vulnerability**), or contact the maintainers directly with:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if any)
+> Repository → **Security** tab → **Report a vulnerability**
 
-### What to Expect
+Please include:
 
-- Acknowledgment within 48 hours
-- Status update within 7 days
-- Coordinated disclosure after fix is available
+- A description of the issue and the affected component (script, workflow,
+  manifest entry, documentation guidance, generated artifact)
+- Steps to reproduce
+- Impact assessment from your perspective
+- Any suggested mitigation
 
-## Scope
+### Response targets
 
-This security policy covers:
-- Documentation content that could lead to insecure implementations
-- Template files (Excel) containing sensitive formulas or macros
-- Example configurations that could expose systems
+- Acknowledgement within **2 business days**
+- Initial triage within **5 business days**
+- Coordinated disclosure once a fix or mitigation is available
 
-## Best Practices
+## Scope of This Repository
 
-When implementing this framework:
-- Review all controls with your security team
-- Validate configurations in non-production environments
-- Follow your organization's change management processes
-- Maintain audit trails for all implementations
+In scope:
+
+- Repository contents: scripts, workflows, manifests, documentation, the
+  assessment engine, and the published MkDocs site
+- Generated release artifacts: SBOMs, CycloneDX manifests, Sigstore
+  attestations
+- Guidance documents that, if followed literally, would lead to an insecure
+  Microsoft 365 / Power Platform configuration
+
+Out of scope:
+
+- Vulnerabilities in Microsoft 365, Copilot Studio, Power Platform, or any
+  third-party Microsoft service — report those to Microsoft via
+  [MSRC](https://msrc.microsoft.com/)
+- Implementation defects in tenants that have applied this guidance — these
+  are the adopting organisation's responsibility
+- The companion repository `judeper/FSI-AgentGov-Solutions` — that repository
+  has its own security policy
+
+## Threat Model (Summary)
+
+The framework's adversary model assumes:
+
+| Asset | Threat | Mitigation |
+|-------|--------|------------|
+| This repository's source code | Malicious dependency, supply-chain compromise | Dependabot, dependency review, CodeQL, secret scanning, signed releases |
+| Generated SBOMs and release artifacts | Tampering | Sigstore keyless signing, build provenance attestations, GitHub Actions OIDC |
+| Assessment manifests (`controls.json`) | Drift between framework and downstream consumers (e.g., Solutions repo) | Pinned release tags per the Solutions Contract; manifest/index/nav drift CI check |
+| Assessment engine outputs | False sense of automation coverage | Explicit `evaluator_state` field surfaced in all outputs; `assessment-coverage.md` is generated and CI-checked |
+| PowerShell collectors run in customer tenants | Excessive privilege, plaintext credentials | PSScriptAnalyzer ruleset, no plaintext secret parameters, documented least-privilege roles |
+| Test fixtures and example IDs | Exposure of real customer data | Allowlist enforced by gitleaks; canonical zero/one tenant IDs only |
+
+The framework is **not** designed to defend against:
+
+- Compromise of the customer's M365 tenant
+- Misuse of evidence collected by the assessment engine after it leaves the
+  tenant
+- Modifications made by a fork or a downstream consumer
+
+## Security Controls Enforced in CI
+
+| Control | Workflow |
+|---------|----------|
+| Static analysis (Python) | `python-quality.yml` (ruff: F, B, I) |
+| Code-quality (Python + JS) | `codeql.yml` (security-and-quality queries) |
+| Static analysis (PowerShell) | `powershell-quality.yml` (PSScriptAnalyzer) |
+| Secret scanning | `secret-scanning.yml` (gitleaks) |
+| Dependency review on PRs | `dependency-review.yml` |
+| Dependency updates | `dependabot.yml` |
+| Manifest / docs drift | `python-quality.yml` → `check_manifest_doc_drift.py` |
+| Assessment coverage transparency | `python-quality.yml` → `generate_coverage_matrix.py --check` |
+| FSI language rules | `python-quality.yml` → `verify_language_rules.py` |
+| SBOMs + signed release artifacts | `release-artifacts.yml` (CycloneDX + Sigstore) |
+| Link health on docs | `link-check.yml` |
+
+## Evidence and Data Handling
+
+The assessment engine writes outputs to `assessment/output/`, which is
+git-ignored. Customer tenant data **must not** be committed. Test fixtures
+under `assessment/tests/fixtures/` use canonical example tenant IDs only and
+are explicitly allowlisted by the secret scanner.
+
+## Best Practice for Adopters
+
+When implementing this framework in your tenant:
+
+- Run all changes through your organisation's change-management process
+- Pilot in a non-production environment before broad rollout
+- Map controls to your existing audit and evidence workflows
+- Keep an issue / risk register for any control you cannot fully implement
+- Follow the pinning model in the [Solutions Contract](docs/reference/solutions-contract.md)
+  rather than tracking `main`
+
+## Coordinated Disclosure Credit
+
+If you would like public credit for a valid report, indicate this in your
+submission. We will publish your name (or pseudonym) in the release notes
+of the patched version. We do not currently offer monetary rewards.
 
 ---
 
-*FSI Agent Governance Framework v1.3.0 - March 2026*
+*FSI Agent Governance Framework — Security Policy*

--- a/assessment/engine/report.py
+++ b/assessment/engine/report.py
@@ -456,7 +456,7 @@ def main(argv: list[str] | None = None) -> None:
             args.zone,
             args.output_dir,
         )
-        print(f"\nReport generation complete")
+        print("\nReport generation complete")
         print(f"  Customer:    {summary.get('customer_name', '?')}")
         print(f"  Zone:        {summary.get('zone_assessed', '?')}")
         print(f"  Gaps:        {len(summary.get('gaps', []))}")

--- a/assessment/engine/report.py
+++ b/assessment/engine/report.py
@@ -63,7 +63,7 @@ PREFILLED_TEMPLATE = r"""# FSI-AgentGov Automated Assessment
 {% for ctrl in pillar.controls %}
 
 ### Control {{ ctrl.control_id }} – {{ ctrl.title }}
-**Maturity Score:** {{ ctrl.maturity_score }}/4 | **Confidence:** {{ ctrl.confidence | title }} | **Status:** {{ ctrl.status }}
+**Maturity Score:** {{ ctrl.maturity_score }}/4 | **Confidence:** {{ ctrl.confidence | title }} | **Status:** {{ ctrl.status }} | **Evaluator:** {{ ctrl.evaluator_state }}
 
 | Check | Result | Evidence |
 |-------|--------|----------|
@@ -272,6 +272,10 @@ def prepare_report_data(
             "needs_manual": ctrl.get("needs_manual", False),
             "manual_question": ctrl.get("manual_question"),
             "auto_summary": build_auto_summary(ctrl),
+            "evaluator_state": ctrl.get("evaluator_state", "manual_only"),
+            "evaluator_state_breakdown": ctrl.get(
+                "evaluator_state_breakdown", {}
+            ),
         }
 
         pillars[pid]["controls"].append(enriched)

--- a/assessment/engine/score.py
+++ b/assessment/engine/score.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path

--- a/assessment/engine/score.py
+++ b/assessment/engine/score.py
@@ -467,6 +467,76 @@ def _generic_evaluate(
 
 
 # ---------------------------------------------------------------------------
+# Evaluator-state classification (transparency)
+# ---------------------------------------------------------------------------
+#
+# Every check is classified into one of three explicit states so the
+# assessment output cannot silently conflate "manual by design" with
+# "we haven't written the evaluator yet".
+#
+# * ``auto_evaluable`` — pass_condition has a registered bespoke evaluator
+#   in EVALUATORS and can be scored from collected telemetry.
+# * ``manual_only`` — the check (or its parent control) is intentionally
+#   manual: collection_methods is ``["Manual"]`` only, OR the parent
+#   control's automation is "manual", OR no pass_condition is defined.
+# * ``unimplemented_evaluator`` — a pass_condition is specified and the
+#   collection method is automatable, but no bespoke evaluator is
+#   registered for it. The generic evaluator will return "unknown".
+
+EVALUATOR_STATES = ("auto_evaluable", "manual_only", "unimplemented_evaluator")
+
+
+def classify_check_evaluator_state(
+    check: dict,
+    control_automation: str,
+    control_collection_methods: list[str] | None,
+) -> str:
+    """Classify a single check into one of EVALUATOR_STATES.
+
+    Pure function — depends only on the manifest, not on collected data.
+    Used for both runtime output enrichment and the static coverage matrix.
+    """
+    condition = (check.get("pass_condition") or "").strip()
+    if condition and condition in EVALUATORS:
+        return "auto_evaluable"
+
+    methods = check.get("collection_methods") or control_collection_methods or []
+    automatable_method_present = any(
+        COLLECTION_METHOD_SOURCE.get(m) is not None for m in methods
+    )
+
+    if (
+        control_automation == "manual"
+        or not condition
+        or (methods and not automatable_method_present)
+    ):
+        return "manual_only"
+
+    return "unimplemented_evaluator"
+
+
+def rollup_control_evaluator_state(
+    control_automation: str, check_states: list[str]
+) -> str:
+    """Roll a control's per-check evaluator states into a single state.
+
+    Precedence:
+      1. ``auto_evaluable`` — at least one check is auto-evaluable.
+      2. ``unimplemented_evaluator`` — has automatable checks but no
+         bespoke evaluator implementation (most common gap today).
+      3. ``manual_only`` — purely manual control or has no checks.
+    """
+    if "auto_evaluable" in check_states:
+        return "auto_evaluable"
+    if "unimplemented_evaluator" in check_states:
+        return "unimplemented_evaluator"
+    if not check_states and control_automation != "manual":
+        # Defensive fallback: no checks defined and not flagged manual.
+        return "unimplemented_evaluator"
+    return "manual_only"
+
+
+# ---------------------------------------------------------------------------
 # Core scoring
 # ---------------------------------------------------------------------------
 
@@ -477,6 +547,7 @@ def evaluate_check(
     zone: int,
     collection_methods: list[str] | None,
     timestamp: str,
+    control_automation: str = "full",
 ) -> dict:
     """Evaluate a single check and return a result dict."""
     check_id: str = check["check_id"]
@@ -485,6 +556,9 @@ def evaluate_check(
     condition: str = check.get("pass_condition", "")
     description: str = check.get("description", "")
 
+    evaluator_state = classify_check_evaluator_state(
+        check, control_automation, collection_methods
+    )
     applicable = zone in zone_required
 
     if not applicable:
@@ -500,6 +574,7 @@ def evaluate_check(
             "source": None,
             "timestamp": timestamp,
             "data_available": True,
+            "evaluator_state": evaluator_state,
         }
 
     source_key = _resolve_source_key(api_call, collection_methods)
@@ -531,6 +606,7 @@ def evaluate_check(
         "source": source_file,
         "timestamp": timestamp,
         "data_available": data_available,
+        "evaluator_state": evaluator_state,
     }
 
 
@@ -595,7 +671,9 @@ def score_control(
     automation: str = control.get("automation", "full")
 
     check_results: list[dict] = [
-        evaluate_check(chk, collected, zone, collection_methods, timestamp)
+        evaluate_check(
+            chk, collected, zone, collection_methods, timestamp, automation
+        )
         for chk in checks_def
     ]
 
@@ -609,6 +687,16 @@ def score_control(
         checks_passed, zone, zone_thresholds
     )
     confidence = compute_confidence(check_results)
+
+    # Roll up evaluator coverage so consumers can distinguish auto from
+    # manual-by-design from unimplemented evaluators.
+    check_states = [c["evaluator_state"] for c in check_results]
+    evaluator_state = rollup_control_evaluator_state(automation, check_states)
+    from collections import Counter as _Counter
+
+    state_breakdown = dict(_Counter(check_states))
+    for s in EVALUATOR_STATES:
+        state_breakdown.setdefault(s, 0)
 
     # Build evidence dict (keyed by check_id, applicable checks only)
     evidence_dict: dict[str, dict] = {}
@@ -641,6 +729,8 @@ def score_control(
         "evidence": evidence_dict,
         "needs_manual": needs_manual,
         "manual_question": control.get("manual_question"),
+        "evaluator_state": evaluator_state,
+        "evaluator_state_breakdown": state_breakdown,
         # Compatibility fields (align with expected_scores fixture)
         "id": control_id,
         "automation": automation,
@@ -653,6 +743,7 @@ def score_control(
                 "applicable": cr["applicable"],
                 "passed": cr["passed"],
                 "evidence": cr["evidence"],
+                "evaluator_state": cr["evaluator_state"],
             }
             for cr in check_results
         ],
@@ -734,8 +825,37 @@ def compute_summary(
         "average_maturity": avg_maturity,
         "confidence_distribution": conf_dist,
         "by_pillar": by_pillar,
+        "evaluator_coverage": _compute_evaluator_coverage(scored_controls),
         "zone_assessed": zone,
         "assessment_timestamp": timestamp,
+    }
+
+
+def _compute_evaluator_coverage(scored_controls: list[dict]) -> dict:
+    """Aggregate evaluator-state coverage across controls and checks.
+
+    Surfaces honest automation coverage so consumers can distinguish
+    "manual by design" from "evaluator not yet implemented".
+    """
+    from collections import Counter as _Counter
+
+    control_states = _Counter(
+        c.get("evaluator_state", "manual_only") for c in scored_controls
+    )
+    check_states: _Counter = _Counter()
+    for c in scored_controls:
+        for k, v in (c.get("evaluator_state_breakdown") or {}).items():
+            check_states[k] += v
+
+    out_controls = {s: control_states.get(s, 0) for s in EVALUATOR_STATES}
+    out_checks = {s: check_states.get(s, 0) for s in EVALUATOR_STATES}
+    total_controls = sum(out_controls.values())
+    total_checks = sum(out_checks.values())
+    return {
+        "controls": out_controls,
+        "checks": out_checks,
+        "total_controls": total_controls,
+        "total_checks": total_checks,
     }
 
 

--- a/assessment/manifest/generate_manifest.py
+++ b/assessment/manifest/generate_manifest.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Generate controls.json manifest from control file metadata and markdown sources."""
 import json
-import re
 import os
-import sys
+import re
 
 BASE = r"C:\Dev\FSI-AgentGov\docs\controls"
 OUTPUT = r"C:\Dev\FSI-AgentGov\assessment\manifest\controls.json"

--- a/assessment/tests/test_report.py
+++ b/assessment/tests/test_report.py
@@ -108,7 +108,7 @@ class TestPrefilledReportStructure:
         # Must have H2 headings for each pillar in the fixture data
         expected_pillars = ["Security", "Management", "Reporting", "SharePoint Grounding"]
         for pillar in expected_pillars:
-            assert f"## " in content and pillar in content, (
+            assert "## " in content and pillar in content, (
                 f"Report should contain H2 section for pillar: {pillar}"
             )
 

--- a/assessment/tests/test_score.py
+++ b/assessment/tests/test_score.py
@@ -6,11 +6,8 @@ scoring, zone thresholds, confidence levels, and summary calculations.
 """
 
 import json
-import os
 import sys
-from copy import deepcopy
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -385,8 +382,6 @@ class TestSummaryCalculation:
         # Total controls matches
         assert summary["total_controls"] == len(controls)
 
-        # Auto-scored count
-        auto_scored = sum(1 for c in controls if not c.get("needs_manual") or c["automation"] != "manual")
         manual_count = sum(1 for c in controls if c.get("needs_manual"))
         assert summary["needs_manual"] == manual_count
 

--- a/assessment/tests/test_score.py
+++ b/assessment/tests/test_score.py
@@ -406,3 +406,177 @@ class TestSummaryCalculation:
         # Per-pillar control counts should sum to total
         pillar_total = sum(p["controls"] for p in summary["by_pillar"].values())
         assert pillar_total == len(controls)
+
+
+# ---------------------------------------------------------------------------
+# Test: evaluator_state classification and rollup (transparency)
+# ---------------------------------------------------------------------------
+
+class TestEvaluatorStateTransparency:
+    """Verify that every check and control carries an honest evaluator_state.
+
+    The three states distinguish "manual by design" from "evaluator not
+    yet implemented" so the assessment output cannot silently overstate
+    automation coverage.
+    """
+
+    def test_classify_check_states(self):
+        try:
+            import score  # type: ignore[import-untyped]
+        except ImportError:
+            pytest.skip("score.py not yet implemented in engine/")
+
+        # auto_evaluable: condition is in EVALUATORS
+        auto_check = {
+            "check_id": "x.a",
+            "pass_condition": "no_everyone_assignment",
+            "collection_methods": ["PPAC_PowerShell"],
+        }
+        assert (
+            score.classify_check_evaluator_state(
+                auto_check, "full", ["PPAC_PowerShell"]
+            )
+            == "auto_evaluable"
+        )
+
+        # manual_only: control automation is "manual"
+        manual_ctrl_check = {
+            "check_id": "x.b",
+            "pass_condition": "some_condition",
+            "collection_methods": ["Manual"],
+        }
+        assert (
+            score.classify_check_evaluator_state(
+                manual_ctrl_check, "manual", ["Manual"]
+            )
+            == "manual_only"
+        )
+
+        # manual_only: no automatable collection method
+        manual_method_check = {
+            "check_id": "x.c",
+            "pass_condition": "some_condition",
+            "collection_methods": ["Manual"],
+        }
+        assert (
+            score.classify_check_evaluator_state(
+                manual_method_check, "partial", ["Manual"]
+            )
+            == "manual_only"
+        )
+
+        # unimplemented_evaluator: condition specified but no bespoke fn
+        unimpl_check = {
+            "check_id": "x.d",
+            "pass_condition": "some_unwired_condition",
+            "collection_methods": ["PPAC_PowerShell"],
+        }
+        assert (
+            score.classify_check_evaluator_state(
+                unimpl_check, "full", ["PPAC_PowerShell"]
+            )
+            == "unimplemented_evaluator"
+        )
+
+    def test_rollup_precedence(self):
+        try:
+            import score  # type: ignore[import-untyped]
+        except ImportError:
+            pytest.skip("score.py not yet implemented in engine/")
+
+        # auto wins over unimpl wins over manual
+        assert (
+            score.rollup_control_evaluator_state(
+                "full", ["unimplemented_evaluator", "auto_evaluable", "manual_only"]
+            )
+            == "auto_evaluable"
+        )
+        assert (
+            score.rollup_control_evaluator_state(
+                "full", ["unimplemented_evaluator", "manual_only"]
+            )
+            == "unimplemented_evaluator"
+        )
+        assert (
+            score.rollup_control_evaluator_state("manual", ["manual_only"])
+            == "manual_only"
+        )
+
+    def test_state_surfaces_in_output(
+        self, tmp_path: Path, manifest: dict, collected_dir: Path
+    ):
+        try:
+            import score  # type: ignore[import-untyped]
+        except ImportError:
+            pytest.skip("score.py not yet implemented in engine/")
+
+        manifest_path = tmp_path / "controls.json"
+        output_path = tmp_path / "scores.json"
+        write_json(manifest_path, manifest)
+
+        score.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected_dir),
+            zone=2,
+            output_path=str(output_path),
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+
+        # Every control has an evaluator_state and a breakdown that sums
+        # to the number of checks defined.
+        for ctrl in result["controls"]:
+            assert ctrl["evaluator_state"] in score.EVALUATOR_STATES
+            breakdown = ctrl["evaluator_state_breakdown"]
+            assert set(breakdown.keys()) >= set(score.EVALUATOR_STATES)
+            assert sum(breakdown.values()) == len(ctrl["checks"])
+            for chk in ctrl["checks"]:
+                assert chk["evaluator_state"] in score.EVALUATOR_STATES
+
+        # Summary surfaces evaluator_coverage rollups
+        coverage = result["summary"]["evaluator_coverage"]
+        assert set(coverage["controls"].keys()) == set(score.EVALUATOR_STATES)
+        assert set(coverage["checks"].keys()) == set(score.EVALUATOR_STATES)
+        assert coverage["total_controls"] == len(result["controls"])
+        assert coverage["total_checks"] == sum(
+            len(c["checks"]) for c in result["controls"]
+        )
+
+    def test_full_manifest_coverage_honest(self, tmp_path: Path, collected_dir: Path):
+        """Score the real 78-control manifest and assert that the rollup
+        reflects today's actual evaluator coverage rather than overstating it.
+        """
+        try:
+            import score  # type: ignore[import-untyped]
+        except ImportError:
+            pytest.skip("score.py not yet implemented in engine/")
+
+        real_manifest = ASSESSMENT_ROOT / "manifest" / "controls.json"
+        if not real_manifest.exists():
+            pytest.skip("real controls.json manifest not available")
+
+        # The real manifest is a list of controls; wrap it for the engine
+        # if needed.
+        raw = json.loads(real_manifest.read_text(encoding="utf-8"))
+        controls = raw if isinstance(raw, list) else raw.get("controls", [])
+        manifest_data = build_manifest_with_controls(controls)
+
+        manifest_path = tmp_path / "controls.json"
+        output_path = tmp_path / "scores.json"
+        write_json(manifest_path, manifest_data)
+
+        score.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected_dir),
+            zone=2,
+            output_path=str(output_path),
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        coverage = result["summary"]["evaluator_coverage"]
+
+        # We must not silently classify every check as auto-evaluable.
+        # If this assertion ever fires, either real evaluators were added
+        # (great — relax the cap) or the classifier regressed.
+        assert coverage["checks"]["auto_evaluable"] < coverage["total_checks"]
+        assert coverage["total_controls"] == 78

--- a/docs/framework/solutions-integration.md
+++ b/docs/framework/solutions-integration.md
@@ -648,6 +648,7 @@ For detailed architecture guidance including scalability limits and alternative 
 ## Related Documentation
 
 - [Solutions Index](../reference/solutions-index.md) — Complete solution catalog with version history
+- [Solutions Contract](../reference/solutions-contract.md) — Versioning and pinning contract between this repo and FSI-AgentGov-Solutions
 - [Solutions Architecture Guide](../reference/solutions-architecture-guide.md) — Enterprise scalability and platform limits
 - [Adoption Roadmap](adoption-roadmap.md) — Phased implementation guidance
 - [FSI-AgentGov-Solutions Repository](https://github.com/judeper/FSI-AgentGov-Solutions) — Source code and deployment scripts

--- a/docs/reference/assessment-coverage.md
+++ b/docs/reference/assessment-coverage.md
@@ -1,0 +1,169 @@
+# Assessment Engine Coverage Matrix
+
+This page is **generated** by `scripts/generate_coverage_matrix.py` from `assessment/manifest/controls.json` and the `EVALUATORS` registry in `assessment/engine/score.py`. Do not edit by hand.
+
+It is the honest answer to *what does the assessment engine actually automate today?* and is intended to prevent confusion between **manual by design** and **evaluator not yet implemented**.
+
+## Evaluator states
+
+| State | Icon | Meaning |
+|-------|------|---------|
+| `auto_evaluable` | ✅ | A bespoke evaluator is registered for the check's `pass_condition` and the engine can score it from collected telemetry. |
+| `unimplemented_evaluator` | ⚠️ | The manifest declares a `pass_condition`, but no evaluator function is registered yet. The generic fallback returns `unknown`. |
+| `manual_only` | 📝 | The control is manual by design — either `automation: manual` in the manifest or all collection methods are non-automatable. Reviewer must answer the manual question. |
+
+## Summary
+
+### By control
+
+| State | Count | Share |
+|-------|-------|-------|
+| ✅ Auto | 1 | 1.3% |
+| 📝 Manual | 39 | 50.0% |
+| ⚠️ Unimplemented | 38 | 48.7% |
+| **Total** | **78** | 100% |
+
+### By check
+
+| State | Count | Share |
+|-------|-------|-------|
+| ✅ Auto | 3 | 3.2% |
+| 📝 Manual | 21 | 22.3% |
+| ⚠️ Unimplemented | 70 | 74.5% |
+| **Total** | **94** | 100% |
+
+### Registered evaluators
+
+`assessment/engine/score.py` registers **11** bespoke evaluator functions:
+
+- `audit_log_enabled`
+- `ca_policy_requires_mfa`
+- `ca_policy_targets_copilot_studio`
+- `copilot_retention_policy_exists`
+- `fsi_publisher_group_exists`
+- `grounding_sources_approved`
+- `no_everyone_assignment`
+- `no_external_sharing_on_grounding`
+- `prod_env_has_security_group`
+- `prod_env_is_managed`
+- `share_everyone_disabled`
+
+**Drift warning** — the following evaluators are registered but no manifest check uses them as a `pass_condition`. This usually means the manifest condition string drifted from the evaluator key:
+
+- `audit_log_enabled`
+- `ca_policy_requires_mfa`
+- `ca_policy_targets_copilot_studio`
+- `copilot_retention_policy_exists`
+- `grounding_sources_approved`
+- `no_external_sharing_on_grounding`
+- `prod_env_has_security_group`
+- `prod_env_is_managed`
+
+## Per-pillar matrix
+
+### Pillar 1 – Security
+
+| Control | Title | State | Auto | Unimpl | Manual | Collection | Caveats |
+|---------|-------|-------|------|--------|--------|------------|---------|
+| 1.1 | Control 1.1: Restrict Agent Publishing by Authorization | ✅ Auto | 3 | 0 | 0 | Graph_API, PPAC_PowerShell |  |
+| 1.10 | Control 1.10: Communication Compliance Monitoring | ⚠️ Unimplemented | 0 | 1 | 0 | Purview_PowerShell | `pass_condition: comm_compliance_policy_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 1.11 | Control 1.11: Conditional Access and Phishing-Resistant MFA | ⚠️ Unimplemented | 0 | 3 | 0 | Graph_API | `pass_condition: ca_mfa_enforced` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: signin_frequency_set` declared in manifest but no bespoke evaluator registered in score.py… |
+| 1.12 | Control 1.12: Insider Risk Detection and Response | ⚠️ Unimplemented | 0 | 1 | 0 | Purview_PowerShell | `pass_condition: insider_risk_policy_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 1.13 | Control 1.13: Sensitive Information Types (SITs) and Pattern Recognition | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell, Purview_PowerShell | `pass_condition: sit_count_adequate` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: dlp_references_sits` declared in manifest but no bespoke evaluator registered in score.… |
+| 1.14 | Control 1.14: Data Minimization and Agent Scope Control | 📝 Manual | 0 | 0 | 0 | — |  |
+| 1.15 | Control 1.15: Encryption: Data in Transit and at Rest | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API | `pass_condition: tls_12_enforced` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: at_rest_encryption_verified` declared in manifest but no bespoke evaluator registered in s… |
+| 1.16 | Control 1.16: Information Rights Management (IRM) for Documents | 📝 Manual | 0 | 0 | 0 | — |  |
+| 1.17 | Control 1.17: Endpoint Data Loss Prevention (Endpoint DLP) | ⚠️ Unimplemented | 0 | 1 | 0 | Purview_PowerShell | `pass_condition: endpoint_dlp_policy_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 1.18 | Control 1.18: Application-Level Authorization and Role-Based Access Control (RBAC) | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API | `pass_condition: rbac_least_privilege` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: no_excessive_admin` declared in manifest but no bespoke evaluator registered in score… |
+| 1.19 | Control 1.19: eDiscovery for Agent Interactions | ⚠️ Unimplemented | 0 | 2 | 0 | Purview_PowerShell | `pass_condition: ediscovery_agent_scope` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: ediscovery_copilot_content` declared in manifest but no bespoke evaluator registere… |
+| 1.2 | Control 1.2: Agent Registry and Integrated Apps Management | ⚠️ Unimplemented | 0 | 3 | 0 | Graph_API | `pass_condition: agent_inventory_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: auth_mode_configured` declared in manifest but no bespoke evaluator registered in s… |
+| 1.20 | Control 1.20: Network Isolation and Private Connectivity | 📝 Manual | 0 | 0 | 2 | Azure_API | Manual review required. |
+| 1.21 | Control 1.21: Adversarial Input Logging | ⚠️ Unimplemented | 0 | 1 | 0 | Purview_PowerShell | `pass_condition: prompt_response_logging` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 1.22 | Control 1.22: Information Barriers for AI Agents | ⚠️ Unimplemented | 0 | 2 | 0 | Purview_PowerShell | `pass_condition: ib_policy_active` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: ib_segments_configured` declared in manifest but no bespoke evaluator registered in score… |
+| 1.23 | Control 1.23: Step-Up Authentication for AI Agent Operations | ⚠️ Unimplemented | 0 | 1 | 0 | Graph_API | `pass_condition: stepup_auth_deployed` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 1.24 | Control 1.24: Defender AI Security Posture Management (AI-SPM) | 📝 Manual | 0 | 0 | 0 | Azure_API |  |
+| 1.25 | Control 1.25: MIME Type Restrictions for File Uploads | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: mime_zone_compliant` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: blocked_extensions_enforced` declared in manifest but no bespoke evaluator registered … |
+| 1.26 | Control 1.26: Agent File Upload and File Analysis Restrictions | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API, PPAC_REST | `pass_condition: file_upload_zone_appropriate` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: label_inheritance_configured` declared in manifest but no bespoke evaluator r… |
+| 1.27 | Control 1.27: AI Agent Content Moderation Enforcement | ⚠️ Unimplemented | 0 | 3 | 0 | Graph_API, PPAC_REST | `pass_condition: moderation_level_set` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: moderation_zone_compliant` declared in manifest but no bespoke evaluator registered i… |
+| 1.28 | Control 1.28: Policy-Based Agent Publishing Restrictions | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: dlp_publishing_restrictions` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: security_scan_enabled` declared in manifest but no bespoke evaluator registere… |
+| 1.29 | Control 1.29: Global Secure Access: Network Controls for Copilot Studio Agents | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API | `pass_condition: gsa_profile_linked` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: wcf_policy_configured` declared in manifest but no bespoke evaluator registered in scor… |
+| 1.3 | Control 1.3: SharePoint Content Governance and Permissions | 📝 Manual | 0 | 0 | 2 | SharePoint_Graph | Manual review required. |
+| 1.4 | Control 1.4: Advanced Connector Policies (ACP) | ⚠️ Unimplemented | 0 | 3 | 0 | PPAC_PowerShell | `pass_condition: dlp_policy_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: acp_allowlist_configured` declared in manifest but no bespoke evaluator registered in sc… |
+| 1.5 | Control 1.5: Data Loss Prevention (DLP) and Sensitivity Labels | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell, Purview_PowerShell | `pass_condition: dlp_scope_covers_agents` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: sensitivity_labels_enabled` declared in manifest but no bespoke evaluator register… |
+| 1.6 | Control 1.6: Microsoft Purview DSPM for AI | ⚠️ Unimplemented | 0 | 1 | 0 | Purview_PowerShell | `pass_condition: dspm_policy_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 1.7 | Control 1.7: Comprehensive Audit Logging and Compliance | ⚠️ Unimplemented | 0 | 2 | 0 | Purview_PowerShell | `pass_condition: audit_logging_enabled` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: audit_plan_tier_adequate` declared in manifest but no bespoke evaluator registered i… |
+| 1.8 | Control 1.8: Runtime Protection and External Threat Detection | 📝 Manual | 0 | 0 | 1 | Sentinel_KQL | Manual review required. |
+| 1.9 | Control 1.9: Data Retention and Deletion Policies | ⚠️ Unimplemented | 0 | 2 | 0 | Purview_PowerShell | `pass_condition: copilot_retention_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: retention_duration_adequate` declared in manifest but no bespoke evaluator regist… |
+
+### Pillar 2 – Management
+
+| Control | Title | State | Auto | Unimpl | Manual | Collection | Caveats |
+|---------|-------|-------|------|--------|--------|------------|---------|
+| 2.1 | Control 2.1: Managed Environments | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: all_prod_managed` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: managed_policies_enforced` declared in manifest but no bespoke evaluator registered in sc… |
+| 2.10 | Control 2.10: Patch Management and System Updates | ⚠️ Unimplemented | 0 | 1 | 0 | PPAC_PowerShell | `pass_condition: version_info_available` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 2.11 | Control 2.11: Bias Testing and Fairness Assessment | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.12 | Control 2.12: Supervision and Oversight (FINRA Rule 3110) | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.13 | Control 2.13: Documentation and Record Keeping | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.14 | Control 2.14: Training and Awareness Program | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.15 | Control 2.15: Environment Routing and Auto-Provisioning | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: routing_rules_configured` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: routing_zone_enforced` declared in manifest but no bespoke evaluator registered i… |
+| 2.16 | Control 2.16: RAG Source Integrity Validation | 📝 Manual | 0 | 0 | 1 | SharePoint_Graph | Manual review required. |
+| 2.17 | Control 2.17: Multi-Agent Orchestration Limits | ⚠️ Unimplemented | 0 | 1 | 0 | PPAC_PowerShell | `pass_condition: orchestration_limits_set` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 2.18 | Control 2.18: Automated Conflict of Interest Testing | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.19 | Control 2.19: Customer AI Disclosure and Transparency | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.2 | Control 2.2: Environment Groups and Tier Classification | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: env_groups_exist` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: tier_classification_present` declared in manifest but no bespoke evaluator registered in … |
+| 2.20 | Control 2.20: Adversarial Testing and Red Team Framework | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.21 | Control 2.21: AI Marketing Claims and Substantiation | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.22 | Control 2.22: Inactivity Timeout Enforcement | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_REST | `pass_condition: timeout_configured` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: timeout_value_adequate` declared in manifest but no bespoke evaluator registered in sco… |
+| 2.23 | Control 2.23: User Consent and AI Disclosure Enforcement | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.24 | Control 2.24: Agent Feature Enablement and Restriction Governance | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: genai_flags_reviewed` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: external_plugins_controlled` declared in manifest but no bespoke evaluator registered… |
+| 2.25 | Control 2.25: Microsoft Agent 365 — Admin Center Governance Console | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API | `pass_condition: agent365_console_accessible` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: agent365_inventory_visible` declared in manifest but no bespoke evaluator regi… |
+| 2.26 | Control 2.26: Entra Agent ID — Identity Governance for Agents | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API | `pass_condition: agent_ids_registered` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: access_packages_configured` declared in manifest but no bespoke evaluator registered … |
+| 2.3 | Control 2.3: Change Management and Release Planning | ⚠️ Unimplemented | 0 | 1 | 0 | PPAC_PowerShell | `pass_condition: approval_workflow_exists` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+| 2.4 | Control 2.4: Business Continuity and Disaster Recovery | 📝 Manual | 0 | 0 | 1 | SharePoint_Graph | Manual review required. |
+| 2.5 | Control 2.5: Testing, Validation, and Quality Assurance | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.6 | Control 2.6: Model Risk Management (OCC 2011-12/SR 11-7) | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.7 | Control 2.7: Vendor and Third-Party Risk Management | 📝 Manual | 0 | 0 | 0 | — |  |
+| 2.8 | Control 2.8: Access Control and Segregation of Duties | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API | `pass_condition: sod_matrix_match` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: no_dev_prod_overlap` declared in manifest but no bespoke evaluator registered in score.py… |
+| 2.9 | Control 2.9: Agent Performance Monitoring and Optimization | ⚠️ Unimplemented | 0 | 1 | 0 | PPAC_PowerShell | `pass_condition: usage_metrics_available` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. |
+
+### Pillar 3 – Reporting
+
+| Control | Title | State | Auto | Unimpl | Manual | Collection | Caveats |
+|---------|-------|-------|------|--------|--------|------------|---------|
+| 3.1 | Control 3.1: Agent Inventory and Metadata Management | ⚠️ Unimplemented | 0 | 2 | 0 | Graph_API | `pass_condition: agent_inventory_exportable` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: all_agents_classified` declared in manifest but no bespoke evaluator registered… |
+| 3.10 | Control 3.10: Hallucination Feedback Loop | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.11 | Control 3.11: Centralized Agent Inventory Enforcement | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.12 | Control 3.12: Agent Governance Exception and Override Management | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.13 | Control 3.13: Agent 365 Admin Center Analytics and Reporting | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.14 | Control 3.14: Agent 365 Observability SDK and Custom Agent Telemetry | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.2 | Control 3.2: Usage Analytics and Activity Monitoring | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.3 | Control 3.3: Compliance and Regulatory Reporting | 📝 Manual | 0 | 0 | 1 | SharePoint_Graph | Manual review required. |
+| 3.4 | Control 3.4: Incident Reporting and Root Cause Analysis | 📝 Manual | 0 | 0 | 1 | SharePoint_Graph | Manual review required. |
+| 3.5 | Control 3.5: Cost Allocation and Budget Tracking | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: usage_dashboard_enabled` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: data_export_configured` declared in manifest but no bespoke evaluator registered i… |
+| 3.6 | Control 3.6: Orphaned Agent Detection and Remediation | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.7 | Control 3.7: PPAC Security Posture Assessment | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell | `pass_condition: security_posture_retrievable` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: posture_score_adequate` declared in manifest but no bespoke evaluator registe… |
+| 3.8 | Control 3.8: Copilot Hub and Governance Dashboard | 📝 Manual | 0 | 0 | 0 | — |  |
+| 3.9 | Control 3.9: Microsoft Sentinel Integration | 📝 Manual | 0 | 0 | 2 | Sentinel_KQL | Manual review required. |
+
+### Pillar 4 – SharePoint
+
+| Control | Title | State | Auto | Unimpl | Manual | Collection | Caveats |
+|---------|-------|-------|------|--------|--------|------------|---------|
+| 4.1 | Control 4.1: SharePoint Information Access Governance (IAG) / Restricted Content Discovery | 📝 Manual | 0 | 0 | 2 | SharePoint_Graph | Manual review required. |
+| 4.2 | Control 4.2: Site Access Reviews and Certification | 📝 Manual | 0 | 0 | 1 | SharePoint_Graph | Manual review required. |
+| 4.3 | Control 4.3: Site and Document Retention Management | 📝 Manual | 0 | 0 | 2 | SharePoint_Graph | Manual review required. |
+| 4.4 | Control 4.4: Guest and External User Access Controls | 📝 Manual | 0 | 0 | 2 | SharePoint_Graph | Manual review required. |
+| 4.5 | Control 4.5: SharePoint Security and Compliance Monitoring | 📝 Manual | 0 | 0 | 1 | SharePoint_Graph | Manual review required. |
+| 4.6 | Control 4.6: Grounding Scope Governance | ⚠️ Unimplemented | 0 | 2 | 0 | PPAC_PowerShell, SharePoint_Graph | `pass_condition: grounding_scope_restricted` declared in manifest but no bespoke evaluator registered in score.py. Result will be `unknown`. `pass_condition: no_unapproved_grounding` declared in manifest but no bespoke evaluator register… |
+| 4.7 | Control 4.7: Microsoft 365 Copilot Data Governance | 📝 Manual | 0 | 0 | 0 | — |  |
+| 4.8 | Control 4.8: Item-Level Permission Scanning for Agent Knowledge Sources | 📝 Manual | 0 | 0 | 2 | SharePoint_Graph | Manual review required. |
+| 4.9 | Control 4.9: Embedded File Content Governance | 📝 Manual | 0 | 0 | 0 | — |  |
+
+## How to add a new evaluator
+
+1. Add a `_eval_<name>(collected, source_key)` function to `assessment/engine/score.py` returning `(passed: bool | None, evidence: str)`.
+2. Register it in the `EVALUATORS` dict using the same string as the manifest's `pass_condition`.
+3. Add a fixture and a unit test in `assessment/tests/`.
+4. Re-run `python scripts/generate_coverage_matrix.py` and commit the regenerated `docs/reference/assessment-coverage.md`.
+
+<!-- This page is generated by scripts/generate_coverage_matrix.py. Do not edit by hand. -->

--- a/docs/reference/solutions-contract.md
+++ b/docs/reference/solutions-contract.md
@@ -39,7 +39,7 @@ to a framework release tag, not to `main`**.
 | Solution → control mappings | Solutions | Framework `solutions-integration.md` | Solutions cite framework tag in `manifest.yaml` |
 | Generated `solutions.json` | Solutions | Framework `solutions-index.md` | Solutions repo publishes per-tag artifacts |
 
-### Framework guarantees
+### Framework commitments
 
 For any framework release `vX.Y.Z`:
 
@@ -56,7 +56,7 @@ For any framework release `vX.Y.Z`:
    [Assessment Engine Coverage matrix](assessment-coverage.md) shows the
    current state.
 
-### Solutions-side guarantees
+### Solutions-side commitments
 
 The Solutions repository is expected to:
 

--- a/docs/reference/solutions-contract.md
+++ b/docs/reference/solutions-contract.md
@@ -1,0 +1,142 @@
+# Solutions Repository Coupling Contract
+
+This page is the **source-of-truth contract** between the FSI-AgentGov framework
+repository and the
+[FSI-AgentGov-Solutions](https://github.com/judeper/FSI-AgentGov-Solutions)
+implementation catalog. It describes how the two repositories are coupled,
+which artifacts cross the boundary, and how each side should pin to the
+other to avoid silent breakage.
+
+---
+
+## Why a contract
+
+The framework repository (this one) owns the **78-control taxonomy**, the
+control manifest at `assessment/manifest/controls.json`, the assessment
+engine, and the regulatory-mapping documentation. The Solutions repository
+owns the 35 reference implementation solutions that map back to those
+controls.
+
+The Solutions repository validates each solution's `manifest.yaml` against
+the framework's `controls.json` to ensure every claimed control mapping is
+real. That validation creates a versioning dependency: if the framework
+renames or removes a control on `main`, every Solutions PR that consumes
+the framework from `main` will red-line at the same instant — even if the
+Solutions change is unrelated.
+
+To keep both repositories releasable, **the Solutions repository must pin
+to a framework release tag, not to `main`**.
+
+---
+
+## Versioned contract
+
+| Boundary artifact | Owner | Consumer | Contract |
+|-------------------|-------|----------|----------|
+| `assessment/manifest/controls.json` | Framework | Solutions (validation), assessment engine | SemVer; control IDs are stable within a major version |
+| Control IDs and pillar numbers | Framework | Solutions, downstream docs | Removal or renumbering = **major** version bump |
+| Pass-condition strings (`pass_condition`) | Framework | Assessment engine evaluators | Renaming = **minor** unless the evaluator is also updated atomically |
+| Solution → control mappings | Solutions | Framework `solutions-integration.md` | Solutions cite framework tag in `manifest.yaml` |
+| Generated `solutions.json` | Solutions | Framework `solutions-index.md` | Solutions repo publishes per-tag artifacts |
+
+### Framework guarantees
+
+For any framework release `vX.Y.Z`:
+
+1. The 78 control IDs and their pillar assignments are stable within
+   the same **major** version.
+2. The `pass_condition` strings used by registered evaluators are stable
+   within the same **minor** version. Adding a new `pass_condition` is a
+   minor change; renaming an existing one is a major change.
+3. The shape of `controls.json` (top-level array of control objects with
+   the keys listed in `assessment/manifest/README.md`) is additive within
+   a major version — fields may be added but not removed.
+4. Bug fixes that change `evaluator_state` rollups (e.g., wiring up a
+   missing evaluator) are minor changes. The
+   [Assessment Engine Coverage matrix](assessment-coverage.md) shows the
+   current state.
+
+### Solutions-side guarantees
+
+The Solutions repository is expected to:
+
+1. Pin its framework consumption to a **release tag** (e.g.,
+   `framework_version: v1.4.0` in repo-level config), not `main`.
+2. Bump the pinned tag deliberately, as part of a release of its own.
+3. Treat a framework **major** bump as a planned migration, not an
+   incidental dependency update.
+4. Re-run cross-repo validation against the new tag in CI before
+   updating the pin.
+
+---
+
+## Recommended pinning patterns
+
+There are two patterns the Solutions repository can use. Both are
+acceptable; the project should pick one and document it.
+
+### Pattern A — Submodule pin
+
+```bash
+# In the Solutions repo, pin the framework as a submodule at a tag.
+git submodule add -b v1.4.0 https://github.com/judeper/FSI-AgentGov.git \
+    .framework
+```
+
+Pros: cryptographically pinned, fully reproducible.
+Cons: contributors must remember `git submodule update --init`.
+
+### Pattern B — CI-side fetch-by-tag
+
+In the Solutions repo's validation workflow:
+
+```yaml
+- name: Fetch framework manifest at pinned tag
+  env:
+    FRAMEWORK_TAG: v1.4.0   # update deliberately
+  run: |
+    curl -fsSL \
+      "https://raw.githubusercontent.com/judeper/FSI-AgentGov/${FRAMEWORK_TAG}/assessment/manifest/controls.json" \
+      -o .framework/controls.json
+```
+
+Pros: zero submodule overhead.
+Cons: relies on the consumer to bump `FRAMEWORK_TAG` deliberately.
+
+---
+
+## Compatibility matrix
+
+The Solutions repository is responsible for publishing the matrix below
+(or its equivalent) so consumers know which framework tag a given
+Solutions release was built against. The framework repository keeps a
+mirror only as a courtesy; the authoritative copy lives with the
+producer.
+
+| Solutions release | Framework tag | Notes |
+|-------------------|---------------|-------|
+| _maintained in the Solutions repo_ | _maintained in the Solutions repo_ | This table intentionally left as a pointer — see [FSI-AgentGov-Solutions release notes](https://github.com/judeper/FSI-AgentGov-Solutions/releases) |
+
+---
+
+## When this contract changes
+
+* Framework PRs that touch `controls.json` IDs, pillars, or
+  `pass_condition` strings must include a one-line note in the PR
+  description identifying the change as additive, minor, or breaking.
+* Framework releases that include any breaking change to this contract
+  must bump the **major** version and call out the change in the
+  release notes.
+* The Solutions repository owns its own migration cadence. The
+  framework will not delete deprecated control IDs without a deprecation
+  release in the prior major version.
+
+---
+
+## Related references
+
+- [Assessment Engine Coverage](assessment-coverage.md) — current
+  evaluator state across all 78 controls.
+- [Solutions Integration](../framework/solutions-integration.md) —
+  high-level architecture of the two-repo system.
+- [Solutions Index](solutions-index.md) — current solution catalog.

--- a/docs/reference/versioning-and-support.md
+++ b/docs/reference/versioning-and-support.md
@@ -1,0 +1,97 @@
+# Versioning and Support
+
+This page is the canonical statement of how the FSI Agent Governance
+Framework is versioned, what we consider a breaking change, and how long a
+given release is supported. It complements the [Solutions Contract](solutions-contract.md),
+which describes how downstream repositories should pin to framework releases.
+
+## Source of Truth
+
+The framework version is the value of `framework_version` referenced by the
+[Solutions Contract](solutions-contract.md) and the latest entry in
+[`CHANGELOG.md`](https://github.com/judeper/FSI-AgentGov/blob/main/CHANGELOG.md).
+The MkDocs site footer reflects the same value.
+
+## Versioning Scheme
+
+We follow [Semantic Versioning 2.0.0](https://semver.org/) adapted to a
+governance-content project:
+
+| Component | Bumped when… |
+|-----------|--------------|
+| **Major** (`X`.0.0) | A control ID is removed, an existing `pass_condition` string is renamed, the manifest schema removes a field, a zone definition changes, or a regulatory mapping is removed |
+| **Minor** (`X.Y`.0) | A new control is added, a new `pass_condition` is added, a new evaluator is wired, a manifest field is added, or a new playbook section is introduced |
+| **Patch** (`X.Y.Z`) | Documentation fixes, evidence-link refreshes, typos, bug fixes that do not change the public schema, dependency updates |
+
+The 78-control baseline is itself a major-version commitment. Adding the 79th
+control would be a minor change, but renumbering existing controls would be
+a major change.
+
+## Stability Commitments by Version
+
+For any release `vX.Y.Z`, the following hold within the same **major**
+version:
+
+1. The set of control IDs present at the time of `vX.0.0` will continue to
+   exist (additions allowed; removals require a major bump).
+2. The pillar assignment of every control is stable.
+3. The shape of `controls.json` is additive — fields may be added but not
+   removed or repurposed.
+4. The zone tier model (Personal / Team / Enterprise) is stable.
+
+Within the same **minor** version:
+
+1. `pass_condition` strings used by registered evaluators are stable.
+2. `evaluator_state` rollups are stable for any control whose underlying
+   manifest entry has not changed.
+3. Output schemas of `assessment-prefilled.md`,
+   `manual-questionnaire.md`, and `assessment-summary.json` are stable.
+
+Patch releases never change any of the above.
+
+## Support Window
+
+| Version | Status |
+|---------|--------|
+| Latest minor on `main` | Fully supported |
+| Previous minor | Security fixes only |
+| Older versions | Unsupported after **60 days** from a new minor release |
+
+Security fixes follow the process in [`SECURITY.md`](https://github.com/judeper/FSI-AgentGov/blob/main/SECURITY.md).
+
+## Release Artifacts
+
+Each tagged release publishes:
+
+- A GitHub Release with auto-generated notes
+- A CycloneDX SBOM for the Python dependency tree
+- A CycloneDX SBOM for the npm dependency tree
+- Sigstore (cosign keyless) build-provenance attestations
+- Sigstore SBOM attestations
+
+All artifacts are produced by `.github/workflows/release-artifacts.yml`
+using GitHub Actions OIDC; there are no long-lived signing keys.
+
+## Deprecation Process
+
+If a public-surface element will be removed in the next major:
+
+1. The element is annotated `Deprecated` in its source location and in the
+   relevant docs page during a minor release.
+2. The deprecation is summarised in `CHANGELOG.md` under
+   **Deprecations** for that minor.
+3. The element remains functional for the entire remaining major version.
+4. Removal happens only at the next major release, with a migration note in
+   `CHANGELOG.md`.
+
+## How Downstream Consumers Should Pin
+
+See the [Solutions Contract](solutions-contract.md) for the recommended
+pinning patterns. In short: pin to a release tag (e.g., `v1.4.0`), not
+`main`, and bump the pin deliberately as part of your own release process.
+
+## Pre-Release Versions
+
+Release candidates use the `vX.Y.Z-rcN` suffix. RCs are signed and produce
+SBOMs but are not considered supported releases. The Solutions repo should
+not pin to an RC tag in production guidance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -734,6 +734,7 @@ nav:
     - Agent 365 Capabilities Summary: reference/agent-365-capabilities-summary.md
     - Solutions Index: reference/solutions-index.md
     - Solutions Contract: reference/solutions-contract.md
+    - Versioning and Support: reference/versioning-and-support.md
     - Solutions Coverage Gaps: reference/solutions-coverage-gaps.md
     - Solutions Architecture Guide: reference/solutions-architecture-guide.md
     - SharePoint Advanced Management Licensing: reference/sharepoint-advanced-management-licensing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -733,10 +733,12 @@ nav:
     - reference/index.md
     - Agent 365 Capabilities Summary: reference/agent-365-capabilities-summary.md
     - Solutions Index: reference/solutions-index.md
+    - Solutions Contract: reference/solutions-contract.md
     - Solutions Coverage Gaps: reference/solutions-coverage-gaps.md
     - Solutions Architecture Guide: reference/solutions-architecture-guide.md
     - SharePoint Advanced Management Licensing: reference/sharepoint-advanced-management-licensing.md
     - Evidence Standards: reference/evidence-standards.md
+    - Assessment Engine Coverage: reference/assessment-coverage.md
     - Administrator Role Catalog: reference/role-catalog.md
     - SOC Analyst Purview Roles: reference/purview-soc-analyst-roles.md
     - License Requirements: reference/license-requirements.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+extend-exclude = [
+    "site",
+    "node_modules",
+    "maintainers-local",
+    ".venv",
+]
+
+[tool.ruff.lint]
+# Curated minimal ruleset. We deliberately exclude E501 (line too long) until
+# the codebase has had a dedicated wrapping pass.
+select = ["F", "B", "I"]
+ignore = []
+
+[tool.ruff.lint.per-file-ignores]
+# Tests can use unused imports for fixture side effects, etc.
+"assessment/tests/*.py" = ["F401"]

--- a/scripts/audit_control_metadata.py
+++ b/scripts/audit_control_metadata.py
@@ -7,9 +7,9 @@ Checks for:
 - Roles & Responsibilities section
 """
 
-import os
 import re
 from pathlib import Path
+
 
 def audit_control_file(filepath):
     """Audit a single control file for metadata compliance."""

--- a/scripts/caa_client.py
+++ b/scripts/caa_client.py
@@ -14,11 +14,9 @@ CAA_CLIENT_SECRET    App registration client secret (omit for interactive)
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
-import sys
 from typing import Any, Dict, List, Optional
 
 import msal

--- a/scripts/check_manifest_doc_drift.py
+++ b/scripts/check_manifest_doc_drift.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Detect drift between the control manifest, CONTROL-INDEX, and mkdocs nav.
+
+The 78-control framework is described in three places:
+
+* ``assessment/manifest/controls.json`` — machine-readable source of truth
+* ``docs/controls/CONTROL-INDEX.md`` — human-readable master index
+* ``mkdocs.yml`` — published navigation
+
+This script makes sure the same 78 control IDs appear in all three with
+the same pillar grouping. Run with ``--check`` in CI to fail on drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "assessment" / "manifest" / "controls.json"
+INDEX = REPO_ROOT / "docs" / "controls" / "CONTROL-INDEX.md"
+MKDOCS = REPO_ROOT / "mkdocs.yml"
+
+CONTROL_ID_RE = re.compile(r"^\d+\.\d+$")
+INDEX_ROW_RE = re.compile(r"^\|\s*(\d+\.\d+)\s*\|")
+NAV_FILE_RE = re.compile(r"controls/pillar-(\d)-[\w-]+/(\d+\.\d+)-")
+
+
+def load_manifest_ids() -> set[str]:
+    raw = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    controls = raw if isinstance(raw, list) else raw.get("controls", [])
+    return {c["id"] for c in controls}
+
+
+def load_index_ids() -> set[str]:
+    ids: set[str] = set()
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        m = INDEX_ROW_RE.match(line)
+        if m:
+            ids.add(m.group(1))
+    return ids
+
+
+def load_nav_ids() -> set[str]:
+    ids: set[str] = set()
+    for line in MKDOCS.read_text(encoding="utf-8").splitlines():
+        m = NAV_FILE_RE.search(line)
+        if m:
+            ids.add(m.group(2))
+    return ids
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero on drift (default behavior; flag kept for clarity).",
+    )
+    parser.parse_args(argv)
+
+    manifest_ids = load_manifest_ids()
+    index_ids = load_index_ids()
+    nav_ids = load_nav_ids()
+
+    sources = {
+        "manifest (controls.json)": manifest_ids,
+        "CONTROL-INDEX.md": index_ids,
+        "mkdocs.yml nav": nav_ids,
+    }
+
+    print("Source counts:")
+    for label, ids in sources.items():
+        print(f"  {label}: {len(ids)} control IDs")
+    print()
+
+    union = set().union(*sources.values())
+    drift = False
+    for label, ids in sources.items():
+        missing = union - ids
+        if missing:
+            drift = True
+            print(
+                f"DRIFT: {label} is missing {len(missing)} control(s): "
+                f"{sorted(missing)}"
+            )
+
+    # Sanity: every recorded ID should look like N.N.
+    bogus = [cid for cid in union if not CONTROL_ID_RE.match(cid)]
+    if bogus:
+        drift = True
+        print(f"DRIFT: malformed control IDs detected: {sorted(bogus)}")
+
+    if drift:
+        print(
+            "\nFAIL: control IDs drift between manifest, CONTROL-INDEX, "
+            "and mkdocs nav. Update all three to stay in sync."
+        )
+        return 1
+
+    print("OK: all 3 sources reference the same control IDs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_temp.py
+++ b/scripts/check_temp.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import hashlib
+from pathlib import Path
 
 TEMP_DIR = Path("temp")
 REPO_DIR = Path(".")

--- a/scripts/compile_researcher_package.py
+++ b/scripts/compile_researcher_package.py
@@ -7,7 +7,6 @@ Usage:
     python scripts/compile_researcher_package.py
 """
 
-import os
 import re
 import sys
 from pathlib import Path

--- a/scripts/create_connection_references.py
+++ b/scripts/create_connection_references.py
@@ -19,7 +19,6 @@ import sys
 from typing import Any, Dict, List
 
 import requests
-
 from caa_client import CAAClient
 
 logger = logging.getLogger(__name__)

--- a/scripts/create_timeout_connection_references.py
+++ b/scripts/create_timeout_connection_references.py
@@ -19,7 +19,6 @@ import sys
 from typing import Any, Dict, List
 
 import requests
-
 from caa_client import CAAClient
 
 logger = logging.getLogger(__name__)

--- a/scripts/create_uasd_connection_references.py
+++ b/scripts/create_uasd_connection_references.py
@@ -19,7 +19,6 @@ import sys
 from typing import Any, Dict, List
 
 import requests
-
 from caa_client import CAAClient
 
 logger = logging.getLogger(__name__)

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -19,9 +19,9 @@ import logging
 import sys
 
 from caa_client import CAAClient
+from create_connection_references import create_connection_references
 from create_dataverse_schema import create_schema
 from create_environment_variables import create_environment_variables
-from create_connection_references import create_connection_references
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/detect_agent_sharing_violations.py
+++ b/scripts/detect_agent_sharing_violations.py
@@ -50,7 +50,6 @@ import csv
 import hashlib
 import json
 import logging
-import os
 import re
 import sys
 import uuid
@@ -59,12 +58,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
-from dateutil import parser as dateparser
 
 # Import Phase 1 modules
 from asard_zone_rules import check_agent_compliance
 from bap_admin_client import BAPAdminClient
 from caa_client import CAAClient
+from dateutil import parser as dateparser
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +146,6 @@ def enumerate_agents_in_environment(
         Empty list on API failure (graceful degradation).
     """
     environment_id = environment.get("name", "")
-    environment_name = environment.get("properties", {}).get("displayName", environment_id)
 
     if not environment_id:
         logger.warning("Environment object missing 'name' field — skipping")
@@ -507,7 +505,7 @@ def print_console_output(
         results_by_env[env_id].append(result)
     
     # Print per-environment results
-    for env_id, env_results in results_by_env.items():
+    for _env_id, env_results in results_by_env.items():
         # Use first result for environment metadata
         first_result = env_results[0]
         env_name = first_result["environment_name"]

--- a/scripts/extract_assessment_data.py
+++ b/scripts/extract_assessment_data.py
@@ -18,7 +18,6 @@ Usage:
 """
 
 import json
-import os
 import re
 import sys
 from pathlib import Path

--- a/scripts/extract_whitepaper_text.py
+++ b/scripts/extract_whitepaper_text.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 from pypdf import PdfReader
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LOCAL_REF_PACK = REPO_ROOT / "maintainers-local" / "reference-pack"
 

--- a/scripts/generate_coverage_matrix.py
+++ b/scripts/generate_coverage_matrix.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Generate the 78-control evaluator coverage matrix.
+
+Reads ``assessment/manifest/controls.json`` and the ``EVALUATORS`` registry
+from ``assessment/engine/score.py`` and writes a Markdown coverage report
+to ``docs/reference/assessment-coverage.md``.
+
+The matrix is the canonical answer to the question "what does the
+assessment engine actually automate today?" — distinguishing:
+
+* ``auto_evaluable`` — bespoke evaluator wired up
+* ``manual_only`` — manual by design (manual control or non-automatable
+  collection method)
+* ``unimplemented_evaluator`` — pass condition exists but no evaluator
+  is registered yet (today's biggest coverage gap)
+
+Run::
+
+    python scripts/generate_coverage_matrix.py
+
+CI may also call this with ``--check`` to fail when the doc is stale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENGINE_DIR = REPO_ROOT / "assessment" / "engine"
+MANIFEST_PATH = REPO_ROOT / "assessment" / "manifest" / "controls.json"
+OUTPUT_PATH = REPO_ROOT / "docs" / "reference" / "assessment-coverage.md"
+
+sys.path.insert(0, str(ENGINE_DIR))
+
+import score  # type: ignore[import-untyped]  # noqa: E402
+
+STATE_LABEL = {
+    "auto_evaluable": "Auto",
+    "unimplemented_evaluator": "Unimplemented",
+    "manual_only": "Manual",
+}
+
+STATE_ICON = {
+    "auto_evaluable": "✅",
+    "unimplemented_evaluator": "⚠️",
+    "manual_only": "📝",
+}
+
+
+def load_controls() -> list[dict]:
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return raw if isinstance(raw, list) else raw.get("controls", [])
+
+
+def collection_sources(check: dict, control: dict) -> str:
+    methods = check.get("collection_methods") or control.get(
+        "collection_methods", []
+    )
+    if not methods:
+        return "—"
+    return ", ".join(sorted(set(methods)))
+
+
+def caveat_for_check(check: dict, state: str) -> str:
+    cond = (check.get("pass_condition") or "").strip()
+    if state == "auto_evaluable":
+        return ""
+    if state == "manual_only":
+        return "Manual review required."
+    return (
+        f"`pass_condition: {cond}` declared in manifest but no bespoke "
+        f"evaluator registered in score.py. Result will be `unknown`."
+    )
+
+
+def render(controls: list[dict]) -> str:
+    registered = sorted(score.EVALUATORS.keys())
+    total_controls = len(controls)
+    control_states: Counter = Counter()
+    check_states: Counter = Counter()
+
+    pillars: dict[int, list[dict]] = {}
+    for ctrl in controls:
+        cm = ctrl.get("collection_methods", [])
+        automation = ctrl.get("automation", "full")
+        per_check_states = []
+        for chk in ctrl.get("checks", []):
+            s = score.classify_check_evaluator_state(chk, automation, cm)
+            per_check_states.append(s)
+            check_states[s] += 1
+        rollup = score.rollup_control_evaluator_state(automation, per_check_states)
+        control_states[rollup] += 1
+        pillars.setdefault(int(ctrl["pillar"]), []).append(
+            {
+                "control": ctrl,
+                "rollup": rollup,
+                "check_states": per_check_states,
+            }
+        )
+
+    lines: list[str] = []
+    lines.append("# Assessment Engine Coverage Matrix")
+    lines.append("")
+    lines.append(
+        "This page is **generated** by `scripts/generate_coverage_matrix.py` "
+        "from `assessment/manifest/controls.json` and the `EVALUATORS` "
+        "registry in `assessment/engine/score.py`. Do not edit by hand."
+    )
+    lines.append("")
+    lines.append(
+        "It is the honest answer to *what does the assessment engine "
+        "actually automate today?* and is intended to prevent confusion "
+        "between **manual by design** and **evaluator not yet implemented**."
+    )
+    lines.append("")
+    lines.append("## Evaluator states")
+    lines.append("")
+    lines.append("| State | Icon | Meaning |")
+    lines.append("|-------|------|---------|")
+    lines.append(
+        "| `auto_evaluable` | ✅ | A bespoke evaluator is registered for the "
+        "check's `pass_condition` and the engine can score it from collected "
+        "telemetry. |"
+    )
+    lines.append(
+        "| `unimplemented_evaluator` | ⚠️ | The manifest declares a "
+        "`pass_condition`, but no evaluator function is registered yet. "
+        "The generic fallback returns `unknown`. |"
+    )
+    lines.append(
+        "| `manual_only` | 📝 | The control is manual by design — either "
+        "`automation: manual` in the manifest or all collection methods are "
+        "non-automatable. Reviewer must answer the manual question. |"
+    )
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("### By control")
+    lines.append("")
+    lines.append("| State | Count | Share |")
+    lines.append("|-------|-------|-------|")
+    for s in score.EVALUATOR_STATES:
+        n = control_states.get(s, 0)
+        pct = (n / total_controls * 100) if total_controls else 0
+        lines.append(f"| {STATE_ICON[s]} {STATE_LABEL[s]} | {n} | {pct:.1f}% |")
+    lines.append(f"| **Total** | **{total_controls}** | 100% |")
+    lines.append("")
+    total_checks = sum(check_states.values())
+    lines.append("### By check")
+    lines.append("")
+    lines.append("| State | Count | Share |")
+    lines.append("|-------|-------|-------|")
+    for s in score.EVALUATOR_STATES:
+        n = check_states.get(s, 0)
+        pct = (n / total_checks * 100) if total_checks else 0
+        lines.append(f"| {STATE_ICON[s]} {STATE_LABEL[s]} | {n} | {pct:.1f}% |")
+    lines.append(f"| **Total** | **{total_checks}** | 100% |")
+    lines.append("")
+    lines.append("### Registered evaluators")
+    lines.append("")
+    lines.append(
+        f"`assessment/engine/score.py` registers **{len(registered)}** "
+        "bespoke evaluator functions:"
+    )
+    lines.append("")
+    for name in registered:
+        lines.append(f"- `{name}`")
+    lines.append("")
+    used_conditions = {
+        chk.get("pass_condition")
+        for ctrl in controls
+        for chk in ctrl.get("checks", [])
+    }
+    unused = sorted(set(registered) - used_conditions)
+    if unused:
+        lines.append(
+            "**Drift warning** — the following evaluators are registered "
+            "but no manifest check uses them as a `pass_condition`. This "
+            "usually means the manifest condition string drifted from "
+            "the evaluator key:"
+        )
+        lines.append("")
+        for name in unused:
+            lines.append(f"- `{name}`")
+        lines.append("")
+
+    lines.append("## Per-pillar matrix")
+    lines.append("")
+
+    for pillar_id in sorted(pillars):
+        first = pillars[pillar_id][0]["control"]
+        lines.append(f"### Pillar {pillar_id} – {first['pillar_name']}")
+        lines.append("")
+        lines.append(
+            "| Control | Title | State | Auto | Unimpl | Manual | "
+            "Collection | Caveats |"
+        )
+        lines.append(
+            "|---------|-------|-------|------|--------|--------|"
+            "------------|---------|"
+        )
+        for entry in sorted(
+            pillars[pillar_id], key=lambda e: e["control"]["id"]
+        ):
+            ctrl = entry["control"]
+            states = entry["check_states"]
+            counts = Counter(states)
+            sources = ", ".join(
+                sorted(set(ctrl.get("collection_methods", []) or ["—"]))
+            )
+            # Caveats: prefer the most specific drift message.
+            caveats: list[str] = []
+            for chk in ctrl.get("checks", []):
+                s = score.classify_check_evaluator_state(
+                    chk, ctrl.get("automation", "full"),
+                    ctrl.get("collection_methods", []),
+                )
+                msg = caveat_for_check(chk, s)
+                if msg and msg not in caveats:
+                    caveats.append(msg)
+            caveat_text = " ".join(caveats) if caveats else ""
+            # Truncate to keep the table readable.
+            if len(caveat_text) > 240:
+                caveat_text = caveat_text[:237] + "…"
+            # Escape pipes in title and caveat text.
+            title = ctrl["title"].replace("|", "\\|")
+            caveat_text = caveat_text.replace("|", "\\|")
+            lines.append(
+                f"| {ctrl['id']} | {title} | "
+                f"{STATE_ICON[entry['rollup']]} {STATE_LABEL[entry['rollup']]} "
+                f"| {counts.get('auto_evaluable', 0)} "
+                f"| {counts.get('unimplemented_evaluator', 0)} "
+                f"| {counts.get('manual_only', 0)} "
+                f"| {sources} | {caveat_text} |"
+            )
+        lines.append("")
+
+    lines.append("## How to add a new evaluator")
+    lines.append("")
+    lines.append(
+        "1. Add a `_eval_<name>(collected, source_key)` function to "
+        "`assessment/engine/score.py` returning `(passed: bool | None, "
+        "evidence: str)`."
+    )
+    lines.append(
+        "2. Register it in the `EVALUATORS` dict using the same string "
+        "as the manifest's `pass_condition`."
+    )
+    lines.append(
+        "3. Add a fixture and a unit test in `assessment/tests/`."
+    )
+    lines.append(
+        "4. Re-run `python scripts/generate_coverage_matrix.py` and commit "
+        "the regenerated `docs/reference/assessment-coverage.md`."
+    )
+    lines.append("")
+    lines.append(
+        "<!-- This page is generated by scripts/generate_coverage_matrix.py. "
+        "Do not edit by hand. -->"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the generated content differs from disk.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(OUTPUT_PATH),
+        help="Override output path (default: docs/reference/assessment-coverage.md)",
+    )
+    args = parser.parse_args(argv)
+
+    controls = load_controls()
+    rendered = render(controls)
+    target = Path(args.output)
+
+    if args.check:
+        if not target.exists():
+            print(
+                f"ERROR: {target} does not exist. Run "
+                "`python scripts/generate_coverage_matrix.py` to create it.",
+                file=sys.stderr,
+            )
+            return 1
+        existing = target.read_text(encoding="utf-8")
+        if existing != rendered:
+            print(
+                f"ERROR: {target} is out of date. Run "
+                "`python scripts/generate_coverage_matrix.py` and commit.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"OK: {target} is current.")
+        return 0
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {target} ({len(controls)} controls).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_excel_templates.py
+++ b/scripts/generate_excel_templates.py
@@ -3,11 +3,12 @@ Generate FSI-AgentGov Excel checklist templates.
 Creates 6 professional, clean .xlsx files with no DRM/encryption.
 """
 
+import os
+
 import openpyxl
-from openpyxl.styles import Font, PatternFill, Alignment, Border, Side, numbers
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.datavalidation import DataValidation
-import os
 
 # ── All 78 controls ──────────────────────────────────────────────────────────
 
@@ -102,7 +103,7 @@ ALL_CONTROLS = {
 
 # Build flat lookup
 CONTROL_LOOKUP = {}
-for pillar, controls in ALL_CONTROLS.items():
+for _pillar, controls in ALL_CONTROLS.items():
     for cid, cname in controls:
         CONTROL_LOOKUP[cid] = cname
 
@@ -183,7 +184,7 @@ VERSION_FOOTER = "FSI Agent Governance Framework v1.3.0 \u2014 March 2026"
 
 def style_header_row(ws, row):
     """Apply professional header styling."""
-    for col_idx, (header, width) in enumerate(zip(HEADERS, COL_WIDTHS), 1):
+    for col_idx, (header, width) in enumerate(zip(HEADERS, COL_WIDTHS, strict=False), 1):
         cell = ws.cell(row=row, column=col_idx, value=header)
         cell.font = HEADER_FONT
         cell.fill = HEADER_FILL
@@ -349,7 +350,7 @@ def create_dashboard():
     ws_summary.row_dimensions[4].height = 6
     summary_headers = ["Pillar", "Controls", "Not Started", "In Progress", "Completed"]
     summary_widths = [30, 14, 14, 14, 14]
-    for col_idx, (h, w) in enumerate(zip(summary_headers, summary_widths), 1):
+    for col_idx, (h, w) in enumerate(zip(summary_headers, summary_widths, strict=False), 1):
         cell = ws_summary.cell(row=5, column=col_idx, value=h)
         cell.font = HEADER_FONT
         cell.fill = HEADER_FILL

--- a/scripts/governance/FsiMimeControl.Tests.ps1
+++ b/scripts/governance/FsiMimeControl.Tests.ps1
@@ -1,6 +1,9 @@
 #Requires -Version 7.0
 #Requires -Modules Pester
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText','',Justification='Mock tokens in unit-test fixtures are not secrets.')]
+param()
+
 <#
 .SYNOPSIS
     Pester 5 test suite for FsiMimeControl PowerShell module.

--- a/scripts/hooks/boundary-check.py
+++ b/scripts/hooks/boundary-check.py
@@ -8,12 +8,12 @@ outside the project directory.
 Usage: Configured in .claude/settings.local.json as PreToolUse hook
 """
 
-import sys
 import json
 import os
-import re
 import platform
+import re
 import shlex
+import sys
 
 # Project root - detect dynamically based on script location
 # Script is at: {PROJECT_ROOT}/scripts/hooks/boundary-check.py

--- a/scripts/hooks/researcher-package-reminder.py
+++ b/scripts/hooks/researcher-package-reminder.py
@@ -10,8 +10,8 @@ Matcher: Edit, Write
 """
 
 import json
-import sys
 import re
+import sys
 
 
 def main():

--- a/scripts/learn_monitor.py
+++ b/scripts/learn_monitor.py
@@ -21,7 +21,6 @@ Environment Variables:
     LEARN_MONITOR_DEBUG=1  - Enable debug output
 """
 
-import json
 import logging
 import os
 import re
@@ -31,30 +30,29 @@ import traceback
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
 
 # Import shared monitoring framework
 from monitoring_shared import (
-    fetch_page,
-    normalize_content,
-    compute_hash,
-    classify_change,
-    find_affected_controls,
-    format_change_summary,
-    load_state,
-    save_state_atomic,
-    get_source_state,
-    set_source_state,
-    generate_report_header,
-    generate_executive_summary,
-    write_report,
-    load_monitoring_config,
-    validate_config,
-    DEFAULT_CONFIG_PATH,
     CLASSIFICATION_CRITICAL,
     CLASSIFICATION_HIGH,
     CLASSIFICATION_MEDIUM,
     CLASSIFICATION_NOISE,
+    DEFAULT_CONFIG_PATH,
+    classify_change,
+    compute_hash,
+    fetch_page,
+    find_affected_controls,
+    format_change_summary,
+    generate_executive_summary,
+    generate_report_header,
+    get_source_state,
+    load_monitoring_config,
+    load_state,
+    normalize_content,
+    save_state_atomic,
+    set_source_state,
+    validate_config,
+    write_report,
 )
 
 # Handle Windows encoding
@@ -88,7 +86,7 @@ logger = logging.getLogger(__name__)
 
 try:
     import requests
-    from bs4 import BeautifulSoup
+    from bs4 import BeautifulSoup  # noqa: F401  (imported for availability check)
 except ImportError as e:
     print(f"ERROR: Missing dependency: {e}")
     print("Install with: pip install requests beautifulsoup4")
@@ -139,7 +137,6 @@ def parse_watchlist(watchlist_path: Path) -> list[URLEntry]:
     """
     content = watchlist_path.read_text(encoding='utf-8')
     urls = []
-    current_section = "Unknown"
 
     # Sections to skip (not Learn URLs)
     skip_sections = [
@@ -344,7 +341,7 @@ def _format_change(c: ChangeRecord, index: int) -> list[str]:
 # === Debug Functions ===
 def _debug_single_url(url: str, config: dict):
     """Debug a single URL - useful for troubleshooting."""
-    print(f"\nDebug mode: checking single URL")
+    print("\nDebug mode: checking single URL")
     print(f"URL: {url}")
     print("=" * 60)
 
@@ -366,7 +363,7 @@ def _debug_single_url(url: str, config: dict):
     try:
         normalized = normalize_content(result['content'])
         print(f"   Normalized length: {len(normalized)} chars")
-        print(f"   First 500 chars:\n   ---")
+        print("   First 500 chars:\n   ---")
         print("   " + normalized[:500].replace("\n", "\n   "))
         print("   ---")
     except Exception as e:
@@ -393,7 +390,7 @@ def _debug_single_url(url: str, config: dict):
 
     if source_state and url in source_state.get("urls", {}):
         old_state = source_state["urls"][url]
-        print(f"   Found in state file")
+        print("   Found in state file")
         print(f"   Last checked: {old_state.get('last_checked', 'unknown')}")
         print(f"   Last changed: {old_state.get('last_changed', 'unknown')}")
         if old_state.get("content_hash") == content_hash:

--- a/scripts/monitoring_shared.py
+++ b/scripts/monitoring_shared.py
@@ -24,7 +24,6 @@ import re
 import sys
 import tempfile
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -614,9 +613,9 @@ def load_monitoring_config(config_path: Optional[Path] = None) -> dict:
 
     # Check file exists
     if not config_path.exists():
-        print(f"ERROR: Configuration file not found")
+        print("ERROR: Configuration file not found")
         print(f"  Expected: {config_path}")
-        print(f"  Please ensure the monitoring config file exists.")
+        print("  Please ensure the monitoring config file exists.")
         sys.exit(2)
 
     # Load YAML
@@ -624,7 +623,7 @@ def load_monitoring_config(config_path: Optional[Path] = None) -> dict:
         with open(config_path, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f)
     except yaml.YAMLError as e:
-        print(f"ERROR: Invalid YAML syntax in configuration file")
+        print("ERROR: Invalid YAML syntax in configuration file")
         print(f"  File: {config_path}")
         if hasattr(e, 'problem_mark'):
             mark = e.problem_mark

--- a/scripts/normalize_controls.py
+++ b/scripts/normalize_controls.py
@@ -25,7 +25,6 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-
 DOCS_DIR = Path("docs")
 PILLAR_DIRS = [
     DOCS_DIR / "controls" / "pillar-1-security",
@@ -116,10 +115,7 @@ def _strip_existing_footer_blocks(text: str) -> tuple[str, str | None]:
         return any(p.match(line.strip()) for p in footer_line_patterns)
 
     # Pop footer meta lines at bottom (possibly multiple blocks)
-    removed_any = False
     while lines and (is_footer_meta(lines[-1]) or lines[-1].strip() == "---"):
-        if is_footer_meta(lines[-1]) or lines[-1].strip() == "---":
-            removed_any = True
         lines.pop()
         while lines and lines[-1].strip() == "":
             lines.pop()

--- a/scripts/regulatory_monitor.py
+++ b/scripts/regulatory_monitor.py
@@ -30,30 +30,28 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
-from urllib.parse import urlparse
 
 # Import shared monitoring framework
 from monitoring_shared import (
-    fetch_page,
-    compute_hash,
-    load_state,
-    save_state_atomic,
-    get_source_state,
-    set_source_state,
-    generate_report_header,
-    generate_executive_summary,
-    format_change_summary,
-    write_report,
-    load_monitoring_config,
-    validate_config,
-    DEFAULT_CONFIG_PATH,
     CLASSIFICATION_CRITICAL,
     CLASSIFICATION_HIGH,
     CLASSIFICATION_MEDIUM,
     CLASSIFICATION_NOISE,
+    DEFAULT_CONFIG_PATH,
+    compute_hash,
+    fetch_page,
+    generate_executive_summary,
+    generate_report_header,
+    get_source_state,
+    load_monitoring_config,
+    load_state,
+    save_state_atomic,
+    set_source_state,
+    validate_config,
+    write_report,
 )
 
 try:
@@ -513,8 +511,6 @@ def generate_regulatory_report(
         lines.append("|---|--------|--------|----------------|-------------------|--------|\n")
 
         for i, item in enumerate(priority_items, 1):
-            # Shorten URL for table
-            url_short = item.title[:40] + "..." if len(item.title) > 40 else item.title
             controls = ", ".join(item.affected_controls) if item.affected_controls else "None identified"
             action = "Review and update framework" if item.classification == CLASSIFICATION_CRITICAL else "Review"
 
@@ -539,7 +535,7 @@ def generate_regulatory_report(
                 lines.append(f"- **Abstract:** {item.abstract[:500]}{'...' if len(item.abstract) > 500 else ''}\n")
 
             if item.affected_controls:
-                lines.append(f"- **Potentially Affected Controls:**\n")
+                lines.append("- **Potentially Affected Controls:**\n")
                 for control in item.affected_controls:
                     lines.append(f"  - Control {control}\n")
 
@@ -682,7 +678,7 @@ def main():
         since_date = fed_state.get('last_checked')
         if not since_date:
             since_date = (datetime.now(timezone.utc) - timedelta(days=30)).strftime('%Y-%m-%d')
-            logger.info(f"No prior state, fetching documents from last 30 days")
+            logger.info("No prior state, fetching documents from last 30 days")
         else:
             logger.info(f"Fetching documents since {since_date}")
 

--- a/scripts/remediate_agent_sharing.py
+++ b/scripts/remediate_agent_sharing.py
@@ -53,8 +53,6 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from dateutil import parser as dateparser
-
 from asard_zone_rules import (
     check_agent_compliance,
     classify_environment_zone,
@@ -63,6 +61,7 @@ from asard_zone_rules import (
 )
 from bap_admin_client import BAPAdminClient
 from caa_client import CAAClient
+from dateutil import parser as dateparser
 
 # =========================================================================
 # Module constants
@@ -462,7 +461,7 @@ def update_compliance_record(
         entity_set = "fsi_agentsharingcompliances"
         alternate_key = f"fsi_agent_id='{agent_id}',fsi_environment_id='{environment_id}'"
         
-        result = dataverse_client.upsert_record(
+        dataverse_client.upsert_record(
             entity_set=entity_set,
             alternate_key=alternate_key,
             data=payload,

--- a/scripts/test_asard_zone_rules.py
+++ b/scripts/test_asard_zone_rules.py
@@ -10,16 +10,14 @@ requiring a live Dataverse connection.
 from __future__ import annotations
 
 import json
-import pytest
 
 from asard_zone_rules import (
     ZONE_SHARING_RULES,
+    check_agent_compliance,
     classify_environment_zone,
     evaluate_zone_compliance,
     parse_sharing_principals,
-    check_agent_compliance,
 )
-
 
 # =========================================================================
 # Zone rules configuration tests

--- a/scripts/test_bap_admin_client.py
+++ b/scripts/test_bap_admin_client.py
@@ -1,12 +1,9 @@
 """Unit tests for BAPAdminClient."""
 
-import json
 from unittest import mock
 
 import pytest
-
 from bap_admin_client import BAPAdminClient
-
 
 # =========================================================================
 # Test fixtures

--- a/scripts/test_detect_agent_sharing_violations.py
+++ b/scripts/test_detect_agent_sharing_violations.py
@@ -20,9 +20,6 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
-import pytest
-import requests
-
 # Import functions under test
 from detect_agent_sharing_violations import (
     _map_compliance_status_to_optionset,
@@ -32,7 +29,6 @@ from detect_agent_sharing_violations import (
     upsert_compliance_record,
     write_compliance_results_to_dataverse,
 )
-
 
 # =========================================================================
 # Test: Violation type mapping

--- a/scripts/test_remediate_agent_sharing.py
+++ b/scripts/test_remediate_agent_sharing.py
@@ -1,17 +1,14 @@
 """Unit tests for remediate_agent_sharing.py."""
 
-import json
 from unittest import mock
 
 import pytest
-
 from remediate_agent_sharing import (
     build_permission_object,
     get_zone_remediation_principals,
-    validate_remediation,
     update_compliance_record,
+    validate_remediation,
 )
-
 
 # =========================================================================
 # Test fixtures
@@ -471,9 +468,8 @@ def test_remediate_agent_single_agent_mode():
 
 def test_remediate_agent_skips_active_exception():
     """Test that remediate_agent skips agents with active exceptions."""
-    from datetime import datetime, timezone
-    from unittest import mock
     import argparse
+    from unittest import mock
     
     # Mock clients
     mock_bap_client = mock.MagicMock()
@@ -526,9 +522,8 @@ def test_remediate_agent_skips_active_exception():
 
 def test_remediate_agent_proceeds_with_expired_exception():
     """Test that remediate_agent proceeds when exception is expired."""
-    from datetime import datetime, timezone
-    from unittest import mock
     import argparse
+    from unittest import mock
     
     # Mock clients
     mock_bap_client = mock.MagicMock()
@@ -602,9 +597,8 @@ def test_remediate_agent_proceeds_with_expired_exception():
 
 def test_remediate_agent_proceeds_with_no_exception():
     """Test that remediate_agent proceeds normally when no exception exists."""
-    from datetime import datetime, timezone
-    from unittest import mock
     import argparse
+    from unittest import mock
     
     # Mock clients
     mock_bap_client = mock.MagicMock()

--- a/scripts/update_excel_templates.py
+++ b/scripts/update_excel_templates.py
@@ -13,12 +13,11 @@ Usage:
 Author: Claude Code
 """
 
-import os
-import sys
 import argparse
+import sys
 from pathlib import Path
+
 from openpyxl import load_workbook
-from openpyxl.styles import Font, Alignment, Border, Side, PatternFill
 
 # All 78 controls in the framework
 ALL_CONTROLS = {
@@ -336,7 +335,7 @@ def main():
     project_root = script_dir.parent
     downloads_dir = project_root / "docs" / "downloads"
 
-    print(f"FSI-AgentGov Excel Template Update Script")
+    print("FSI-AgentGov Excel Template Update Script")
     print(f"{'='*80}")
     print(f"Mode: {'DRY RUN (preview only)' if dry_run else 'APPLYING CHANGES'}")
     print(f"Downloads dir: {downloads_dir}")
@@ -345,7 +344,7 @@ def main():
     excel_files = list(downloads_dir.glob("*.xlsx"))
 
     if not excel_files:
-        print(f"\n[ERROR] No Excel files found")
+        print("\n[ERROR] No Excel files found")
         return 1
 
     print(f"\nFound {len(excel_files)} Excel file(s)")
@@ -373,7 +372,7 @@ def main():
                     print(f"   {vc['cell_ref']}: Updated to '{vc.get('new_value', 'v1.3.0')}'")
             file_changes["version_updates"] = version_cells
         else:
-            print(f"\n[VERSION] No version references to update")
+            print("\n[VERSION] No version references to update")
 
         # 2. For governance-maturity-dashboard.xlsx, check for missing controls
         if filename == "governance-maturity-dashboard.xlsx":
@@ -391,7 +390,7 @@ def main():
                         print(f"\n[CONTROLS] Added {len(added)} control(s) to spreadsheet")
                         file_changes["added_controls"] = added
             else:
-                print(f"\n[CONTROLS] All 78 controls present")
+                print("\n[CONTROLS] All 78 controls present")
 
             if extra:
                 print(f"\n[WARN] Found {len(extra)} unexpected control ID(s): {extra}")
@@ -399,7 +398,7 @@ def main():
             # Check summary count
             count_cells = update_summary_count(excel_file, dry_run=dry_run)
             if count_cells:
-                print(f"\n[SUMMARY] Found count cells to update:")
+                print("\n[SUMMARY] Found count cells to update:")
                 for cc in count_cells:
                     print(f"   {cc['cell_ref']}: '{cc['current_value']}'")
 
@@ -408,7 +407,7 @@ def main():
 
     # Summary
     print(f"\n{'='*80}")
-    print(f"SUMMARY")
+    print("SUMMARY")
     print(f"{'='*80}")
 
     if all_changes:
@@ -416,18 +415,18 @@ def main():
         total_missing = sum(len(c["missing_controls"]) for c in all_changes.values())
 
         if dry_run:
-            print(f"\nChanges to apply:")
+            print("\nChanges to apply:")
             print(f"   - {total_version} version reference(s) to update")
             print(f"   - {total_missing} missing control(s) to add")
-            print(f"\nRun with --update to apply these changes")
+            print("\nRun with --update to apply these changes")
         else:
-            print(f"\nChanges applied:")
+            print("\nChanges applied:")
             print(f"   - {total_version} version reference(s) updated")
             total_added = sum(len(c["added_controls"]) for c in all_changes.values())
             print(f"   - {total_added} control(s) added")
-            print(f"\n[OK] All Excel files updated successfully!")
+            print("\n[OK] All Excel files updated successfully!")
     else:
-        print(f"\n[OK] No changes needed - all files are up to date")
+        print("\n[OK] No changes needed - all files are up to date")
 
     return 0
 

--- a/scripts/verify_controls.py
+++ b/scripts/verify_controls.py
@@ -1,4 +1,3 @@
-import os
 import re
 import subprocess
 import sys
@@ -27,7 +26,7 @@ def _accepted_update_dates(lookback_months=3):
     today = date.today()
     dates = []
     first_of_month = today.replace(day=1)
-    for i in range(lookback_months):
+    for _i in range(lookback_months):
         label = f"Updated: {first_of_month.strftime('%B %Y')}"
         if label not in dates:
             dates.append(label)
@@ -181,7 +180,7 @@ def verify_consistency():
     missing_files = []
     for cid in controls:
         found = False
-        for filename, rel_path, pillar in files:
+        for filename, _rel_path, _pillar in files:
             # Match control ID at start of filename (e.g., "1.1-" matches "1.1")
             if filename.startswith(f"{cid}-"):
                 found = True
@@ -197,7 +196,7 @@ def verify_consistency():
     # 3. Validate control content (structure + beta metadata)
     print("\n--- CONTROL CONTENT VALIDATION ---\n")
     hard_failures = 0
-    for filename, rel_path, pillar in files:
+    for _filename, rel_path, _pillar in files:
         # rel_path already includes reference/... relative to docs
         full_path = DOCS_DIR / rel_path
         if not full_path.exists():
@@ -219,7 +218,7 @@ def verify_consistency():
     # 3b) Validate playbook files exist per control
     print("\n--- PLAYBOOK FILE VALIDATION ---\n")
     playbook_failures = 0
-    for filename, rel_path, pillar in files:
+    for filename, _rel_path, _pillar in files:
         # Extract control ID from filename (e.g., "1.1-restrict-agent-publishing.md" -> "1.1")
         match = re.match(r"^(\d+\.\d+)-", filename)
         if not match:

--- a/scripts/verify_excel_templates.py
+++ b/scripts/verify_excel_templates.py
@@ -16,6 +16,7 @@ import os
 import sys
 import zipfile
 from pathlib import Path
+
 from openpyxl import load_workbook
 
 # Expected control counts per template
@@ -51,8 +52,8 @@ def verify_excel_file(file_path):
             "[FAIL] File is not valid OOXML (.xlsx) format — appears to be DRM-encrypted (OLE2 container). "
             "Remove the sensitivity label in Excel and re-save as .xlsx to fix."
         )
-        print(f"[FAIL] DRM-encrypted OLE2 format detected — not readable as .xlsx")
-        print(f"   Fix: Open in Excel → File → Info → Remove sensitivity label → Save As .xlsx")
+        print("[FAIL] DRM-encrypted OLE2 format detected — not readable as .xlsx")
+        print("   Fix: Open in Excel → File → Info → Remove sensitivity label → Save As .xlsx")
         return issues
 
     try:
@@ -96,12 +97,12 @@ def verify_excel_file(file_path):
 
         # Show breakdown by sheet
         if control_breakdown:
-            print(f"\n   Control breakdown by sheet:")
+            print("\n   Control breakdown by sheet:")
             for sheet_name, count in control_breakdown.items():
                 print(f"   - {sheet_name}: {count} controls")
 
         # Search for stale content patterns
-        print(f"\n   Checking for stale content...")
+        print("\n   Checking for stale content...")
         stale_findings = {pattern: [] for pattern in STALE_PATTERNS.keys()}
 
         for sheet_name in wb.sheetnames:
@@ -112,7 +113,7 @@ def verify_excel_file(file_path):
                     if cell_value is not None:
                         cell_str = str(cell_value).lower()
 
-                        for pattern, description in STALE_PATTERNS.items():
+                        for pattern, _description in STALE_PATTERNS.items():
                             if pattern.lower() in cell_str:
                                 col_letter = chr(64 + col_idx)  # Convert to A, B, C...
                                 stale_findings[pattern].append({
@@ -135,7 +136,7 @@ def verify_excel_file(file_path):
                     print(f"      ... and {len(findings) - 5} more")
 
         if not stale_found:
-            print(f"   [PASS] No stale content patterns found")
+            print("   [PASS] No stale content patterns found")
 
         wb.close()
 
@@ -153,7 +154,7 @@ def main():
     project_root = script_dir.parent
     downloads_dir = project_root / "docs" / "downloads"
 
-    print(f"FSI-AgentGov Excel Template Verification")
+    print("FSI-AgentGov Excel Template Verification")
     print(f"{'='*80}")
     print(f"Project root: {project_root}")
     print(f"Downloads dir: {downloads_dir}")
@@ -180,7 +181,7 @@ def main():
 
     # Summary report
     print(f"\n{'='*80}")
-    print(f"VERIFICATION SUMMARY")
+    print("VERIFICATION SUMMARY")
     print(f"{'='*80}")
 
     if all_issues:
@@ -192,9 +193,9 @@ def main():
             print()
         return 1
     else:
-        print(f"\n[PASS] All Excel files passed verification!")
-        print(f"   - Control counts correct")
-        print(f"   - No stale content found")
+        print("\n[PASS] All Excel files passed verification!")
+        print("   - Control counts correct")
+        print("   - No stale content found")
         return 0
 
 if __name__ == "__main__":

--- a/scripts/verify_templates.py
+++ b/scripts/verify_templates.py
@@ -1,6 +1,5 @@
-from pathlib import Path
-import os
 import sys
+from pathlib import Path
 
 # Fix Unicode encoding issues on Windows
 if sys.platform == 'win32':


### PR DESCRIPTION
Repository hardening pass in response to an external critique of FSI-AgentGov and FSI-AgentGov-Solutions. No framework feature changes; this is governance/CI/release-hygiene work plus aligned documentation.

## Waves

### Wave 1 - Evaluator transparency, Solutions Contract, hook fix
- Every check, control, and summary in `assessment-prefilled.md` and `assessment-summary.json` now carries an `evaluator_state` (`auto_evaluable` / `manual_only` / `unimplemented_evaluator`).
- New generated [Assessment Engine Coverage matrix](docs/reference/assessment-coverage.md) reports honest coverage across all 78 controls (1 auto / 38 unimplemented / 39 manual at landing) and flags 8 evaluators that are dead code due to manifest pass-condition drift.
- New [Solutions Contract](docs/reference/solutions-contract.md) tells FSI-AgentGov-Solutions to pin to framework release tags rather than `main`.
- `.claude/settings.json` hooks now use `$CLAUDE_PROJECT_DIR` instead of absolute `C:/dev/...` paths.

### Wave 2 - CI quality gates
- `python-quality.yml`, `powershell-quality.yml`, `secret-scanning.yml` workflows added.
- 96 ruff auto-fixes + 19 manual; 1 PSSA error suppressed with justification; 2 FSI language-rule violations fixed.

### Wave 3 - Release hygiene
- `codeql.yml`, `dependency-review.yml`, `release-artifacts.yml` workflows added (Sigstore-signed CycloneDX SBOMs on tag).
- `SECURITY.md` rewritten (~140 lines).
- New [Versioning and Support policy](docs/reference/versioning-and-support.md).

### Wave 4 - Documentation alignment
- `README.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `.claude/claude.md` updated with new validation commands and CI workflow table.
- `CHANGELOG-v1.4.md` Maintenance entry for April 30, 2026.

## Validation

All gates green at the rebased tip: `mkdocs build --strict`, `pytest assessment/tests` (26/26), `ruff check assessment scripts`, `check_manifest_doc_drift --check`, `generate_coverage_matrix --check`, `verify_language_rules.py` (752 docs), `verify_controls.py`.

## Out of scope

- Bespoke evaluators for the 38 `unimplemented_evaluator` controls (transparency-first stance).
- Changes in `FSI-AgentGov-Solutions`.