### PR TITLE
feat(frontier): add Q17 evaluator + PPAC env-tag/group enumeration

### DIFF
--- a/assessment/collectors/Collect-PPAC.ps1
+++ b/assessment/collectors/Collect-PPAC.ps1
@@ -4,8 +4,9 @@
 
 .DESCRIPTION
     Enumerates Power Platform environments, DLP policies, role assignments, environment
-    routing rules, inactivity timeout settings, security posture score, and agent feature
-    flags via the PowerApps Administration module and BAP REST API.
+    routing rules, inactivity timeout settings, security posture score, agent feature
+    flags, environment groups, and per-environment tags and group membership via the
+    PowerApps Administration module and BAP REST API.
 
     Outputs a structured JSON file (ppac.json) consumed by the assessment engine.
 
@@ -32,7 +33,8 @@
 
 .OUTPUTS
     ppac.json — JSON file with environments, DLP policies, role assignments, routing rules,
-    inactivity timeout, security posture, and agent feature flags.
+    inactivity timeout, security posture, agent feature flags, environment groups, and
+    per-environment tags/group membership.
 
 .NOTES
     Part of the FSI Agent Governance Assessment Engine — PPAC Collector.
@@ -401,6 +403,112 @@ catch {
 }
 
 # ═══════════════════════════════════════════════════════════════════════
+# Section 8: Environment Groups (BAP REST API)
+# Supports: Frontier Q17 (tagged_environments_with_basic_telemetry)
+# Pattern: BAP admin API for environment group enumeration
+# ═══════════════════════════════════════════════════════════════════════
+$environmentGroups = $null
+try {
+    Write-Verbose "Section 8: Collecting environment groups via BAP API..."
+    if ($bapToken) {
+        $groupsUri = "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environmentGroups?api-version=2021-04-01"
+        $groupsResponse = Invoke-BapApi -Uri $groupsUri -Token $bapToken
+        if ($null -ne $groupsResponse) {
+            $groupItems = @()
+            if ($groupsResponse.value) {
+                $groupItems = $groupsResponse.value
+            }
+            elseif ($groupsResponse -is [System.Collections.IEnumerable] -and $groupsResponse -isnot [string]) {
+                $groupItems = @($groupsResponse)
+            }
+            $environmentGroups = @(foreach ($grp in $groupItems) {
+                $envCount = 0
+                if ($grp.properties.environments) {
+                    $envCount = @($grp.properties.environments).Count
+                }
+                [PSCustomObject]@{
+                    Id               = $grp.id
+                    DisplayName      = $grp.properties.displayName
+                    Description      = $grp.properties.description
+                    CreatedTime      = $grp.properties.createdTime
+                    EnvironmentCount = $envCount
+                }
+            })
+            Write-Verbose "  Collected $($environmentGroups.Count) environment group(s)."
+        }
+        else {
+            $environmentGroups = @()
+            $warnings.Add("Section 8 (Environment Groups): API returned no data — tenant may not have environment groups.")
+            Write-Warning $warnings[-1]
+        }
+    }
+    else {
+        $warnings.Add("Section 8 (Environment Groups): Skipped — BAP token unavailable.")
+        Write-Warning $warnings[-1]
+    }
+}
+catch {
+    $warnings.Add("Section 8 (Environment Groups) failed: $($_.Exception.Message)")
+    Write-Warning $warnings[-1]
+}
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 9: Per-Environment Tags + Group Membership (BAP REST API)
+# Supports: Frontier Q17 (tagged_environments_with_basic_telemetry)
+# Pattern: BAP admin API per-environment detail with $expand
+# ═══════════════════════════════════════════════════════════════════════
+try {
+    Write-Verbose "Section 9: Enriching environments with tags and group membership..."
+    if ($bapToken -and $environments) {
+        foreach ($env in $environments) {
+            $envId = $env.EnvironmentName
+            try {
+                $detailUri = "https://api.bap.microsoft.com/providers/Microsoft.BusinessAppPlatform/scopes/admin/environments/${envId}?api-version=2021-04-01&`$expand=permissions,properties.environmentGroup"
+                $detail = Invoke-BapApi -Uri $detailUri -Token $bapToken
+                if ($detail) {
+                    $tags = @{}
+                    if ($detail.properties.tags -and $detail.properties.tags -is [System.Collections.IDictionary]) {
+                        $tags = $detail.properties.tags
+                    }
+                    elseif ($detail.properties.tags -is [psobject]) {
+                        $detail.properties.tags.PSObject.Properties | ForEach-Object {
+                            $tags[$_.Name] = $_.Value
+                        }
+                    }
+                    $env | Add-Member -NotePropertyName 'Tags' -NotePropertyValue $tags -Force
+                    $groupId = $null
+                    if ($detail.properties.environmentGroup -and $detail.properties.environmentGroup.id) {
+                        $groupId = $detail.properties.environmentGroup.id
+                    }
+                    $env | Add-Member -NotePropertyName 'EnvironmentGroupId' -NotePropertyValue $groupId -Force
+                }
+                else {
+                    $env | Add-Member -NotePropertyName 'Tags' -NotePropertyValue @{} -Force
+                    $env | Add-Member -NotePropertyName 'EnvironmentGroupId' -NotePropertyValue $null -Force
+                    $warnings.Add("Section 9 (Tags): Detail API returned null for environment '$envId'.")
+                    Write-Warning $warnings[-1]
+                }
+            }
+            catch {
+                $env | Add-Member -NotePropertyName 'Tags' -NotePropertyValue $null -Force
+                $env | Add-Member -NotePropertyName 'EnvironmentGroupId' -NotePropertyValue $null -Force
+                $warnings.Add("Section 9 (Tags) failed for environment '${envId}': $($_.Exception.Message)")
+                Write-Warning $warnings[-1]
+            }
+        }
+        Write-Verbose "  Enriched $(@($environments).Count) environment(s) with tags and group membership."
+    }
+    else {
+        $warnings.Add("Section 9 (Tags): Skipped — BAP token or environments unavailable.")
+        Write-Warning $warnings[-1]
+    }
+}
+catch {
+    $warnings.Add("Section 9 (Tags) failed: $($_.Exception.Message)")
+    Write-Warning $warnings[-1]
+}
+
+# ═══════════════════════════════════════════════════════════════════════
 # Build Output
 # ═══════════════════════════════════════════════════════════════════════
 $result = [ordered]@{
@@ -411,6 +519,7 @@ $result = [ordered]@{
     inactivityTimeout  = $inactivityTimeout
     securityPosture    = $securityPosture
     agentFeatureFlags  = $agentFeatureFlags
+    environmentGroups  = $environmentGroups
     _metadata          = [ordered]@{
         collector               = 'Collect-PPAC'
         timestamp               = (Get-Date -Format 'o')
@@ -427,15 +536,15 @@ Write-Verbose "Output written to $outputFile"
 # ─── Exit Code ───────────────────────────────────────────────────────
 $nullSections = @(
     $environments, $dlpPolicies, $roleAssignments, $routingRules,
-    $inactivityTimeout, $securityPosture, $agentFeatureFlags
+    $inactivityTimeout, $securityPosture, $agentFeatureFlags, $environmentGroups
 ) | Where-Object { $null -eq $_ }
 
-if ($nullSections.Count -eq 7) {
+if ($nullSections.Count -eq 8) {
     Write-Error "All sections failed to collect data. See warnings for details."
     exit 2
 }
 elseif ($nullSections.Count -gt 0) {
-    Write-Warning "Partial collection: $($nullSections.Count)/7 sections returned null."
+    Write-Warning "Partial collection: $($nullSections.Count)/8 sections returned null."
     exit 1
 }
 else {

--- a/assessment/engine/score_frontier.py
+++ b/assessment/engine/score_frontier.py
@@ -350,19 +350,30 @@ def assess_pattern_readiness(
 # the collected-data dict assembly that score.py performs.
 
 
+def _load_collected_json(
+    collected_dir: Path, filename: str
+) -> tuple[dict | None, str | None]:
+    """Load a collector JSON file from the collected directory.
+
+    Returns ``(data, None)`` on success, or ``(None, error_reason)`` on failure.
+    """
+    path = collected_dir / filename
+    if not path.is_file():
+        return None, f"{filename} not found"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh), None
+    except (json.JSONDecodeError, OSError) as exc:
+        return None, f"failed to read {filename} ({exc})"
+
+
 def _eval_any_environment_visibility_for_agents(
     collected_dir: Path,
 ) -> tuple[str | None, str]:
     """Q16 evaluator: check ppac.json for environment visibility."""
-    ppac_path = collected_dir / "ppac.json"
-    if not ppac_path.is_file():
-        return None, "PPAC data unavailable: ppac.json not found"
-
-    try:
-        with open(ppac_path, "r", encoding="utf-8") as fh:
-            ppac = json.load(fh)
-    except (json.JSONDecodeError, OSError) as exc:
-        return None, f"PPAC data unavailable: failed to read ppac.json ({exc})"
+    ppac, err = _load_collected_json(collected_dir, "ppac.json")
+    if ppac is None:
+        return None, f"PPAC data unavailable: {err}"
 
     # Check for collector errors.
     metadata = ppac.get("_metadata") or {}
@@ -392,10 +403,92 @@ def _eval_any_environment_visibility_for_agents(
     )
 
 
+def _eval_tagged_environments_with_basic_telemetry(
+    collected_dir: Path,
+) -> tuple[str | None, str]:
+    """Q17 evaluator: check env tags/groups in ppac.json + Sentinel workspace.
+
+    Returns:
+      - ("yes", evidence) — at least one env has tags or group membership AND
+        Sentinel workspace present.
+      - ("partial", evidence) — only one signal present (tags/groups OR Sentinel).
+      - ("no", evidence) — neither signal present.
+      - (None, evidence) — ppac.json missing or collector errored.
+    """
+    ppac, ppac_err = _load_collected_json(collected_dir, "ppac.json")
+    if ppac is None:
+        return None, f"PPAC data unavailable: {ppac_err}"
+
+    # Check for collector errors on environments.
+    metadata = ppac.get("_metadata") or {}
+    errors = metadata.get("errors") or []
+    if errors:
+        first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+        return None, f"PPAC data unavailable: collector reported errors ({first_error})"
+
+    environments = ppac.get("environments")
+    if environments is None or not isinstance(environments, list):
+        return None, "PPAC data unavailable: environments field absent or invalid"
+
+    # Count environments with non-empty tags.
+    tagged_count = 0
+    for env in environments:
+        tags = env.get("Tags")
+        if isinstance(tags, dict) and len(tags) > 0:
+            tagged_count += 1
+
+    # Count environments with group membership.
+    grouped_count = 0
+    for env in environments:
+        gid = env.get("EnvironmentGroupId")
+        if gid is not None and gid != "":
+            grouped_count += 1
+
+    # Count environment groups from top-level field.
+    env_groups = ppac.get("environmentGroups")
+    env_group_count = len(env_groups) if isinstance(env_groups, list) else 0
+
+    has_tags_or_groups = tagged_count > 0 or grouped_count > 0
+
+    # Build PPAC evidence fragment.
+    total = len(environments)
+    parts: list[str] = []
+    parts.append(f"{tagged_count}/{total} environments with tags")
+    if grouped_count > 0:
+        parts.append(f"{grouped_count} with group membership")
+    if env_group_count > 0:
+        parts.append(f"{env_group_count} environment group(s)")
+    ppac_evidence = "PPAC reported " + "; ".join(parts)
+
+    # Sentinel workspace presence.
+    sentinel, _ = _load_collected_json(collected_dir, "sentinel.json")
+    has_sentinel = False
+    sentinel_name = ""
+    if sentinel is not None:
+        workspace = sentinel.get("workspace")
+        if isinstance(workspace, dict) and workspace.get("WorkspaceId"):
+            has_sentinel = True
+            sentinel_name = workspace.get("WorkspaceName") or workspace.get("WorkspaceId") or "unnamed"
+
+    if has_sentinel:
+        sentinel_evidence = f"Sentinel workspace '{sentinel_name}' present"
+    else:
+        sentinel_evidence = "Sentinel workspace not found"
+
+    evidence = f"{ppac_evidence}; {sentinel_evidence}"
+
+    if has_tags_or_groups and has_sentinel:
+        return "yes", evidence
+    if has_tags_or_groups or has_sentinel:
+        return "partial", evidence
+    return "no", evidence
+
+
 # --- Evaluator registry ---------------------------------------------------
 
 EVALUATORS: dict[str, object] = {
     "any_environment_visibility_for_agents": _eval_any_environment_visibility_for_agents,
+    "tagged_environments_with_basic_telemetry": _eval_tagged_environments_with_basic_telemetry,
 }
 
 

--- a/assessment/manifest/frontier-readiness.json
+++ b/assessment/manifest/frontier-readiness.json
@@ -256,9 +256,9 @@
       "fsi_context": "Repeatable maturity requires environment grouping and baseline telemetry collection. This is the foundation for later SIEM integration and incident reconstruction supporting GLBA 501(b) Safeguards and FINRA 4511 retention.",
       "answer_format": "yes_no_partial",
       "scoring_weight": 1.0,
-      "auto_evaluable": false,
+      "auto_evaluable": true,
       "pass_condition": "tagged_environments_with_basic_telemetry",
-      "collection_methods": ["Manual"],
+      "collection_methods": ["Manual", "PPAC_API", "Sentinel_API"],
       "regulatory_relevance": ["FINRA-4511", "SEC-17a-4", "GLBA-501b"]
     },
     {

--- a/assessment/tests/fixtures/ppac_no_tags_no_groups.json
+++ b/assessment/tests/fixtures/ppac_no_tags_no_groups.json
@@ -1,0 +1,26 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Default",
+      "EnvironmentName": "env-default-001",
+      "EnvironmentSku": "Default",
+      "Tags": {},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Prod-CoE",
+      "EnvironmentName": "env-prod-coe-001",
+      "EnvironmentSku": "Production",
+      "Tags": {},
+      "EnvironmentGroupId": null
+    }
+  ],
+  "environmentGroups": []
+}

--- a/assessment/tests/fixtures/ppac_with_env_group.json
+++ b/assessment/tests/fixtures/ppac_with_env_group.json
@@ -1,0 +1,34 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Default",
+      "EnvironmentName": "env-default-001",
+      "EnvironmentSku": "Default",
+      "Tags": {},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Prod-CoE",
+      "EnvironmentName": "env-prod-coe-001",
+      "EnvironmentSku": "Production",
+      "Tags": {},
+      "EnvironmentGroupId": "grp-prod-fsi-001"
+    }
+  ],
+  "environmentGroups": [
+    {
+      "Id": "grp-prod-fsi-001",
+      "DisplayName": "Prod-FSI",
+      "Description": "Production FSI agent environments",
+      "CreatedTime": "2026-01-15T10:00:00Z",
+      "EnvironmentCount": 2
+    }
+  ]
+}

--- a/assessment/tests/fixtures/ppac_with_tagged_envs.json
+++ b/assessment/tests/fixtures/ppac_with_tagged_envs.json
@@ -1,0 +1,33 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Default",
+      "EnvironmentName": "env-default-001",
+      "EnvironmentSku": "Default",
+      "Tags": {},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Prod-CoE",
+      "EnvironmentName": "env-prod-coe-001",
+      "EnvironmentSku": "Production",
+      "Tags": {"zone": "2", "workload": "agent"},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Dev-Sandbox",
+      "EnvironmentName": "env-dev-001",
+      "EnvironmentSku": "Sandbox",
+      "Tags": {"zone": "1"},
+      "EnvironmentGroupId": null
+    }
+  ],
+  "environmentGroups": []
+}

--- a/assessment/tests/fixtures/sentinel_no_workspace.json
+++ b/assessment/tests/fixtures/sentinel_no_workspace.json
@@ -1,0 +1,10 @@
+{
+  "_metadata": {
+    "collector": "Sentinel",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": ["Section 1 (Workspace) failed: Subscription not found"]
+  },
+  "workspace": null
+}

--- a/assessment/tests/fixtures/sentinel_with_workspace.json
+++ b/assessment/tests/fixtures/sentinel_with_workspace.json
@@ -1,0 +1,14 @@
+{
+  "_metadata": {
+    "collector": "Sentinel",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "workspace": {
+    "WorkspaceId": "ws-fsi-001",
+    "WorkspaceName": "fsi-prod-siem",
+    "ProvisioningState": "Succeeded",
+    "Sku": "PerGB2018"
+  }
+}

--- a/assessment/tests/test_score_frontier.py
+++ b/assessment/tests/test_score_frontier.py
@@ -417,12 +417,12 @@ class TestPatternReadiness:
 class TestEvaluatorCoverage:
     """Unit tests for compute_evaluator_coverage()."""
 
-    def test_v1_counts_after_q16_wiring(self, manifest_data: dict) -> None:
-        """Real frontier-readiness.json post-Q16: 1 auto, 24 manual, 0 unimplemented."""
+    def test_v1_counts_after_q16_q17_wiring(self, manifest_data: dict) -> None:
+        """Real frontier-readiness.json post-Q16/Q17: 2 auto, 23 manual, 0 unimplemented."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 1
-        assert coverage["questions"]["manual_only"] == 24
+        assert coverage["questions"]["auto_evaluable"] == 2
+        assert coverage["questions"]["manual_only"] == 23
         assert coverage["questions"]["unimplemented_evaluator"] == 0
         assert coverage["total_questions"] == 25
 
@@ -691,10 +691,10 @@ class TestFrontierEvaluators:
         assert result["questions_answered"] >= 1
 
     def test_evaluator_coverage_q16_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage matrix counts Q16 as auto_evaluable: 1."""
+        """After manifest update, coverage matrix counts Q16+Q17 as auto_evaluable: 2."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 1
+        assert coverage["questions"]["auto_evaluable"] == 2
 
     def test_run_includes_evaluator_results_in_output(self, tmp_path: Path) -> None:
         """End-to-end via run() populates evaluator_results.Q16 in output JSON."""
@@ -719,3 +719,110 @@ class TestFrontierEvaluators:
         assert q16_result["answer_value"] == "yes"
         assert "environment(s)" in q16_result["evidence"]
         assert q16_result["used_for_scoring"] is True
+
+
+# ---------------------------------------------------------------------------
+# TestFrontierQ17Evaluator — Q17 evaluator tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_collected_with(
+    tmp_path: Path,
+    ppac_fixture: str | None = None,
+    sentinel_fixture: str | None = None,
+) -> Path:
+    """Set up a collected directory with optional PPAC and Sentinel fixtures."""
+    collected = tmp_path / "collected"
+    collected.mkdir(exist_ok=True)
+    if ppac_fixture is not None:
+        data = load_fixture(ppac_fixture)
+        write_json(collected / "ppac.json", data)
+    if sentinel_fixture is not None:
+        data = load_fixture(sentinel_fixture)
+        write_json(collected / "sentinel.json", data)
+    return collected
+
+
+class TestFrontierQ17Evaluator:
+    """Tests for the Q17 evaluator (tagged_environments_with_basic_telemetry)."""
+
+    def test_evaluator_q17_yes_with_tagged_envs_and_sentinel(self, tmp_path: Path) -> None:
+        """Tagged envs + Sentinel workspace → ('yes', evidence)."""
+        collected = _setup_collected_with(
+            tmp_path, "ppac_with_tagged_envs.json", "sentinel_with_workspace.json"
+        )
+        answer, evidence = score_frontier._eval_tagged_environments_with_basic_telemetry(collected)
+        assert answer == "yes"
+        assert "2/3 environments with tags" in evidence
+        assert "fsi-prod-siem" in evidence
+
+    def test_evaluator_q17_partial_with_tags_but_no_sentinel(self, tmp_path: Path) -> None:
+        """Tagged envs but no Sentinel workspace → ('partial', evidence)."""
+        collected = _setup_collected_with(
+            tmp_path, "ppac_with_tagged_envs.json", "sentinel_no_workspace.json"
+        )
+        answer, evidence = score_frontier._eval_tagged_environments_with_basic_telemetry(collected)
+        assert answer == "partial"
+        assert "2/3 environments with tags" in evidence
+        assert "Sentinel workspace not found" in evidence
+
+    def test_evaluator_q17_partial_with_sentinel_but_no_tags(self, tmp_path: Path) -> None:
+        """No tags/groups but Sentinel workspace present → ('partial', evidence)."""
+        collected = _setup_collected_with(
+            tmp_path, "ppac_no_tags_no_groups.json", "sentinel_with_workspace.json"
+        )
+        answer, evidence = score_frontier._eval_tagged_environments_with_basic_telemetry(collected)
+        assert answer == "partial"
+        assert "0/2 environments with tags" in evidence
+        assert "fsi-prod-siem" in evidence
+
+    def test_evaluator_q17_no_when_neither_present(self, tmp_path: Path) -> None:
+        """No tags/groups and no Sentinel workspace → ('no', evidence)."""
+        collected = _setup_collected_with(
+            tmp_path, "ppac_no_tags_no_groups.json", "sentinel_no_workspace.json"
+        )
+        answer, evidence = score_frontier._eval_tagged_environments_with_basic_telemetry(collected)
+        assert answer == "no"
+        assert "0/2 environments with tags" in evidence
+        assert "Sentinel workspace not found" in evidence
+
+    def test_evaluator_q17_inconclusive_when_ppac_errored(self, tmp_path: Path) -> None:
+        """PPAC with collector errors → (None, evidence)."""
+        collected = _setup_collected_with(
+            tmp_path, "ppac_with_errors.json", "sentinel_with_workspace.json"
+        )
+        answer, evidence = score_frontier._eval_tagged_environments_with_basic_telemetry(collected)
+        assert answer is None
+        assert "PPAC data unavailable" in evidence
+
+    def test_evaluator_q17_recognizes_environment_group_membership(self, tmp_path: Path) -> None:
+        """Envs with empty Tags but EnvironmentGroupId set + Sentinel → ('yes', group evidence)."""
+        collected = _setup_collected_with(
+            tmp_path, "ppac_with_env_group.json", "sentinel_with_workspace.json"
+        )
+        answer, evidence = score_frontier._eval_tagged_environments_with_basic_telemetry(collected)
+        assert answer == "yes"
+        assert "1 with group membership" in evidence
+        assert "1 environment group(s)" in evidence
+
+    def test_score_driver_q17_facilitator_wins_over_evaluator_partial(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator says 'yes' while evaluator returns 'partial' → facilitator answer used."""
+        collected = _setup_collected_with(
+            tmp_path, "ppac_with_tagged_envs.json", "sentinel_no_workspace.json"
+        )
+        questions = manifest_data["questions"]
+        # Facilitator explicitly says "yes" for Q17
+        answers = {"Q17": {"value": "yes"}}
+        result = score_frontier.score_driver(
+            "technology_data", questions, answers, collected_dir=collected
+        )
+        # L200 ratio should be 1.0 (from facilitator "yes"), not 0.5 (from evaluator "partial")
+        assert result["level_breakdown"]["200"]["ratio"] == pytest.approx(1.0)
+
+    def test_evaluator_coverage_q17_classified_as_auto(self, manifest_data: dict) -> None:
+        """After manifest update, coverage counts Q16 + Q17 as auto_evaluable: 2."""
+        questions = manifest_data["questions"]
+        coverage = score_frontier.compute_evaluator_coverage(questions)
+        assert coverage["questions"]["auto_evaluable"] == 2

--- a/docs/reference/frontier-assessment-coverage.md
+++ b/docs/reference/frontier-assessment-coverage.md
@@ -18,8 +18,8 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | State | Count | Share |
 |-------|-------|-------|
-| ✅ Auto | 1 | 4.0% |
-| 📝 Manual | 24 | 96.0% |
+| ✅ Auto | 2 | 8.0% |
+| 📝 Manual | 23 | 92.0% |
 | ⚠️ Unimplemented | 0 | 0.0% |
 | **Total** | 25 | 100% |
 
@@ -30,7 +30,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 | AI Strategy & Experience | 5 | 0 | 5 | 0 |
 | Business Strategy | 5 | 0 | 5 | 0 |
 | AI Governance & Security | 5 | 0 | 5 | 0 |
-| Technology & Data | 5 | 1 | 4 | 0 |
+| Technology & Data | 5 | 2 | 3 | 0 |
 | Organization & Culture | 5 | 0 | 5 | 0 |
 
 ## Per-question detail
@@ -70,7 +70,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 | Q ID | Level | Question | State | Pass Condition | Notes |
 |---|---|---|---|---|---|
 | Q16 | 100 | Is there any visibility into which Power Platform environments host AI agents... | ✅ Auto | `any_environment_visibility_for_agents` |  |
-| Q17 | 200 | Are some environments tagged or grouped for agent workloads, with basic telem... | 📝 Manual | `tagged_environments_with_basic_telemetry` | Facilitator-answered. |
+| Q17 | 200 | Are some environments tagged or grouped for agent workloads, with basic telem... | ✅ Auto | `tagged_environments_with_basic_telemetry` |  |
 | Q18 | 300 | Are Environment Groups with tier classification operational, with automated a... | 📝 Manual | `env_groups_with_inventory_siem_rag_and_lineage` | Facilitator-answered. |
 | Q19 | 400 | Does the platform provide integrated telemetry across Sentinel, the Agent 365... | 📝 Manual | `integrated_telemetry_with_curated_templates_and_agent_id` | Facilitator-answered. |
 | Q20 | 500 | Is the platform continuously monitored and version-controlled, with multi-age... | 📝 Manual | `continuous_platform_with_orchestration_limits_and_validated_grounding` | Facilitator-answered. |
@@ -92,8 +92,6 @@ The following questions have `pass_condition` strings populated, suggesting they
 - **Q01** (AI Strategy & Experience, L100): pass_condition `ai_initiative_owner_identified` — *plausible automation source: Graph API: query Entra directory roles for named CIO/CDAO assignment*
 - **Q03** (AI Strategy & Experience, L300): pass_condition `enterprise_ai_strategy_published_with_portfolio` — *plausible automation source: SharePoint PnP search for AI strategy document in Governance Committee site*
 - **Q13** (AI Governance & Security, L300): pass_condition `zone_classification_with_audit_supervision_and_model_risk` — *plausible automation source: PPAC environment list API: check for managed environment groups with zone tags*
-- **Q16** (Technology & Data, L100): pass_condition `any_environment_visibility_for_agents` — *plausible automation source: PPAC environments list API — non-empty response confirms platform-level visibility*
-- **Q17** (Technology & Data, L200): pass_condition `tagged_environments_with_basic_telemetry` — *plausible automation source: PPAC environment group/tag API plus Sentinel workspace log ingestion volume check*
 - **Q18** (Technology & Data, L300): pass_condition `env_groups_with_inventory_siem_rag_and_lineage` — *plausible automation source: PPAC Environment Groups API; Sentinel workspace connectivity; SharePoint permission scan logs*
 
 ## How to wire up an evaluator (future)

--- a/scripts/generate_coverage_matrix.py
+++ b/scripts/generate_coverage_matrix.py
@@ -311,16 +311,6 @@ _FRONTIER_EVALUATOR_CANDIDATES = [
         "PPAC environment list API: check for managed environment groups with zone tags",
     ),
     (
-        "Q16", "technology_data", 100,
-        "any_environment_visibility_for_agents",
-        "PPAC environments list API — non-empty response confirms platform-level visibility",
-    ),
-    (
-        "Q17", "technology_data", 200,
-        "tagged_environments_with_basic_telemetry",
-        "PPAC environment group/tag API plus Sentinel workspace log ingestion volume check",
-    ),
-    (
         "Q18", "technology_data", 300,
         "env_groups_with_inventory_siem_rag_and_lineage",
         "PPAC Environment Groups API; Sentinel workspace connectivity; SharePoint permission scan logs",


### PR DESCRIPTION
Extends Collect-PPAC.ps1 with two new sections:
- Section 8: Environment Groups enumeration via BAP admin API
- Section 9: Per-environment tag + group-membership enrichment

Implements Q17 evaluator (tagged_environments_with_basic_telemetry, L200 Technology & Data) using the framework from PR #215. Returns yes/partial/no based on env tags + Sentinel workspace presence; partial when only one signal present.

**Coverage:** 2/25 questions now auto-evaluated (was 1/25). Q16 unchanged.

**Validation:** All 9 gates pass — ruff, PSScriptAnalyzer, 72 pytest (16 new/updated frontier tests), drift, both coverage matrix checks, mkdocs --strict, language rules, control structure.