### PR TITLE
chore(ci): sync remaining action versions after dependabot bumps

### DIFF
--- a/.github/workflows/prod-smoke-scheduled.yml
+++ b/.github/workflows/prod-smoke-scheduled.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with: { node-version: '20' }
       - name: Install Node deps
         run: npm ci
@@ -92,7 +92,7 @@ jobs:
           PROD_URL: ${{ github.event.inputs.target_url || 'https://judeper.github.io/FSI-AgentGov/' }}
       - name: Upload trace on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: prod-smoke-scheduled-traces-${{ github.run_id }}
           path: test-results/

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -43,7 +43,7 @@ jobs:
           mkdir -p sbom
           cyclonedx-py environment -o sbom/python.cdx.json
           echo "path=sbom/python.cdx.json" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sbom-python
           path: sbom/python.cdx.json
@@ -58,7 +58,7 @@ jobs:
           node-version: '20'
       - run: npm ci --no-audit --no-fund
       - run: npx --yes @cyclonedx/cyclonedx-npm --output-file sbom/npm.cdx.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sbom-npm
           path: sbom/npm.cdx.json


### PR DESCRIPTION
Three workflows still had `upload-artifact@v4` / `setup-node@v4` after the dependabot wave (PRs #154/#156/#157/#177/#178). Dependabot didn't catch them (likely because the workflow files were added after the PRs opened, or scoping mismatch).

## Why it matters

Most notable: `release-artifacts.yml` had `upload-artifact@v4` and `download-artifact@v8` in the same job. The artifact API has been stable since v4 so this works, but it's gross and a potential footgun.

## Changes

- `release-artifacts.yml`: `upload-artifact@v4` → `@v7` (lines 46, 61) — eliminates intra-job version skew with `download-artifact@v8`.
- `prod-smoke-scheduled.yml`: `setup-node@v4` → `@v6`, `upload-artifact@v4` → `@v7`.
- `prod-smoke.yml`: `setup-node@v4` → `@v6`.

## Risk

Low. Same inputs work in v6/v7. All other workflows (e2e, e2e-smoke, update-snapshots, sri-check, spa-tests, learn-monitor, link-check, publish_docs, python-quality, regulatory-monitoring) are already on v6/v7 and have green runs at HEAD.