### PR TITLE
fix(controls 3.2/2.5/2.6/2.9/3.10): Copilot Studio analytics retention + 7-area effectiveness restructure (#206)

### DIFF
--- a/docs/controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md
+++ b/docs/controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md
@@ -137,6 +137,9 @@ For higher-risk use cases, the validation record should go beyond functional pas
 !!! note "Read-only Analytics Access for Validators and Supervisors"
     Independent validators (Model Risk Manager) and Designated Supervisors frequently need to review post-deployment quality and drift signals on the Copilot Studio Analytics page without being granted edit rights on the agent. The Copilot Studio **Analytics Viewer** sharing role helps meet this separation-of-duties requirement by granting read-only access to the agent's Analytics page; pair it with the **Bot Transcript Viewer** role to also expose conversation transcripts used as testing and supervisory evidence. The role is shared by the agent owner via the agent's three-dots menu → **Share** → **Analytics viewer** and **must be assigned to individual users — security groups are not supported**, so maintain a named-individual attestation list to support FINRA 3110 and OCC 2011-12 evidence trails. See [Share an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-share-bots).
 
+!!! info "Copilot Studio Analytics Retention Windows (May 2026)"
+    Per Microsoft Learn, analytics data is available for up to **180 days**; session details and transcript information is available for the last **28 days**. Validation evidence, transcript records, and testing artifacts required beyond these windows must be exported and stored in a retention-bound location (Purview retention, Log Analytics, or a zone-appropriate WORM store) before expiry. For Zone 3 evidence packs, schedule automated export before the 28-day session-data window closes.
+
 ---
 
 ## Related Controls

--- a/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md
+++ b/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md
@@ -125,6 +125,9 @@ SR 11-7 sets three validation pillars: **conceptual soundness**, **ongoing monit
 | Ongoing monitoring | **Copilot Studio Analytics** (conversational and autonomous-agent metrics) + **Azure AI Foundry monitoring** (when underlying model is on Foundry) + **Application Insights / Azure Monitor** + DSPM for AI interaction reports | KPI drift, exception rate, sensitive-prompt rate, sentiment, customer-comment summaries | Quarterly monitoring report to MRM Committee; threshold breaches feed Control 3.4 incident workflow |
 | Outcomes analysis | **Azure AI Foundry built-in evaluators** (groundedness, relevance, coherence, fluency; safety: hate/unfairness, violence, protected materials; agent-specific: tool-call accuracy, task completion) + Copilot Studio test panel + custom evaluators | Quantitative quality / safety / agent-behavior scores against an evaluation dataset | Periodic re-validation evidence; effective-challenge inputs |
 
+!!! info "Copilot Studio Analytics Retention Windows (May 2026)"
+    Analytics data is available for up to **180 days**; session details and transcript information is available for the last **28 days** (per Microsoft Learn). Ongoing-monitoring evidence — session-level data, conversation transcripts — required beyond 28 days must be exported to Log Analytics or a WORM-capable store before expiry. Validation memos and MRM Committee minutes do not live in Copilot Studio Analytics; route those to the 17a-4(f) retention path described in the [Control 2.6 portal walkthrough §6](../../playbooks/control-implementations/2.6/portal-walkthrough.md#6-validation-evidence-retention-path).
+
 In addition:
 
 - **Manifest / solution version control** — use Power Platform solution export/import and Application Lifecycle Management pipelines for point-in-time reconstruction of agent configuration. Pair with [Control 2.3 (Change Management)](2.3-change-management-and-release-planning.md).
@@ -262,7 +265,7 @@ Confirm control effectiveness by verifying:
 - [FFIEC IT Examination Handbook](https://ithandbook.ffiec.gov/)
 - [FINRA Regulatory Notice 25-07 — Use of Artificial Intelligence (RFC)](https://www.finra.org/rules-guidance/notices/25-07)
 
-**Microsoft Learn — surfaces this control depends on (verified April 2026)**
+**Microsoft Learn — surfaces this control depends on (verified May 2026)**
 
 - [Microsoft Purview — protections for AI (DSPM for AI)](https://learn.microsoft.com/en-us/purview/ai-microsoft-purview)
 - [Microsoft Foundry — evaluation of generative AI applications](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-approach-gen-ai)
@@ -275,4 +278,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.4.0 | UI Verification Status: Current*

--- a/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md
+++ b/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md
@@ -153,6 +153,9 @@ Confirm control effectiveness by verifying:
 
 ### Built-In Analytics (All Zones)
 
+!!! info "Copilot Studio Analytics Retention Windows (May 2026)"
+    Analytics data is available for up to **180 days**; session details and transcript information is available for the last **28 days** (per Microsoft Learn). For performance monitoring records required beyond these windows — KPI trend data, session transcripts, RAI event logs — configure export to Log Analytics, Azure Data Lake, or a zone-appropriate retention store before the applicable window closes. See [Control 3.2](../pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md) for export pipeline options.
+
 1. Analytics data flows to Power Platform Admin Center reports
 2. Power BI dashboard displays current metrics with working drill-down
 3. Test alert triggers notification when threshold temporarily lowered
@@ -183,4 +186,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.4.0 | UI Verification Status: Current*

--- a/docs/controls/pillar-3-reporting/3.10-hallucination-feedback-loop.md
+++ b/docs/controls/pillar-3-reporting/3.10-hallucination-feedback-loop.md
@@ -72,6 +72,9 @@ Since automated detection is not available, organizations should implement proac
 | **Application Insights** | Yes | Custom telemetry | Detailed conversation analysis |
 | **Conversation Transcript** | Yes | Dataverse | Full context for RCA |
 
+!!! info "Copilot Studio Analytics Retention Windows (May 2026)"
+    Analytics data (including CSAT feedback signals) is available for up to **180 days**; session details and transcript information is available for the last **28 days** (per Microsoft Learn). Hallucination tracking records, flagged-session transcripts, and remediation evidence required beyond 28 days must be exported to SharePoint/Dataverse or a retention-bound store before the session window closes. The 28-day limit is especially relevant for root-cause analysis workflows that depend on transcript review.
+
 ---
 
 ## Zone-Specific Requirements
@@ -145,4 +148,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.4.0 | UI Verification Status: Current*

--- a/docs/controls/pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md
+++ b/docs/controls/pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md
@@ -59,6 +59,7 @@ Microsoft has expanded analytics capabilities significantly:
 !!! info "Data Availability"
     - **DAU/MAU metrics** require user authentication; anonymous usage is not tracked
     - **Native retention** for PPAC analytics is 28 days; export to Log Analytics for extended retention
+    - **Copilot Studio Analytics retention (May 2026):** analytics data is available for up to **180 days**; session details and transcript information is available for the last **28 days** (per [Microsoft Learn — analytics overview](https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-overview)). Export conversation transcripts and session-level evidence to Log Analytics or a retention-bound store before the 28-day session window closes for any sessions requiring regulatory preservation.
     - **Settings changes** may take up to 8 hours to reflect in dashboards
 
 ### Custom Power BI Analytics Infrastructure

--- a/docs/playbooks/control-implementations/2.5/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/2.5/portal-walkthrough.md
@@ -816,6 +816,35 @@ To grant read-only analytics access:
 - Share an agent — <https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-share-bots>
 - Analytics overview — <https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-overview>
 
+### 9.8 Agent effectiveness: 7-area review (May 2026 update)
+
+Microsoft Copilot Studio Analytics provides **seven core areas** for reviewing and improving conversational agent effectiveness (updated May 2026; previously six areas). Plane 5 monitoring should include a periodic sweep of the **Analyze effectiveness** page to detect gaps across all seven areas.
+
+**Portal path:** Copilot Studio → agent → **Analytics** → navigate to the effectiveness analysis section (exact tab label may vary by release wave — anchor on page title and consult [Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-improve-agent-effectiveness)).
+
+The seven core areas are:
+
+1. **Themes** — Clusters user questions into AI-suggested categories to surface high-volume and emerging intents.
+2. **Conversation outcomes** — Shows the end result of each session (Resolved, Escalated, Abandoned, Unengaged) to identify where the agent is succeeding and where coverage gaps exist.
+3. **Agents** — Displays call volume metrics, success rates, and current status for child and connected agents.
+4. **Generated answer rate and quality** — Surfaces when the agent struggles to answer user questions and how it uses knowledge sources to help improve answer rate and quality.
+5. **Tool use** — Learning how often tools are used and how often they succeed can help you understand if those tools are useful and successful for users.
+6. **Effectiveness** — Reviewing user feedback helps you identify new user scenarios and issues, and making improvements based directly on what your users are asking for.
+7. **Knowledge source use** *(added May 2026)* — Learning how often individual knowledge sources are used and how often they return errors helps you improve the quality and coverage of your agent's answers.
+
+!!! note "FSI monitoring signal — Knowledge source use (area 7)"
+    The **Knowledge source use** panel is particularly relevant for RAG-grounded agents in FSI use cases. Rising knowledge-source error rates can indicate stale, unavailable, or misconfigured sources — a signal that should feed the re-validation trigger logic in §9.5 and the knowledge-source integrity checks in [Control 2.16](../../../controls/pillar-2-management/2.16-rag-source-integrity-validation.md). Document knowledge-source error rate baselines in the zone threshold file (`tests/zone-thresholds.json`, PRE-06) and configure threshold alerts.
+
+!!! info "Analytics data retention (May 2026)"
+    Analytics data is available for up to **180 days**; session details and transcript information is available for the last **28 days** (per Microsoft Learn). Export flagged-session transcripts and quality snapshots to the Evidence Pack or a retention-bound store before the 28-day session window closes, especially for Zone 3 sessions subject to regulatory examination.
+
+**Inline references for §9.8:**
+
+- Analyze conversational agent effectiveness — <https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-improve-agent-effectiveness>
+- Analytics overview — <https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-overview>
+
+**Cross-links:** [Control 2.16](../../../controls/pillar-2-management/2.16-rag-source-integrity-validation.md) (RAG source integrity), §9.5 (re-validation triggers)
+
 ---
 
 ## §10. Microsoft 365 Agents Toolkit — local sideload and manifest validation

--- a/docs/playbooks/control-implementations/2.6/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/2.6/portal-walkthrough.md
@@ -225,6 +225,9 @@ SR 11-7 ongoing monitoring asks whether the model continues to perform as intend
 5. Name a **threshold-breach owner** (typically the Agent Owner with notification to the Model Risk Manager). Document the named owner on the Agent Card.
 6. Schedule a recurring monthly Analytics export per in-scope agent and route to the MRM Committee.
 
+!!! info "Copilot Studio Analytics Retention Windows (May 2026)"
+    Analytics data is available for up to **180 days**; session details and transcript information is available for the last **28 days** (per Microsoft Learn — analytics overview). Ongoing-monitoring evidence required beyond these windows — session transcripts, KPI trend snapshots, threshold-breach records — must be exported to Log Analytics or the retention path described in [§6](#6-validation-evidence-retention-path) before the applicable window closes. Validation memos and MRM Committee minutes are not stored in Copilot Studio Analytics and must be routed to the §6 retention path directly.
+
 !!! warning "Analytics is the evidence — not the validation"
     Copilot Studio Analytics produces operational telemetry. It is one input the MRM Committee uses to perform ongoing monitoring under SR 11-7. The committee's review, judgment, and effective challenge are the validation — Analytics dashboards are not.
 


### PR DESCRIPTION
Closes #206

Updates 5 controls + 2 playbooks to reflect Microsoft Learn changes (May 2026):
- Analytics retention: 180 days for analytics data, 28 days for session details/transcripts
- Effectiveness panel restructured from 6 areas to 7 (added 'Knowledge source use')

Source: reports/monitoring/learn-changes-2026-05-10.md

Files: 5 controls + 2 playbooks, +49/-4 lines. All validation gates pass.