### PR TITLE
fix(control 2.4): BCDR retention defaults + RPO/RTO surfacing from Microsoft FAQ (#208)

### DIFF
--- a/docs/controls/pillar-2-management/2.4-business-continuity-and-disaster-recovery.md
+++ b/docs/controls/pillar-2-management/2.4-business-continuity-and-disaster-recovery.md
@@ -11,8 +11,14 @@
 !!! note "Agent 365 Architecture Update"
     Agent 365 Observability supports business continuity planning by providing unified telemetry for disaster recovery testing and agent health monitoring across platforms. See [Unified Agent Governance](../../framework/agent-identity-architecture.md) for observability architecture.
 
-!!! warning "Microsoft Shared-Responsibility Boundary"
-    Microsoft does **not** publish a contractual Recovery Time Objective (RTO) or Recovery Point Objective (RPO) for Power Platform, Dataverse, or Copilot Studio. The Online Services SLA covers **availability** (financially backed 99.9%) — not recovery time after a destructive event or regional outage. Customers remain responsible for defining RTO/RPO, deploying secondary-region environments, exporting solutions and Dataverse data, and exercising failover. This control documents the customer-side controls that supplement the Microsoft platform.
+!!! warning "Microsoft Shared-Responsibility Boundary and Platform RPO/RTO Reference Points"
+    Microsoft now publishes the following platform-level reference points in the Power Platform [Business Continuity and Disaster Recovery FAQ](https://learn.microsoft.com/en-us/power-platform/admin/business-continuity-disaster-recovery) (May 2026):
+
+    - **Within-region:** The platform targets approximately near-zero RPO and a recovery time of under five minutes across availability zones and data centers within a region.
+    - **Cross-region (self-service DR):** Typical replication lag is under 15 minutes (often under five minutes); the platform is designed to complete failover within minutes once initiated. Microsoft does **not** publish a cross-region RTO commitment because customers retain control of when and whether to trigger a cross-region failover.
+    - **External integrations:** When Power Platform solutions connect to external systems (SQL Server, REST APIs, third-party services), the RPO/RTO of those integrations are governed by the availability capabilities of the respective target systems and fall outside Power Platform's resiliency commitments.
+
+    The Online Services SLA covers **availability** (financially backed 99.9%) — not recovery time after a destructive event. Customers remain responsible for defining their own firm-level RTO/RPO targets, deploying secondary-region environments, exporting solutions and Dataverse data, and exercising failover. This control documents the customer-side controls that supplement the Microsoft platform.
 
 ## Objective
 
@@ -42,7 +48,7 @@ This control applies the customer-side resilience pattern for Copilot Studio and
 | **Business Impact Analysis (BIA)** | Per-agent classification with criticality, dependencies, RTO, RPO | Required by FFIEC BCM and FINRA 4370 |
 | **Recovery Time Objective (RTO)** | Customer-defined maximum tolerable downtime | Examiner focus; not a Microsoft commitment |
 | **Recovery Point Objective (RPO)** | Customer-defined maximum tolerable data loss | Bounded by Dataverse system-backup cadence and customer export frequency |
-| **Microsoft system backups** | Automatic Dataverse backups (production: retained 28 days; sandbox: 7 days) | Baseline platform protection — does not replace customer-managed exports |
+| **Microsoft system backups** | Automatic Dataverse backups; **7-day default retention for ALL environments** (production and nonproduction); **28-day extended retention requires production Managed Environments** (configurable via PPAC or PowerShell) | Baseline platform protection — does not replace customer-managed exports |
 | **Customer-managed exports** | Solution exports, Dataverse data exports, environment variable / connection-reference snapshots | Supports cross-region recovery and meets reconstruction obligations |
 | **Secondary-region environment** | Customer-provisioned Power Platform environment in a different Azure region | Required for regional-outage scenarios; Microsoft does not auto-failover Dataverse cross-region |
 | **Agent identity continuity** | Entra app registrations, service principals, and Entra Agent IDs are tenant-scoped (global) | Survives single-region outages without re-registration; federated credentials replicate globally |
@@ -59,11 +65,11 @@ The tier table below is a starting framework. Each firm should ratify RTO / RPO 
 | **Tier 3 — Medium** | Moderate internal impact | < 24 hours | < 4 hours | Internal HR bot, IT help desk |
 | **Tier 4 — Low** | Minimal impact | < 72 hours | < 24 hours | Personal productivity agents |
 
-### Microsoft Platform Recovery Behaviors (April 2026)
+### Microsoft Platform Recovery Behaviors (May 2026)
 
 | Layer | Microsoft-managed | Customer-managed |
 |-------|-------------------|------------------|
-| **Dataverse system backup** | Continuous backup; production environments retained 28 days, sandbox 7 days | Trigger manual backups before risky changes; export to long-term storage for retention beyond 28 days |
+| **Dataverse system backup** | Continuous backup; **7-day default retention for ALL environments** (production and nonproduction); **28-day extended retention available for production Managed Environments only** | Trigger manual backups before risky changes; export to long-term storage for retention beyond the system-backup window |
 | **Dataverse restore** | In-place or to new environment within the same region (subject to capacity) | Cross-region restore is **not** a native operation — requires solution + data redeployment to a pre-provisioned secondary environment |
 | **Copy environment** | Full or minimal copy supported between environments | Use to refresh DR environment from production on a defined cadence |
 | **Reset environment** | Available for sandbox only | Not a recovery primitive for production |
@@ -76,6 +82,7 @@ The tier table below is a starting framework. Each firm should ratify RTO / RPO 
 ## Key Configuration Points
 
 - Maintain a Business Impact Analysis (BIA) covering every Zone 2 and Zone 3 agent, with assigned criticality tier, RTO, RPO, dependencies (data sources, connectors, knowledge sources, downstream systems), and named recovery owner
+- When setting firm-level RTO/RPO targets in the BIA, reference the Microsoft platform-level reference points: within a region, near-zero RPO and recovery under five minutes; for cross-region self-service DR, typical replication lag under 15 minutes with failover in minutes once initiated. Microsoft does not publish a cross-region RTO commitment — your firm must define its own thresholds. See the [Power Platform BCDR FAQ](https://learn.microsoft.com/en-us/power-platform/admin/business-continuity-disaster-recovery) for current platform figures.
 - Provision a secondary-region Power Platform environment for each production environment hosting Tier 1 or Tier 2 agents, in a different Azure region within the same regulatory geography
 - Schedule customer-managed solution exports (managed solutions) and Dataverse data exports on a cadence that meets the agent's RPO target; store exports in immutable / WORM-capable storage to support SEC 17a-4 reconstruction
 - Document and apply the same DLP, Conditional Access, and identity policies in the secondary-region environment as in production (see Controls 1.x and 2.1)
@@ -92,7 +99,7 @@ The tier table below is a starting framework. Each firm should ratify RTO / RPO 
 
 | Zone | Requirement | Rationale |
 |------|-------------|-----------|
-| **Zone 1** (Personal) | Listed in BIA only if used for any record-bearing activity. Rely on Microsoft system backups (28-day Dataverse retention). No secondary-region environment required. RTO ≤ 72 hours acceptable. | Minimal regulatory exposure; recovery cost should not exceed business impact. |
+| **Zone 1** (Personal) | Listed in BIA only if used for any record-bearing activity. Rely on Microsoft system backups (**7-day default Dataverse retention**; extended to 28 days only if the environment is a production Managed Environment). No secondary-region environment required. RTO ≤ 72 hours acceptable. | Minimal regulatory exposure; recovery cost should not exceed business impact. |
 | **Zone 2** (Team) | Mandatory BIA entry. Customer-managed solution export at least daily; weekly export retained ≥ 90 days. Warm standby in secondary region recommended for any agent supporting recordkeeping or customer interaction. RTO ≤ 4 hours; RPO ≤ 1 hour. **Annual** documented recovery exercise. | Shared agents typically participate in supervised business workflows and are in-scope for FINRA 4370 / FFIEC BCM. |
 | **Zone 3** (Enterprise) | Mandatory BIA entry with board-ratified RTO / RPO. Hot or warm standby in secondary region **required**; secondary-region environment kept current (≤ 24 hours stale) via automated sync. Solution and data exports replicated to immutable storage to support SEC 17a-4 reconstruction. RTO ≤ 1 hour; RPO ≤ 15 minutes. **Quarterly** exercise (mix of tabletop and live failover); independent assurance review at least annually per OCC Appendix D. | Customer-facing or market-facing agents; primary examiner focus area; failures may trigger Reg SCI-equivalent reporting for affected SCI entities. |
 
@@ -173,4 +180,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.4.0 | UI Verification Status: Current*

--- a/docs/images/2.4/EXPECTED.md
+++ b/docs/images/2.4/EXPECTED.md
@@ -6,8 +6,8 @@
 |----------|--------|-----------------|-----------------|
 | `01-ppac-create-environment.png` | PPAC | Environments → + New | Environment creation for DR |
 | `02-ppac-environment-type.png` | PPAC | New environment → Type | Environment type selection |
-| `03-ppac-backups.png` | PPAC | Environments → [env] → Backups | Backup list and settings |
-| `04-ppac-backup-details.png` | PPAC | Backups → [backup] | Backup details and restore option |
+| `03-ppac-backups.png` | PPAC | Environments → [env] → Backups | Backup list showing system and manual backups; confirm whether retention shows 7-day (default for all environments) or 28-day (production Managed Environments with extended retention enabled) |
+| `04-ppac-backup-details.png` | PPAC | Backups → [backup] | Backup details and restore option; verify retention window matches environment type |
 | `05-ppac-restore.png` | PPAC | Backup → Restore | Restore dialog |
 | `06-ppac-copy-environment.png` | PPAC | Environments → Copy | Environment copy for DR |
 | `07-m365-service-health.png` | M365 | Health → Service health | Service health dashboard |

--- a/docs/playbooks/control-implementations/2.4/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/2.4/portal-walkthrough.md
@@ -72,7 +72,7 @@ Cross-reference the agent inventory maintained under [Control 3.1](../../../cont
 3. Configure:
    - **Name:** `<PrimaryEnvName>-DR`
    - **Region:** the pre-approved secondary region for the primary's geography
-   - **Type:** **Production** (Tier 1 / Tier 2) or **Sandbox** (Tier 3 internal-only agents — note that sandbox retention is shorter)
+   - **Type:** **Production** (Tier 1 / Tier 2) or **Sandbox** (Tier 3 internal-only agents — note that sandbox and non-Managed production environments both default to 7-day backup retention; enable Managed Environments on production to access 28-day extended retention)
    - **Add a Dataverse data store:** **Yes**
    - **Currency / Language:** match the primary environment
    - **Security group:** apply the same restricted security group used in production
@@ -103,17 +103,18 @@ Cross-reference the agent inventory maintained under [Control 3.1](../../../cont
 1. Open the production environment in PPAC
 2. From the command bar, select **Backups**
 3. Confirm:
-   - **System backups** are listed for the past 28 days (production) or 7 days (sandbox) — these are continuous Dataverse backups created automatically
+   - **System backups** are present and current — by default backups are retained for **7 days for all environment types**; production Managed Environments with extended retention enabled show backups spanning up to **28 days**. Confirm which applies to this environment before setting RPO targets that rely on system-backup recovery.
+
    - The most recent system backup timestamp is current
 
-System backups support Microsoft-side recovery for in-region events. They restore the **entire environment**, not individual agents or solutions, and they are not portable cross-region.
+System backups support Microsoft-side recovery for in-region events. Within a region, the platform targets approximately near-zero RPO and recovery in under five minutes (per the [Power Platform BCDR FAQ](https://learn.microsoft.com/en-us/power-platform/admin/business-continuity-disaster-recovery), May 2026). System backups restore the **entire environment**, not individual agents or solutions, and are not portable cross-region.
 
 ### 3.2 Create a manual backup before any high-risk change
 
 1. From the **Backups** view select **Create**
 2. Enter a **Label** describing the change (for example, `Pre-deploy TradingAssistant 4.2.0`)
 3. Select **Create**
-4. Manual backups are retained per the published Power Platform retention policy — verify current retention against [Backup and restore environments](https://learn.microsoft.com/en-us/power-platform/admin/backup-restore-environments) before relying on a specific window
+4. Manual backups of production Managed Environments with extended retention enabled are kept up to **28 days**; all other environments retain manual backups for **7 days** by default. Verify current retention for this environment against [Backup and restore environments](https://learn.microsoft.com/en-us/power-platform/admin/backup-restore-environments) before relying on a specific window.
 
 ### 3.3 Restore drill (sandbox only — never on production without a change ticket)
 
@@ -290,4 +291,4 @@ After completing all parts, confirm:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0*
+*Updated: May 2026 | Version: v1.4.0*

--- a/docs/playbooks/control-implementations/2.4/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.4/troubleshooting.md
@@ -253,4 +253,4 @@ If issues cannot be resolved using this guide:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0*
+*Updated: May 2026 | Version: v1.4.0*


### PR DESCRIPTION
Closes #208

Updates control 2.4 to reflect Microsoft Learn changes (May 2026):
- Default backup retention: 7 days ALL environments (was: varies)
- Extended retention up to 28 days requires production Managed Environments
- Surfaces RPO/RTO from new Microsoft FAQ: within-region near-zero RPO + <5min RTO; cross-region typical lag <15min

Source: reports/monitoring/learn-changes-2026-05-10.md

Files: 1 control + 2 playbook + EXPECTED, +25/-15 lines. All validation gates pass.