### PR TITLE
fix(controls 1.8/3.7): Agent 365 license requirement for AI Agent Inventory (deadline 2026-07-01) (#209)

### DIFF
--- a/docs/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection.md
+++ b/docs/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection.md
@@ -76,7 +76,7 @@ The **Microsoft Defender - Copilot Studio AI Agents** toggle in Power Platform A
 
 | Requirement | Details |
 |-------------|---------|
-| **Licensing (one of)** | (a) Microsoft Agent 365 license, **OR** (b) Microsoft Defender for Cloud Apps license **AND** Microsoft Copilot Studio license — per [ai-agent-inventory](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-inventory) |
+| **Licensing** | **Agent 365 license** (primary — required after 2026-07-01). **Grace period until 2026-07-01:** Defender for Cloud Apps license (without Agent 365) continues to provide AI Agent Inventory access. After 2026-07-01, Defender for Cloud Apps alone will no longer provide AI Agent Inventory — Agent 365 is required. Per [ai-agent-inventory](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-inventory) |
 | **Defender preview opt-in** | Mandatory opt-in to preview features in **both** Microsoft Defender for Cloud and Microsoft Defender XDR |
 | **Roles** | Microsoft Defender XDR System Administrator (or Security Administrator) for Defender preview opt-in and portal toggle; Power Platform Administrator for the PPAC handshake. See [role catalog](../../reference/role-catalog.md). |
 | **Connector** | Microsoft 365 App Connector must be in **Connected** state in the Defender portal (Settings → Cloud apps → App connectors) |
@@ -108,7 +108,7 @@ When enabled, blocked agent actions create Defender XDR incidents that integrate
     Defender XDR alerts and `CloudAppEvents` are **operational telemetry** with product-default retention windows — they are **not** WORM and **not** the system of record for SEC 17a-4 / FINRA 4511 records-retention obligations. For books-and-records retention of agent transcripts, blocked-prompt evidence, and tool-invocation artifacts, rely on Audit Premium long-term retention (Control 1.7) and Microsoft Purview retention policies (Control 1.5). Do not present Defender alerts as books-and-records evidence.
 
 !!! warning "Licensing Consideration"
-    Defender for Cloud Apps licensing is required for all users interacting with protected agents. Verify licensing coverage before enabling for production environments.
+    **Agent 365** is the primary license for AI Agent Inventory (required after 2026-07-01). During the grace period until 2026-07-01, Defender for Cloud Apps license provides equivalent access. After 2026-07-01, organizations without Agent 365 lose AI Agent Inventory visibility. Verify licensing coverage before enabling for production environments.
 
 **Regulatory Alignment for FSI:**
 
@@ -205,6 +205,16 @@ NYDFS cybersecurity guidance emphasizes detection of AI-enabled attack technique
 4. Report AI-enabled attack attempts to security operations within 15-minute SLA (Zone 3)
 
 ---
+
+!!! danger "License deadline: 2026-07-01 — Agent 365 required for AI Agent Inventory"
+    Microsoft changed AI Agent Inventory licensing requirements (May 2026). **Agent 365** is now the primary license enabling Copilot Studio AI agent inventory and detection in Defender for Cloud Apps.
+
+    | Period | Licensing |
+    |--------|-----------|
+    | **Until 2026-07-01** (grace period) | Defender for Cloud Apps license provides AI Agent Inventory access without Agent 365 |
+    | **After 2026-07-01** | **Agent 365 required.** Defender for Cloud Apps alone no longer provides AI Agent Inventory |
+
+    Organizations without Agent 365 after 2026-07-01 **lose AI Agent Inventory visibility entirely**. Plan procurement before the deadline. Source: [AI agent inventory — Microsoft Defender for Cloud Apps](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-inventory)
 
 ## Key Configuration Points
 
@@ -429,4 +439,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.4.0 | UI Verification Status: Current*

--- a/docs/controls/pillar-3-reporting/3.7-ppac-security-posture-assessment.md
+++ b/docs/controls/pillar-3-reporting/3.7-ppac-security-posture-assessment.md
@@ -94,6 +94,16 @@ PPAC organizes proactive policies into three areas, aligned to the Security navi
 
 ---
 
+!!! danger "License deadline: 2026-07-01 — Agent 365 required for AI Agent Inventory"
+    Defender for Cloud Apps AI Agent Inventory is referenced in this control's Additional Resources and portal walkthrough (Step 8). Microsoft changed AI Agent Inventory licensing requirements (May 2026):
+
+    | Period | Licensing |
+    |--------|-----------|
+    | **Until 2026-07-01** (grace period) | Defender for Cloud Apps license provides AI Agent Inventory access without Agent 365 |
+    | **After 2026-07-01** | **Agent 365 required.** Defender for Cloud Apps alone no longer provides AI Agent Inventory |
+
+    Organizations without Agent 365 after 2026-07-01 **lose AI Agent Inventory visibility entirely**. Plan procurement before the deadline. Source: [AI agent inventory — Microsoft Defender for Cloud Apps](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-inventory)
+
 ## Key Configuration Points
 
 - Review Security Overview for top recommendations weekly
@@ -241,7 +251,7 @@ Agent 365 introduces additional security posture considerations for Blueprint-re
 
 | Capability | Description | FSI Relevance |
 |------------|-------------|---------------|
-| **AI Agent Inventory** | Defender for Cloud Apps provides visibility into deployed AI agents | Complements PPAC inventory for comprehensive coverage |
+| **AI Agent Inventory** | **Agent 365 license required after 2026-07-01.** During grace period (until 2026-07-01), Defender for Cloud Apps license provides visibility. After 2026-07-01, Agent 365 is required or inventory access is lost. | Complements PPAC inventory; plan Agent 365 procurement before deadline |
 | **Attack Path Analysis** | Identifies potential attack vectors involving agent identities | Supports NYDFS cybersecurity requirements |
 | **Security Exposure Management** | Correlates agent permissions with sensitive data exposure | Helps meet GLBA 501(b) safeguards |
 
@@ -275,4 +285,4 @@ When available, incorporate these metrics into security posture reporting:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.4.0 | UI Verification Status: Current*

--- a/docs/playbooks/control-implementations/1.8/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.8/portal-walkthrough.md
@@ -43,6 +43,16 @@
 
 ---
 
+!!! danger "License deadline: 2026-07-01 — Agent 365 required for AI Agent Inventory"
+    Microsoft changed AI Agent Inventory licensing requirements (May 2026). During the grace period, you may use Defender for Cloud Apps without Agent 365 to access AI Agent Inventory. After 2026-07-01, Agent 365 is required.
+
+    | Period | Licensing path for AI Agent Inventory |
+    |--------|---------------------------------------|
+    | **Until 2026-07-01** (grace period) | Defender for Cloud Apps license (without Agent 365) |
+    | **After 2026-07-01** | **Agent 365 required** — Defender for Cloud Apps alone no longer provides AI Agent Inventory |
+
+    Source: [AI agent inventory — Microsoft Defender for Cloud Apps](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-inventory)
+
 ## Section 0 — Coverage boundary
 
 This playbook covers the **portal-driven** configuration of Control 1.8 across **two portals** (Microsoft Defender + Power Platform Admin Center) and **one product surface** (Microsoft Copilot Studio per-agent settings). The control has **six functional surfaces** that must be configured together; do not deploy any one in isolation.
@@ -114,7 +124,7 @@ Complete every gate **before** opening Section 4. Each gate has explicit pass cr
 
 | Capability | Required licensing | Verification |
 |---|---|---|
-| Defender for Cloud Apps **AI Agent Protection** + AISPM | Microsoft Defender for Cloud Apps standalone license **or** included via Microsoft 365 E5 / E5 Security; verify Defender XDR plan against ([protect-copilot-studio](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-protection)) | Microsoft Defender portal → Settings → Cloud apps → tenant licensing summary |
+| Defender for Cloud Apps **AI Agent Protection** + AISPM | **Agent 365 license** (required after 2026-07-01). **Grace period until 2026-07-01:** Microsoft Defender for Cloud Apps standalone license or included via Microsoft 365 E5 / E5 Security. After 2026-07-01, Agent 365 is required to retain AI Agent Inventory access. Verify Defender XDR plan against ([protect-copilot-studio](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-protection)) | Microsoft Defender portal → Settings → Cloud apps → tenant licensing summary |
 | Copilot Studio Prompt Shields + content moderation Low/Medium/High | Copilot Studio license (per-tenant or per-user); generative-AI capacity (PAYG or pre-paid messages) per [security-and-governance](https://learn.microsoft.com/en-us/microsoft-copilot-studio/security-and-governance) | PPAC → Resources → Capacity → Copilot Studio messages |
 | PPAC **Threat Protection** (native + Additional) | Power Platform Admin role; capability gated by Defender for Cloud Apps preview opt-in for native handshake | PPAC → Security → Threat Protection visible in left rail |
 | Microsoft Entra **app registration + Federated Identity Credential** | Entra App Admin (Application Administrator) **or** Cloud Application Administrator | Microsoft Entra admin center → Identity → Applications |
@@ -700,4 +710,4 @@ A confirmed runtime event detected by Control 1.8 (e.g., a sustained jailbreak a
 
 ---
 
-*Updated: February 2026 | Version: v1.4.0 | UI Verification Status: Current (commercial); GCC / GCC High / DoD per Sovereign Cloud Availability table*
+*Updated: May-2026 | Version: v1.4.0 | UI Verification Status: Current (commercial); GCC / GCC High / DoD per Sovereign Cloud Availability table*

--- a/docs/playbooks/control-implementations/3.7/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/3.7/portal-walkthrough.md
@@ -127,6 +127,9 @@ Repeat for every Zone 2 and Zone 3 environment. Capture screenshots and archive.
 
 ## Step 8 — Cross-reference Defender for Cloud Apps (optional, recommended for Zone 3)
 
+!!! danger "License deadline: 2026-07-01 — Agent 365 required for AI Agent Inventory"
+    Defender for Cloud Apps AI Agent Inventory access requires **Agent 365** after 2026-07-01. Until 2026-07-01, Defender for Cloud Apps license alone provides access (grace period). After 2026-07-01, organizations without Agent 365 **lose AI Agent Inventory visibility entirely**. Source: [AI agent inventory](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-inventory)
+
 For Zone 3 / customer-facing agents, correlate PPAC posture with Microsoft Defender:
 
 1. Open the **Microsoft Defender** portal as Entra Security Admin.
@@ -189,4 +192,4 @@ Cadence:
 
 ---
 
-*Updated: April 2026 | Version: v1.4.0 | UI Verification Status: Current*
+*Updated: May-2026 | Version: v1.4.0 | UI Verification Status: Current*

--- a/docs/reference/license-requirements.md
+++ b/docs/reference/license-requirements.md
@@ -91,7 +91,7 @@ License mapping guidance for the current FSI Agent Governance Framework control 
 | **1.5** | DLP and Sensitivity Labels | Microsoft 365 E5 or Microsoft Purview Suite | Purview DLP + Information Protection. **Note:** DLP for Copilot *prompts* is available to all M365 Copilot/Copilot Chat users at no additional cost (any SKU); DLP to restrict Copilot from *processing files/emails* requires E5/Purview Suite |
 | **1.6** | DSPM for AI | Microsoft 365 E5 or Microsoft Purview Suite | Microsoft Purview DSPM for AI |
 | **1.7** | Audit Logging | Microsoft 365 E5 (Premium) or E3 (Standard) | E5 for 10-year retention |
-| **1.8** | Runtime Protection | Power Platform Premium | Managed Environments feature |
+| **1.8** | Runtime Protection | Power Platform Premium + **Agent 365** (for AI Agent Inventory after 2026-07-01) | Managed Environments feature; Defender for Cloud Apps provides AI Agent Inventory during grace period until 2026-07-01; Agent 365 required after deadline |
 | **1.9** | Data Retention | Microsoft 365 E5 or Microsoft Purview Suite | Data Lifecycle Management |
 | **1.10** | Communication Compliance | Microsoft 365 E5 or Microsoft Purview Suite | Purview Communication Compliance |
 | **1.11** | Conditional Access & MFA | Microsoft Entra ID P1 (basic) or P2 (advanced) | P2 for risk-based policies |
@@ -266,6 +266,11 @@ To verify current license assignments:
 
 > **GA note:** Microsoft Agent 365 reaches general availability on May 1, 2026 as part of Microsoft 365 E7 and standalone Agent 365 per-user licensing. Validate current terms in Microsoft Learn before procurement or production dependency decisions.
 
+!!! danger "License deadline: 2026-07-01 — AI Agent Inventory requires Agent 365"
+    Defender for Cloud Apps AI Agent Inventory licensing requirements changed (May 2026). **Agent 365 is required after 2026-07-01** to retain AI Agent Inventory visibility in Microsoft Defender. Until 2026-07-01, Defender for Cloud Apps license alone provides access. After the deadline, organizations without Agent 365 lose AI Agent Inventory visibility entirely.
+
+    **Affected controls:** 1.8 (Runtime Protection — Native Defender Integration) and 3.7 (PPAC Security Posture Assessment — Defender cross-reference). Source: [AI agent inventory — Microsoft Defender for Cloud Apps](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-inventory)
+
 ### Official prerequisites
 
 | Requirement | Official guidance | Source |
@@ -287,6 +292,8 @@ To verify current license assignments:
 
 | Control | Licensing interpretation |
 |---------|--------------------------|
+| **1.8 - Runtime Protection** | AI Agent Inventory in Defender for Cloud Apps requires Agent 365 after 2026-07-01. Defender for Cloud Apps provides access during grace period until 2026-07-01. After the deadline, organizations without Agent 365 lose AI Agent Inventory visibility. |
+| **3.7 - PPAC Security Posture Assessment** | Defender for Cloud Apps AI Agent Inventory cross-reference (portal walkthrough Step 8) requires Agent 365 after 2026-07-01. Grace period ends 2026-07-01. |
 | **2.25 - Agent 365 Governance Console** | Requires Agent 365 or Microsoft 365 E7 per-user licensing at GA (May 1, 2026) |
 | **3.8 - Copilot Hub and Governance Dashboard** | Power Platform Premium covers PPAC Copilot Hub; Agent overview metrics and governance cards available with Agent 365 or M365 E7 licensing at GA (May 1, 2026) |
 | **2.23 - User Consent and AI Disclosure Enforcement** | Follow Agent Management Essentials prerequisites for AI Admin role assignment and PIM when delegating admin-center agent governance |
@@ -301,4 +308,4 @@ To verify current license assignments:
 
 ---
 
-*Last Updated: March 2026 | Framework Version: v1.2.52*
+*Last Updated: May-2026 | Framework Version: v1.4.0*


### PR DESCRIPTION
Closes #209

Adds HARD DEADLINE callouts for Microsoft licensing change (May 2026):
- AI Agent Inventory in Defender for Cloud Apps now requires **Agent 365**
- Grace period ends **2026-07-01**: organizations without Agent 365 lose AI Agent Inventory visibility
- Updates license-requirements.md with new license rows

Source: reports/monitoring/learn-changes-2026-05-10.md

Files: 2 controls + 2 playbooks + license-requirements, +60/-10 lines. All validation gates pass.