### PR TITLE
feat(frontier): add evaluator framework + Q16 PPAC environment visibility evaluator

### DIFF
--- a/assessment/engine/score_frontier.py
+++ b/assessment/engine/score_frontier.py
@@ -185,12 +185,16 @@ def score_driver(
     driver_id: str,
     manifest_questions: list[dict],
     answers: dict[str, dict],
+    collected_dir: Path | None = None,
 ) -> dict:
     """Score a single driver across its level-stratified questions.
 
     Returns a dict with ``score``, ``level_label``, ``questions_answered``,
     ``questions_total``, ``confidence``, and ``level_breakdown`` (per-level
     answered / total / ratio).
+
+    When *collected_dir* is provided, evaluator-derived answers are used as
+    fallback for questions where no facilitator answer is present.
     """
     driver_questions = [q for q in manifest_questions if q.get("driver") == driver_id]
     questions_total = len(driver_questions)
@@ -204,7 +208,15 @@ def score_driver(
         weight_sum = 0.0
         answered_at_level = 0
         for q in level_qs:
-            normalized = _normalize_answer(q, answers.get(q.get("question_id")))
+            qid = q.get("question_id")
+            # Facilitator answer wins.
+            answer_obj = answers.get(qid)
+            # Evaluator fallback when no facilitator answer.
+            if (answer_obj is None or answer_obj.get("value") is None) and collected_dir is not None:
+                eval_value, eval_evidence = _lookup_evaluator_answer(q, collected_dir)
+                if eval_value is not None:
+                    answer_obj = {"value": eval_value, "evidence": eval_evidence, "source": "evaluator"}
+            normalized = _normalize_answer(q, answer_obj)
             if normalized is None:
                 continue
             weight = float(q.get("scoring_weight", 1.0))
@@ -330,6 +342,83 @@ def assess_pattern_readiness(
 
 
 # ---------------------------------------------------------------------------
+# Pass-condition evaluators
+# ---------------------------------------------------------------------------
+# Signature: (collected_dir: Path) -> (answer_value: str | None, evidence: str)
+# answer_value ∈ {"yes", "no", "partial", None}. None = inconclusive.
+# Frontier evaluators take a Path (not a dict) because they run before
+# the collected-data dict assembly that score.py performs.
+
+
+def _eval_any_environment_visibility_for_agents(
+    collected_dir: Path,
+) -> tuple[str | None, str]:
+    """Q16 evaluator: check ppac.json for environment visibility."""
+    ppac_path = collected_dir / "ppac.json"
+    if not ppac_path.is_file():
+        return None, "PPAC data unavailable: ppac.json not found"
+
+    try:
+        with open(ppac_path, "r", encoding="utf-8") as fh:
+            ppac = json.load(fh)
+    except (json.JSONDecodeError, OSError) as exc:
+        return None, f"PPAC data unavailable: failed to read ppac.json ({exc})"
+
+    # Check for collector errors.
+    metadata = ppac.get("_metadata") or {}
+    errors = metadata.get("errors") or []
+    if errors:
+        first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+        return None, f"PPAC data unavailable: collector reported errors ({first_error})"
+
+    environments = ppac.get("environments")
+    if environments is None:
+        return None, "PPAC data unavailable: environments field absent"
+
+    if not isinstance(environments, list):
+        return None, "PPAC data unavailable: environments field is not a list"
+
+    if len(environments) == 0:
+        return "no", "PPAC reported zero environments"
+
+    names = [
+        env.get("DisplayName") or env.get("EnvironmentName") or "unnamed"
+        for env in environments[:3]
+    ]
+    suffix = f" (and {len(environments) - 3} more)" if len(environments) > 3 else ""
+    return (
+        "yes",
+        f"PPAC reported {len(environments)} environment(s): {', '.join(names)}{suffix}",
+    )
+
+
+# --- Evaluator registry ---------------------------------------------------
+
+EVALUATORS: dict[str, object] = {
+    "any_environment_visibility_for_agents": _eval_any_environment_visibility_for_agents,
+}
+
+
+def _lookup_evaluator_answer(
+    question: dict, collected_dir: Path
+) -> tuple[str | None, str | None]:
+    """Look up an evaluator result for a frontier question.
+
+    Returns ``(answer_value, evidence)`` if an evaluator is registered and
+    produces a non-None result. Returns ``(None, None)`` when no evaluator
+    applies or the evaluator is inconclusive.
+    """
+    if question.get("auto_evaluable") is not True:
+        return None, None
+    condition = question.get("pass_condition") or ""
+    evaluator = EVALUATORS.get(condition)
+    if evaluator is None:
+        return None, None
+    answer_value, evidence = evaluator(collected_dir)  # type: ignore[operator]
+    return answer_value, evidence
+
+
+# ---------------------------------------------------------------------------
 # Evaluator coverage
 # ---------------------------------------------------------------------------
 
@@ -338,18 +427,26 @@ def compute_evaluator_coverage(manifest_questions: list[dict]) -> dict:
     """Aggregate evaluator-state coverage for the question set.
 
     A frontier question's state is one of:
-      - ``auto_evaluable``: ``auto_evaluable == True``
-      - ``manual_only``: ``collection_methods == ["Manual"]`` and not auto-evaluable
-      - ``unimplemented_evaluator``: anything else (a non-Manual collection
-        method is declared but no evaluator wired)
+      - ``auto_evaluable``: ``auto_evaluable == True`` AND ``pass_condition``
+        has a registered evaluator in EVALUATORS
+      - ``unimplemented_evaluator``: ``auto_evaluable == True`` but no
+        registered evaluator (safety net), OR non-Manual collection method
+        declared without auto_evaluable
+      - ``manual_only``: ``auto_evaluable == False`` and
+        ``collection_methods == ["Manual"]``
     """
     counts = {"auto_evaluable": 0, "manual_only": 0, "unimplemented_evaluator": 0}
     for q in manifest_questions:
-        if q.get("auto_evaluable") is True:
-            counts["auto_evaluable"] += 1
-            continue
+        auto = q.get("auto_evaluable") is True
+        condition = q.get("pass_condition") or ""
+        has_evaluator = condition in EVALUATORS
         methods = q.get("collection_methods") or []
-        if list(methods) == ["Manual"]:
+
+        if auto and has_evaluator:
+            counts["auto_evaluable"] += 1
+        elif auto and not has_evaluator:
+            counts["unimplemented_evaluator"] += 1
+        elif not auto and list(methods) == ["Manual"]:
             counts["manual_only"] += 1
         else:
             counts["unimplemented_evaluator"] += 1
@@ -441,7 +538,7 @@ def run(
 
     driver_scores: dict[str, dict] = {}
     for driver_id in DRIVER_IDS:
-        result = score_driver(driver_id, questions, answers)
+        result = score_driver(driver_id, questions, answers, collected_dir=collected_p)
         driver_scores[driver_id] = result
         log.debug(
             "  %s — score %d (%s), confidence %s",
@@ -455,6 +552,20 @@ def run(
     pattern_readiness = assess_pattern_readiness(driver_scores, pattern_targets)
     evaluator_coverage = compute_evaluator_coverage(questions)
 
+    # Build per-question evaluator results for transparency.
+    evaluator_results: dict[str, dict] = {}
+    for q in questions:
+        eval_value, eval_evidence = _lookup_evaluator_answer(q, collected_p)
+        if eval_value is not None or eval_evidence is not None:
+            qid = q["question_id"]
+            facilitator_answer = answers.get(qid)
+            used = facilitator_answer is None or facilitator_answer.get("value") is None
+            evaluator_results[qid] = {
+                "answer_value": eval_value,
+                "evidence": eval_evidence,
+                "used_for_scoring": used,
+            }
+
     output = {
         "_metadata": {
             "engine_version": ENGINE_VERSION,
@@ -465,6 +576,7 @@ def run(
         "scale_breaker": scale_breaker,
         "pattern_readiness": pattern_readiness,
         "evaluator_coverage": evaluator_coverage,
+        "evaluator_results": evaluator_results,
     }
 
     output_p.parent.mkdir(parents=True, exist_ok=True)

--- a/assessment/manifest/frontier-readiness.json
+++ b/assessment/manifest/frontier-readiness.json
@@ -243,9 +243,9 @@
       "fsi_context": "Initial maturity requires at minimum awareness of where agents run. Without environment visibility the firm cannot scope retention or telemetry to support FINRA 4511 / SEC 17a-4 books-and-records expectations.",
       "answer_format": "yes_no_partial",
       "scoring_weight": 1.0,
-      "auto_evaluable": false,
+      "auto_evaluable": true,
       "pass_condition": "any_environment_visibility_for_agents",
-      "collection_methods": ["Manual"],
+      "collection_methods": ["Manual", "PPAC_API"],
       "regulatory_relevance": ["FINRA-4511", "SEC-17a-4"]
     },
     {

--- a/assessment/tests/fixtures/ppac_empty_envs.json
+++ b/assessment/tests/fixtures/ppac_empty_envs.json
@@ -1,0 +1,10 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "environments": []
+}

--- a/assessment/tests/fixtures/ppac_with_envs.json
+++ b/assessment/tests/fixtures/ppac_with_envs.json
@@ -1,0 +1,21 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Default",
+      "EnvironmentName": "env-default-001",
+      "EnvironmentSku": "Default"
+    },
+    {
+      "DisplayName": "Prod-CoE",
+      "EnvironmentName": "env-prod-coe-001",
+      "EnvironmentSku": "Production"
+    }
+  ]
+}

--- a/assessment/tests/fixtures/ppac_with_errors.json
+++ b/assessment/tests/fixtures/ppac_with_errors.json
@@ -1,0 +1,10 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": ["Section 1 (Environments) failed: Get-AdminPowerAppEnvironment returned HTTP 403"]
+  },
+  "environments": null
+}

--- a/assessment/tests/test_score_frontier.py
+++ b/assessment/tests/test_score_frontier.py
@@ -417,25 +417,30 @@ class TestPatternReadiness:
 class TestEvaluatorCoverage:
     """Unit tests for compute_evaluator_coverage()."""
 
-    def test_v1_all_manual(self, manifest_data: dict) -> None:
-        """Real frontier-readiness.json v1: all 25 questions are manual_only."""
+    def test_v1_counts_after_q16_wiring(self, manifest_data: dict) -> None:
+        """Real frontier-readiness.json post-Q16: 1 auto, 24 manual, 0 unimplemented."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["manual_only"] == 25
-        assert coverage["questions"]["auto_evaluable"] == 0
+        assert coverage["questions"]["auto_evaluable"] == 1
+        assert coverage["questions"]["manual_only"] == 24
         assert coverage["questions"]["unimplemented_evaluator"] == 0
         assert coverage["total_questions"] == 25
 
-    def test_auto_evaluable_flag_counted(self) -> None:
-        """auto_evaluable=True counts in auto_evaluable bucket."""
+    def test_auto_evaluable_requires_registered_evaluator(self) -> None:
+        """auto_evaluable=True with unregistered pass_condition → unimplemented_evaluator."""
         questions = [
-            {"question_id": "Q01", "auto_evaluable": True, "collection_methods": ["Manual"]},
+            {
+                "question_id": "Q01",
+                "auto_evaluable": True,
+                "pass_condition": "nonexistent_evaluator",
+                "collection_methods": ["Manual", "API"],
+            },
             {"question_id": "Q02", "auto_evaluable": False, "collection_methods": ["Manual"]},
         ]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 1
+        assert coverage["questions"]["auto_evaluable"] == 0
+        assert coverage["questions"]["unimplemented_evaluator"] == 1
         assert coverage["questions"]["manual_only"] == 1
-        assert coverage["total_questions"] == 2
 
     def test_non_manual_without_evaluator_counted(self) -> None:
         """Collection method other than Manual, auto_evaluable False → unimplemented_evaluator."""
@@ -462,7 +467,7 @@ class TestEvaluatorCoverage:
 # ---------------------------------------------------------------------------
 
 _REQUIRED_TOP_KEYS = frozenset(
-    {"_metadata", "driver_scores", "scale_breaker", "pattern_readiness", "evaluator_coverage"}
+    {"_metadata", "driver_scores", "scale_breaker", "pattern_readiness", "evaluator_coverage", "evaluator_results"}
 )
 _REQUIRED_METADATA_KEYS = frozenset({"engine_version", "timestamp", "manifest_version"})
 
@@ -606,3 +611,111 @@ class TestEndToEnd:
         assert meta["engine_version"] == score_frontier.ENGINE_VERSION
         assert "T" in meta["timestamp"]  # ISO 8601 contains literal 'T'
         assert meta["manifest_version"] == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# TestFrontierEvaluators — Q16 evaluator and framework integration
+# ---------------------------------------------------------------------------
+
+
+def _setup_ppac_collected(tmp_path: Path, fixture_name: str) -> Path:
+    """Copy a PPAC fixture into a temp collected/ dir for evaluator testing."""
+    collected = tmp_path / "collected"
+    collected.mkdir(exist_ok=True)
+    data = load_fixture(fixture_name)
+    write_json(collected / "ppac.json", data)
+    return collected
+
+
+class TestFrontierEvaluators:
+    """Tests for the Q16 evaluator and frontier evaluator framework."""
+
+    def test_evaluator_q16_yes_with_environments(self, tmp_path: Path) -> None:
+        """PPAC fixture with 2 envs → evaluator returns ('yes', evidence mentioning both)."""
+        collected = _setup_ppac_collected(tmp_path, "ppac_with_envs.json")
+        answer, evidence = score_frontier._eval_any_environment_visibility_for_agents(collected)
+        assert answer == "yes"
+        assert "2 environment(s)" in evidence
+        assert "Default" in evidence
+        assert "Prod-CoE" in evidence
+
+    def test_evaluator_q16_no_with_empty_environments(self, tmp_path: Path) -> None:
+        """PPAC fixture with empty envs list → evaluator returns ('no', evidence)."""
+        collected = _setup_ppac_collected(tmp_path, "ppac_empty_envs.json")
+        answer, evidence = score_frontier._eval_any_environment_visibility_for_agents(collected)
+        assert answer == "no"
+        assert "zero environments" in evidence
+
+    def test_evaluator_q16_inconclusive_when_ppac_missing(self, tmp_path: Path) -> None:
+        """No ppac.json file → returns (None, evidence about missing)."""
+        collected = tmp_path / "collected"
+        collected.mkdir()
+        answer, evidence = score_frontier._eval_any_environment_visibility_for_agents(collected)
+        assert answer is None
+        assert "not found" in evidence
+
+    def test_evaluator_q16_inconclusive_when_collector_errored(self, tmp_path: Path) -> None:
+        """ppac.json with _metadata.errors populated → returns (None, evidence)."""
+        collected = _setup_ppac_collected(tmp_path, "ppac_with_errors.json")
+        answer, evidence = score_frontier._eval_any_environment_visibility_for_agents(collected)
+        assert answer is None
+        assert "collector reported errors" in evidence
+
+    def test_score_driver_facilitator_answer_wins_over_evaluator(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator answers 'no' for Q16, but evaluator would return 'yes' → score uses 'no'."""
+        collected = _setup_ppac_collected(tmp_path, "ppac_with_envs.json")
+        questions = manifest_data["questions"]
+        # Facilitator explicitly says "no"
+        answers = {"Q16": {"value": "no"}}
+        result = score_frontier.score_driver(
+            "technology_data", questions, answers, collected_dir=collected
+        )
+        # L100 ratio should be 0.0 (from "no" = 0.0), not 1.0 (from "yes")
+        assert result["level_breakdown"]["100"]["ratio"] == pytest.approx(0.0)
+
+    def test_score_driver_uses_evaluator_when_no_facilitator_answer(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator omits Q16, evaluator returns 'yes' → score reflects 'yes'."""
+        collected = _setup_ppac_collected(tmp_path, "ppac_with_envs.json")
+        questions = manifest_data["questions"]
+        answers: dict[str, dict] = {}  # no facilitator answers at all
+        result = score_frontier.score_driver(
+            "technology_data", questions, answers, collected_dir=collected
+        )
+        # Q16 is L100 with weight 1.0; evaluator yields "yes" = 1.0
+        # Only 1 of 5 tech_data questions answered → ratio at L100 = 1.0
+        assert result["level_breakdown"]["100"]["ratio"] == pytest.approx(1.0)
+        assert result["questions_answered"] >= 1
+
+    def test_evaluator_coverage_q16_classified_as_auto(self, manifest_data: dict) -> None:
+        """After manifest update, coverage matrix counts Q16 as auto_evaluable: 1."""
+        questions = manifest_data["questions"]
+        coverage = score_frontier.compute_evaluator_coverage(questions)
+        assert coverage["questions"]["auto_evaluable"] == 1
+
+    def test_run_includes_evaluator_results_in_output(self, tmp_path: Path) -> None:
+        """End-to-end via run() populates evaluator_results.Q16 in output JSON."""
+        collected = tmp_path / "collected"
+        collected.mkdir()
+        # Write frontier.json with NO answers (so evaluator kicks in)
+        write_json(collected / "frontier.json", {"_metadata": {}, "answers": {}})
+        # Write ppac.json with environments
+        ppac_data = load_fixture("ppac_with_envs.json")
+        write_json(collected / "ppac.json", ppac_data)
+        output_path = tmp_path / "frontier-summary.json"
+
+        result = score_frontier.run(
+            manifest_path=str(MANIFEST_PATH),
+            collected_dir=str(collected),
+            output_path=str(output_path),
+        )
+
+        assert "evaluator_results" in result
+        assert "Q16" in result["evaluator_results"]
+        q16_result = result["evaluator_results"]["Q16"]
+        assert q16_result["answer_value"] == "yes"
+        assert "environment(s)" in q16_result["evidence"]
+        assert q16_result["used_for_scoring"] is True

--- a/docs/reference/frontier-assessment-coverage.md
+++ b/docs/reference/frontier-assessment-coverage.md
@@ -18,8 +18,8 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | State | Count | Share |
 |-------|-------|-------|
-| ✅ Auto | 0 | 0.0% |
-| 📝 Manual | 25 | 100.0% |
+| ✅ Auto | 1 | 4.0% |
+| 📝 Manual | 24 | 96.0% |
 | ⚠️ Unimplemented | 0 | 0.0% |
 | **Total** | 25 | 100% |
 
@@ -30,7 +30,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 | AI Strategy & Experience | 5 | 0 | 5 | 0 |
 | Business Strategy | 5 | 0 | 5 | 0 |
 | AI Governance & Security | 5 | 0 | 5 | 0 |
-| Technology & Data | 5 | 0 | 5 | 0 |
+| Technology & Data | 5 | 1 | 4 | 0 |
 | Organization & Culture | 5 | 0 | 5 | 0 |
 
 ## Per-question detail
@@ -69,7 +69,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | Q ID | Level | Question | State | Pass Condition | Notes |
 |---|---|---|---|---|---|
-| Q16 | 100 | Is there any visibility into which Power Platform environments host AI agents... | 📝 Manual | `any_environment_visibility_for_agents` | Facilitator-answered. |
+| Q16 | 100 | Is there any visibility into which Power Platform environments host AI agents... | ✅ Auto | `any_environment_visibility_for_agents` |  |
 | Q17 | 200 | Are some environments tagged or grouped for agent workloads, with basic telem... | 📝 Manual | `tagged_environments_with_basic_telemetry` | Facilitator-answered. |
 | Q18 | 300 | Are Environment Groups with tier classification operational, with automated a... | 📝 Manual | `env_groups_with_inventory_siem_rag_and_lineage` | Facilitator-answered. |
 | Q19 | 400 | Does the platform provide integrated telemetry across Sentinel, the Agent 365... | 📝 Manual | `integrated_telemetry_with_curated_templates_and_agent_id` | Facilitator-answered. |

--- a/scripts/generate_coverage_matrix.py
+++ b/scripts/generate_coverage_matrix.py
@@ -39,6 +39,7 @@ FRONTIER_OUTPUT_PATH = REPO_ROOT / "docs" / "reference" / "frontier-assessment-c
 sys.path.insert(0, str(ENGINE_DIR))
 
 import score  # type: ignore[import-untyped]  # noqa: E402
+import score_frontier  # type: ignore[import-untyped]  # noqa: E402
 
 STATE_LABEL = {
     "auto_evaluable": "Auto",
@@ -273,11 +274,20 @@ def load_frontier_manifest() -> dict:
 
 
 def classify_frontier_question_state(question: dict) -> str:
-    """Return one of: 'auto_evaluable', 'manual_only', 'unimplemented_evaluator'."""
+    """Return one of: 'auto_evaluable', 'manual_only', 'unimplemented_evaluator'.
+
+    Mirrors the logic in ``score_frontier.compute_evaluator_coverage`` —
+    requires BOTH ``auto_evaluable: true`` in the manifest AND a registered
+    evaluator in the EVALUATORS dict.
+    """
     auto = question.get("auto_evaluable", False)
+    condition = question.get("pass_condition") or ""
+    has_evaluator = condition in score_frontier.EVALUATORS
     methods = question.get("collection_methods", [])
-    if auto:
+    if auto and has_evaluator:
         return "auto_evaluable"
+    if auto and not has_evaluator:
+        return "unimplemented_evaluator"
     if len(methods) == 1 and methods[0] == "Manual":
         return "manual_only"
     return "unimplemented_evaluator"


### PR DESCRIPTION
Wires up the EVALUATORS registry pattern in score_frontier.py mirroring the controls-side pattern in score.py. Implements the first concrete Frontier evaluator: **Q16 (any_environment_visibility_for_agents)** reading from ppac.json.

**Design:** facilitator answers always win — evaluator provides default suggestion only when no facilitator answer exists. Per-question evidence surfaced in evaluator_results section of frontier-summary.json output.

**Coverage matrix:** 1/25 questions now auto-evaluated (was 0/25).

**Validation:** All 9 gates pass — ruff, 64 pytest (38 frontier including 8 new), drift check, both coverage matrix checks, mkdocs --strict, language rules, control structure.

**Follow-up:** Q17 (env tags + Sentinel) and Q13 (zone classification) in separate PRs once this framework foundation is reviewed.