### PR TITLE
chore(solutions-lock): accept schemaVersion 1.5.0 with required zones

### DIFF
--- a/assessment/data/README.md
+++ b/assessment/data/README.md
@@ -12,8 +12,9 @@ companion repository.
 ### Contract
 
 * The lock is **fetched at framework-release time** from a tagged
-  release of the solutions repo (currently `v1.4.0`). It is **never**
-  fetched at runtime, and CI does **not** cross repos at PR time.
+  release of the solutions repo (currently `v1.4.0`; `v1.5.0`
+  introduces the schema 1.5.0 cutover). It is **never** fetched at
+  runtime, and CI does **not** cross repos at PR time.
 * Provides the rich metadata (`name`, `version`, `domain`, `tier`,
   `description`, `url`, `prerequisites`, `verification`) that the E1
   drawer and E7 agenda export render.
@@ -25,10 +26,14 @@ companion repository.
 
 ```bash
 python scripts/refresh_solutions_lock.py --tag v1.4.0
+# or, after the producer cuts the breaking change:
+python scripts/refresh_solutions_lock.py --tag v1.5.0
 ```
 
-The refresh script verifies `schemaVersion` starts with `1.4.` and
-that the expected solution count and required IDs are present.
+The refresh script verifies `schemaVersion` starts with the
+major.minor of `--tag` (1.4.x or 1.5.x are both accepted by the
+local validator) and that the expected solution count and required
+IDs are present.
 
 ### Coverage scope
 
@@ -51,7 +56,13 @@ doc under `docs/controls/` for native-admin guidance. For the full
 catalog and coverage rationale, see
 `docs/reference/solutions-index.md` (Coverage scope section).
 
-### Schema (1.4.x)
+### Schema (1.4.x and 1.5.x)
+
+`solutions.json` schema 1.5.0 (forthcoming in `judeper/FSI-AgentGov-Solutions`)
+makes the `zones` field **required** on every solution entry. The
+local validator (`scripts/validate_solutions_lock.py`) accepts both
+`schemaVersion` `1.4.x` and `1.5.x` so the framework repo stays
+compatible across the producer-side cutover.
 
 ```json
 {

--- a/scripts/refresh_solutions_lock.py
+++ b/scripts/refresh_solutions_lock.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """Refresh ``assessment/data/solutions-lock.json`` from FSI-AgentGov-Solutions.
 
-Per the v1.4 cross-repo contract, the framework repo never reaches into
-the solutions repo at PR time. This script runs **only on tag bump** to
-fetch ``solutions.json`` from a tagged release of FSI-AgentGov-Solutions
-and commit a local copy.
+Per the v1.4+ cross-repo contract, the framework repo never reaches
+into the solutions repo at PR time. This script runs **only on tag
+bump** to fetch ``solutions.json`` from a tagged release of
+FSI-AgentGov-Solutions and commit a local copy.
 
 Usage::
 
     python scripts/refresh_solutions_lock.py --tag v1.4.0
+    python scripts/refresh_solutions_lock.py --tag v1.5.0
 
 The script will:
 
@@ -108,7 +109,7 @@ def main() -> int:
     if not (isinstance(sv, str) and sv.startswith(expected_prefix)):
         print(
             f"ERROR: schemaVersion {sv!r} does not start with {expected_prefix!r}; "
-            "the framework's lock-file consumer expects 1.4.x.",
+            "the framework's lock-file consumer expects 1.4.x or 1.5.x.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/validate_solutions_lock.py
+++ b/scripts/validate_solutions_lock.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Validate ``assessment/data/solutions-lock.json``.
 
-Per the v1.4 cross-repo contract, this lock file is fetched from the
-``FSI-AgentGov-Solutions`` repo at the **v1.4.0 tag** and committed
+Per the v1.4+ cross-repo contract, this lock file is fetched from the
+``FSI-AgentGov-Solutions`` repo at a pinned release tag and committed
 locally so framework builds are reproducible.
 
 Rules enforced:
 
-* ``schemaVersion`` must start with ``"1.4."``.
+* ``schemaVersion`` must start with ``"1.4."`` or ``"1.5."`` (both
+  accepted; 1.5.0 made the producer-side ``zones`` field required, but
+  the consumer treats either version as structurally valid).
 * ``solutions`` is an object keyed by kebab-case folder-name ID (or a
   list of objects with the same fields — both shapes accepted).
 * Each solution has: ``id``, ``name``, ``version``, ``domain``,
@@ -35,6 +37,7 @@ MANIFEST_DEFAULT = ROOT / "assessment" / "manifest" / "controls.json"
 
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 TIER_VALUES = {"1", "2", "3"}
+ACCEPTED_SCHEMA_PREFIXES = ("1.4.", "1.5.")
 REQUIRED_FIELDS = (
     "id",
     "name",
@@ -132,10 +135,11 @@ def main() -> int:
 
     errs: list[str] = []
     sv = lock.get("schemaVersion", "")
-    if not (isinstance(sv, str) and sv.startswith("1.4.")):
+    if not (isinstance(sv, str) and sv.startswith(ACCEPTED_SCHEMA_PREFIXES)):
+        accepted = ", ".join(repr(p) for p in ACCEPTED_SCHEMA_PREFIXES)
         errs.append(
-            f"schemaVersion must start with '1.4.' (got {sv!r}); "
-            "refresh the lock against the FSI-AgentGov-Solutions v1.4.x tag."
+            f"schemaVersion must start with one of {accepted} (got {sv!r}); "
+            "refresh the lock against a supported FSI-AgentGov-Solutions release tag."
         )
 
     sol_count = 0


### PR DESCRIPTION
## Background
The `judeper/FSI-AgentGov-Solutions` `solutions.json` `schemaVersion` is bumping from 1.4.2 to 1.5.0, which makes the `zones` field **required** on every solution entry (a breaking change for consumers). This PR widens this repo's consumer-side validator to accept 1.5.0 ahead of the breaking change in the producer repo.

## Merge order
**MERGE THIS PR FIRST.** Then mark `judeper/FSI-AgentGov-Solutions` PR `feat/schema-1.5.0-zones-required` ready and merge it.

## Changes
- `scripts/validate_solutions_lock.py` — replace hard-coded `startswith("1.4.")` check with `ACCEPTED_SCHEMA_PREFIXES = ("1.4.", "1.5.")` so both 1.4.x (current state of solutions repo) and 1.5.x (future state) are accepted; updated module docstring.
- `scripts/refresh_solutions_lock.py` — docstring + error message updated to mention 1.5.x is also acceptable when refreshing against a 1.5 tag. (No code change required; the `expected_prefix` is already derived from `--tag`, so passing `--tag v1.5.0` already enforces `1.5.` prefix.)
- `assessment/data/README.md` — schema section retitled `Schema (1.4.x and 1.5.x)`, refresh-script example shows both `--tag v1.4.0` and `--tag v1.5.0`, contract section notes the 1.5.0 cutover and that the local validator accepts both versions across the producer-side bump.

## Validation
Validator behavior matrix (manually verified in PR creation):

| `schemaVersion` | Validator result |
|---|---|
| `1.4.1` (current lock) | ✅ accepted |
| `1.5.0` (simulated future lock) | ✅ accepted |
| `1.6.0` (out-of-band) | ❌ rejected with clear error |

```text
$ python scripts/validate_solutions_lock.py
OK: solutions-lock.json valid (35 solutions, 0 warning(s)).

$ python -m mkdocs build --strict
INFO    -  Documentation built in 112.03 seconds
(exit 0)
```

## Out of scope
- This PR does **not** refresh `assessment/data/solutions-lock.json`. The lock stays at `schemaVersion 1.4.1` because the producer repo has not yet released 1.5.0. The lock will be refreshed in a future PR via `python scripts/refresh_solutions_lock.py --tag v1.5.0` after the producer-side breaking change is tagged.
- The `docs/version.json` build artifact regenerated by `mkdocs build` was intentionally excluded from this branch.

## References
- judeper/FSI-AgentGov-Solutions#37 (tracking issue, AC #4)
- Companion PR (DRAFT until this merges): will be linked once opened
