### PR TITLE
feat(frontier): add Q13 partial evaluator (zone classification + audit log)

### DIFF
--- a/assessment/engine/score_frontier.py
+++ b/assessment/engine/score_frontier.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -484,11 +485,205 @@ def _eval_tagged_environments_with_basic_telemetry(
     return "no", evidence
 
 
+# ---------------------------------------------------------------------------
+# Q13 evaluator — zone classification + audit log + model risk (partial-only)
+# ---------------------------------------------------------------------------
+
+# Zone tag matching patterns (case-insensitive).
+ZONE_TAG_KEY_PATTERN: re.Pattern = re.compile(r"^zone$", re.IGNORECASE)
+ZONE_TAG_VALUE_PATTERN: re.Pattern = re.compile(r"^[1-3]$")
+ZONE_SUBSTRING_PATTERN: re.Pattern = re.compile(r"zone", re.IGNORECASE)
+
+
+def _q13_zone_count(ppac: dict) -> int:
+    """Count environments meeting zone-classification criteria.
+
+    An environment is zone-classified if:
+      - Its ``Tags`` dict contains a key matching ``^zone$`` (case-insensitive)
+        with a value matching ``^[1-3]$``, OR any key/value containing "zone"
+        as a case-insensitive substring.
+      - OR its ``EnvironmentGroupId`` resolves to a group whose
+        ``DisplayName`` contains "zone" (case-insensitive).
+    """
+    environments = ppac.get("environments")
+    if not isinstance(environments, list):
+        return 0
+
+    # Build group-id → DisplayName lookup for env-group zone matching.
+    env_groups = ppac.get("environmentGroups")
+    group_names: dict[str, str] = {}
+    if isinstance(env_groups, list):
+        for grp in env_groups:
+            gid = grp.get("Id") or ""
+            name = grp.get("DisplayName") or ""
+            if gid:
+                group_names[gid] = name
+
+    count = 0
+    for env in environments:
+        # Check Tags dict.
+        tags = env.get("Tags")
+        if isinstance(tags, dict):
+            for key, value in tags.items():
+                key_str = str(key)
+                val_str = str(value)
+                if ZONE_TAG_KEY_PATTERN.match(key_str) and ZONE_TAG_VALUE_PATTERN.match(val_str):
+                    count += 1
+                    break
+                if ZONE_SUBSTRING_PATTERN.search(key_str) or ZONE_SUBSTRING_PATTERN.search(val_str):
+                    count += 1
+                    break
+            else:
+                # Tags didn't match — fall through to group check.
+                gid = env.get("EnvironmentGroupId")
+                if gid and gid in group_names and ZONE_SUBSTRING_PATTERN.search(group_names[gid]):
+                    count += 1
+        else:
+            # No tags — check group membership.
+            gid = env.get("EnvironmentGroupId")
+            if gid and gid in group_names and ZONE_SUBSTRING_PATTERN.search(group_names[gid]):
+                count += 1
+
+    return count
+
+
+def _q13_audit_enabled(purview: dict) -> bool | None:
+    """Check whether unified audit log ingestion is enabled.
+
+    Mirrors the controls-side ``_eval_audit_log_enabled`` read pattern.
+    Returns ``True`` if enabled, ``False`` if explicitly disabled, or
+    ``None`` if the relevant field is absent.
+    """
+    config = purview.get("audit_config")
+    if config is None:
+        return None
+    enabled = config.get("UnifiedAuditLogIngestionEnabled")
+    if enabled is True:
+        return True
+    if enabled is False:
+        return False
+    return None
+
+
+def _eval_zone_classification_with_audit_supervision_and_model_risk(
+    collected_dir: Path,
+) -> tuple[str | None, str]:
+    """Q13 evaluator: zone classification + audit log + model risk overlay.
+
+    Checks two of three L300 signals from telemetry:
+      1. Zone-classified Managed Environments (PPAC env tags/groups)
+      2. Comprehensive audit signals (Purview UnifiedAuditLogIngestionEnabled)
+
+    The third signal — model-risk overlay — is structurally non-telemetry-
+    verifiable (typically a SharePoint document policy or model-card registry).
+
+    **Auto-cap rule:** This evaluator NEVER returns ``"yes"``. The maximum
+    auto-confirmable answer is ``"partial"`` because the third signal (model
+    risk) cannot be verified from any of the 5 existing collectors. The
+    facilitator can upgrade to ``"yes"`` via their own answer (which always
+    wins per framework design).
+
+    Returns:
+      - ``("partial", evidence)`` — both zone tags and audit log verified;
+        evidence notes that model-risk overlay requires facilitator confirmation.
+      - ``("partial", evidence)`` — only one of {zone, audit} present; evidence
+        describes which is missing.
+      - ``("no", evidence)`` — neither zone tags nor audit log enabled.
+      - ``(None, evidence)`` — both ppac.json and purview.json missing or errored.
+    """
+    model_risk_caveat = "model-risk overlay requires facilitator confirmation"
+
+    # --- Load PPAC data ---
+    ppac, ppac_err = _load_collected_json(collected_dir, "ppac.json")
+    ppac_available = False
+    zone_count = 0
+    zone_evidence = ""
+
+    if ppac is not None:
+        metadata = ppac.get("_metadata") or {}
+        errors = metadata.get("errors") or []
+        if errors:
+            first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+            ppac_err = f"collector reported errors ({first_error})"
+        else:
+            ppac_available = True
+            zone_count = _q13_zone_count(ppac)
+
+    if ppac_available:
+        # Build a brief summary of matched zone tags for evidence.
+        tag_samples: list[str] = []
+        environments = ppac.get("environments") or []
+        for env in environments:
+            tags = env.get("Tags")
+            if isinstance(tags, dict):
+                for key, value in tags.items():
+                    key_str = str(key)
+                    val_str = str(value)
+                    if ZONE_TAG_KEY_PATTERN.match(key_str) and ZONE_TAG_VALUE_PATTERN.match(val_str):
+                        tag_samples.append(f"'{key_str}:{val_str}'")
+                        break
+                    if ZONE_SUBSTRING_PATTERN.search(key_str) or ZONE_SUBSTRING_PATTERN.search(val_str):
+                        tag_samples.append(f"'{key_str}:{val_str}'")
+                        break
+        if tag_samples:
+            zone_evidence = (
+                f"PPAC reported {zone_count} zone-classified environment(s) "
+                f"(tags: {', '.join(tag_samples[:5])})"
+            )
+        else:
+            zone_evidence = f"PPAC reported {zone_count} zone-classified environment(s)"
+    else:
+        zone_evidence = f"PPAC data unavailable: {ppac_err}"
+
+    # --- Load Purview data ---
+    purview, purview_err = _load_collected_json(collected_dir, "purview.json")
+    purview_available = False
+    audit_enabled: bool | None = None
+    audit_evidence = ""
+
+    if purview is not None:
+        metadata = purview.get("_metadata") or {}
+        errors = metadata.get("errors") or []
+        if errors:
+            first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+            purview_err = f"collector reported errors ({first_error})"
+        else:
+            purview_available = True
+            audit_enabled = _q13_audit_enabled(purview)
+
+    if purview_available and audit_enabled is not None:
+        audit_evidence = (
+            f"audit log {'enabled' if audit_enabled else 'NOT enabled'} "
+            f"(UnifiedAuditLogIngestionEnabled={str(audit_enabled).lower()})"
+        )
+    elif purview_available:
+        audit_evidence = "audit_config field absent in Purview data"
+    else:
+        audit_evidence = f"Purview data unavailable: {purview_err}"
+
+    # --- Both sources unavailable → inconclusive ---
+    if not ppac_available and not purview_available:
+        return None, f"PPAC and Purview data both unavailable: {ppac_err}; {purview_err}"
+
+    # --- Determine result ---
+    has_zones = zone_count > 0
+    has_audit = audit_enabled is True
+
+    evidence = f"{zone_evidence}; {audit_evidence}; {model_risk_caveat}"
+
+    if has_zones and has_audit:
+        return "partial", evidence
+    if has_zones or has_audit:
+        return "partial", evidence
+    return "no", evidence
+
+
 # --- Evaluator registry ---------------------------------------------------
 
 EVALUATORS: dict[str, object] = {
     "any_environment_visibility_for_agents": _eval_any_environment_visibility_for_agents,
     "tagged_environments_with_basic_telemetry": _eval_tagged_environments_with_basic_telemetry,
+    "zone_classification_with_audit_supervision_and_model_risk": _eval_zone_classification_with_audit_supervision_and_model_risk,
 }
 
 

--- a/assessment/manifest/frontier-readiness.json
+++ b/assessment/manifest/frontier-readiness.json
@@ -204,10 +204,11 @@
       "fsi_context": "Defined maturity requires zone-classified environments, retention-grade audit logging, named supervisors, and model risk tiering — the four evidence pillars an FSI examiner will request first when reviewing AI agent governance.",
       "answer_format": "yes_no_partial",
       "scoring_weight": 1.0,
-      "auto_evaluable": false,
+      "auto_evaluable": true,
       "pass_condition": "zone_classification_with_audit_supervision_and_model_risk",
-      "collection_methods": ["Manual"],
-      "regulatory_relevance": ["FINRA-3110", "FINRA-4511", "SEC-17a-4", "OCC-2011-12", "Fed-SR-11-7"]
+      "collection_methods": ["Manual", "PPAC_API", "Purview_PowerShell"],
+      "regulatory_relevance": ["FINRA-3110", "FINRA-4511", "SEC-17a-4", "OCC-2011-12", "Fed-SR-11-7"],
+      "notes": "Auto-evaluator caps suggested answer at 'partial' because model-risk overlay (the third L300 signal) is not telemetry-verifiable. Facilitator must confirm model risk separately to upgrade to 'yes'."
     },
     {
       "question_id": "Q14",

--- a/assessment/tests/fixtures/ppac_with_zone_env_group.json
+++ b/assessment/tests/fixtures/ppac_with_zone_env_group.json
@@ -1,0 +1,34 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Default",
+      "EnvironmentName": "env-default-001",
+      "EnvironmentSku": "Default",
+      "Tags": {},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Prod-CoE",
+      "EnvironmentName": "env-prod-coe-001",
+      "EnvironmentSku": "Production",
+      "Tags": {},
+      "EnvironmentGroupId": "grp-zone-2-001"
+    }
+  ],
+  "environmentGroups": [
+    {
+      "Id": "grp-zone-2-001",
+      "DisplayName": "Production-Zone-2",
+      "Description": "Zone 2 production environments for FSI agents",
+      "CreatedTime": "2026-01-15T10:00:00Z",
+      "EnvironmentCount": 1
+    }
+  ]
+}

--- a/assessment/tests/fixtures/ppac_with_zone_tags.json
+++ b/assessment/tests/fixtures/ppac_with_zone_tags.json
@@ -1,0 +1,40 @@
+{
+  "_metadata": {
+    "collector": "PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Default",
+      "EnvironmentName": "env-default-001",
+      "EnvironmentSku": "Default",
+      "Tags": {},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Prod-Agents",
+      "EnvironmentName": "env-prod-agents-001",
+      "EnvironmentSku": "Production",
+      "Tags": {"zone": "1", "workload": "agent"},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Prod-Compliance",
+      "EnvironmentName": "env-prod-compliance-001",
+      "EnvironmentSku": "Production",
+      "Tags": {"Zone": "2"},
+      "EnvironmentGroupId": null
+    },
+    {
+      "DisplayName": "Dev-Sandbox",
+      "EnvironmentName": "env-dev-001",
+      "EnvironmentSku": "Sandbox",
+      "Tags": {"zone": "3"},
+      "EnvironmentGroupId": null
+    }
+  ],
+  "environmentGroups": []
+}

--- a/assessment/tests/fixtures/purview_with_audit_disabled.json
+++ b/assessment/tests/fixtures/purview_with_audit_disabled.json
@@ -1,0 +1,20 @@
+{
+  "_metadata": {
+    "collector": "Purview",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "audit_config": {
+    "UnifiedAuditLogIngestionEnabled": false
+  },
+  "dlp_policies": [],
+  "retention_policies": [],
+  "communication_compliance": [],
+  "ediscovery_cases": [],
+  "insider_risk_policies": [],
+  "dspm_for_ai": null,
+  "sensitivity_labels": [],
+  "endpoint_dlp": []
+}

--- a/assessment/tests/fixtures/purview_with_audit_enabled.json
+++ b/assessment/tests/fixtures/purview_with_audit_enabled.json
@@ -1,0 +1,20 @@
+{
+  "_metadata": {
+    "collector": "Purview",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": []
+  },
+  "audit_config": {
+    "UnifiedAuditLogIngestionEnabled": true
+  },
+  "dlp_policies": [],
+  "retention_policies": [],
+  "communication_compliance": [],
+  "ediscovery_cases": [],
+  "insider_risk_policies": [],
+  "dspm_for_ai": null,
+  "sensitivity_labels": [],
+  "endpoint_dlp": []
+}

--- a/assessment/tests/fixtures/purview_with_errors.json
+++ b/assessment/tests/fixtures/purview_with_errors.json
@@ -1,0 +1,18 @@
+{
+  "_metadata": {
+    "collector": "Purview",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "errors": ["Connect-ExchangeOnline failed: authentication timeout"]
+  },
+  "audit_config": null,
+  "dlp_policies": [],
+  "retention_policies": [],
+  "communication_compliance": [],
+  "ediscovery_cases": [],
+  "insider_risk_policies": [],
+  "dspm_for_ai": null,
+  "sensitivity_labels": [],
+  "endpoint_dlp": []
+}

--- a/assessment/tests/test_score_frontier.py
+++ b/assessment/tests/test_score_frontier.py
@@ -418,11 +418,11 @@ class TestEvaluatorCoverage:
     """Unit tests for compute_evaluator_coverage()."""
 
     def test_v1_counts_after_q16_q17_wiring(self, manifest_data: dict) -> None:
-        """Real frontier-readiness.json post-Q16/Q17: 2 auto, 23 manual, 0 unimplemented."""
+        """Real frontier-readiness.json post-Q16/Q17/Q13: 3 auto, 22 manual, 0 unimplemented."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 2
-        assert coverage["questions"]["manual_only"] == 23
+        assert coverage["questions"]["auto_evaluable"] == 3
+        assert coverage["questions"]["manual_only"] == 22
         assert coverage["questions"]["unimplemented_evaluator"] == 0
         assert coverage["total_questions"] == 25
 
@@ -691,10 +691,10 @@ class TestFrontierEvaluators:
         assert result["questions_answered"] >= 1
 
     def test_evaluator_coverage_q16_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage matrix counts Q16+Q17 as auto_evaluable: 2."""
+        """After manifest update, coverage matrix counts Q16+Q17+Q13 as auto_evaluable: 3."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 2
+        assert coverage["questions"]["auto_evaluable"] == 3
 
     def test_run_includes_evaluator_results_in_output(self, tmp_path: Path) -> None:
         """End-to-end via run() populates evaluator_results.Q16 in output JSON."""
@@ -825,4 +825,157 @@ class TestFrontierQ17Evaluator:
         """After manifest update, coverage counts Q16 + Q17 as auto_evaluable: 2."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 2
+        # Updated: Q13 is now also auto-evaluable → 3 total.
+        assert coverage["questions"]["auto_evaluable"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Helper for Q13 test setup
+# ---------------------------------------------------------------------------
+
+
+def _setup_q13_collected(
+    tmp_path: Path,
+    ppac_fixture: str | None = None,
+    purview_fixture: str | None = None,
+) -> Path:
+    """Set up a collected directory with optional PPAC and Purview fixtures."""
+    collected = tmp_path / "collected"
+    collected.mkdir(exist_ok=True)
+    if ppac_fixture is not None:
+        data = load_fixture(ppac_fixture)
+        write_json(collected / "ppac.json", data)
+    if purview_fixture is not None:
+        data = load_fixture(purview_fixture)
+        write_json(collected / "purview.json", data)
+    return collected
+
+
+# ---------------------------------------------------------------------------
+# TestFrontierQ13Evaluator — Q13 evaluator tests
+# ---------------------------------------------------------------------------
+
+
+class TestFrontierQ13Evaluator:
+    """Tests for the Q13 evaluator (zone_classification_with_audit_supervision_and_model_risk)."""
+
+    def test_evaluator_q13_partial_when_zone_tags_and_audit_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Zone-tagged envs + audit enabled → ('partial', evidence noting model risk)."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_with_zone_tags.json", "purview_with_audit_enabled.json"
+        )
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer == "partial"
+        assert "zone-classified environment(s)" in evidence
+        assert "audit log enabled" in evidence
+        assert "model-risk overlay requires facilitator confirmation" in evidence
+
+    def test_evaluator_q13_partial_when_only_audit_present(
+        self, tmp_path: Path
+    ) -> None:
+        """No zone tags + audit enabled → ('partial', evidence noting zones missing)."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_no_tags_no_groups.json", "purview_with_audit_enabled.json"
+        )
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer == "partial"
+        assert "0 zone-classified environment(s)" in evidence
+        assert "audit log enabled" in evidence
+
+    def test_evaluator_q13_partial_when_only_zone_tags_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Zone-tagged envs + audit disabled → ('partial', evidence noting audit missing)."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_with_zone_tags.json", "purview_with_audit_disabled.json"
+        )
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer == "partial"
+        assert "zone-classified environment(s)" in evidence
+        assert "NOT enabled" in evidence
+
+    def test_evaluator_q13_no_when_neither_signal(self, tmp_path: Path) -> None:
+        """No zone tags + audit disabled → ('no', evidence)."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_no_tags_no_groups.json", "purview_with_audit_disabled.json"
+        )
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer == "no"
+        assert "0 zone-classified environment(s)" in evidence
+        assert "NOT enabled" in evidence
+
+    def test_evaluator_q13_inconclusive_when_both_missing(self, tmp_path: Path) -> None:
+        """No ppac.json and no purview.json → (None, evidence)."""
+        collected = _setup_q13_collected(tmp_path)
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer is None
+        assert "PPAC and Purview data both unavailable" in evidence
+
+    def test_evaluator_q13_inconclusive_when_both_errored(self, tmp_path: Path) -> None:
+        """PPAC and Purview both have collector errors → (None, evidence)."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_with_errors.json", "purview_with_errors.json"
+        )
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer is None
+        assert "PPAC and Purview data both unavailable" in evidence
+
+    def test_evaluator_q13_recognizes_env_group_zone_naming(self, tmp_path: Path) -> None:
+        """Envs with EnvironmentGroupId pointing to 'Production-Zone-2' → zone-classified."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_with_zone_env_group.json", "purview_with_audit_enabled.json"
+        )
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer == "partial"
+        assert "zone-classified environment(s)" in evidence
+        # Must find at least 1 zone-classified env via group naming.
+        assert "0 zone-classified" not in evidence
+
+    def test_evaluator_q13_NEVER_returns_yes(self, tmp_path: Path) -> None:
+        """Even with both signals present and zone_count > 0, evaluator returns 'partial' not 'yes'."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_with_zone_tags.json", "purview_with_audit_enabled.json"
+        )
+        answer, evidence = score_frontier._eval_zone_classification_with_audit_supervision_and_model_risk(collected)
+        assert answer != "yes", "Q13 evaluator must NEVER return 'yes' — model risk is not auto-verifiable"
+        assert answer == "partial"
+
+    def test_score_driver_q13_facilitator_can_upgrade_to_yes(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator says 'yes' while evaluator returns 'partial' → facilitator wins."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_with_zone_tags.json", "purview_with_audit_enabled.json"
+        )
+        questions = manifest_data["questions"]
+        # Facilitator explicitly says "yes" for Q13.
+        answers = {"Q13": {"value": "yes"}}
+        result = score_frontier.score_driver(
+            "ai_governance", questions, answers, collected_dir=collected
+        )
+        # L300 ratio should be 1.0 (from facilitator "yes"), not 0.5 (from evaluator "partial").
+        assert result["level_breakdown"]["300"]["ratio"] == pytest.approx(1.0)
+
+    def test_score_driver_q13_facilitator_can_downgrade_to_no(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator says 'no' while evaluator returns 'partial' → facilitator wins."""
+        collected = _setup_q13_collected(
+            tmp_path, "ppac_with_zone_tags.json", "purview_with_audit_enabled.json"
+        )
+        questions = manifest_data["questions"]
+        # Facilitator explicitly says "no" for Q13.
+        answers = {"Q13": {"value": "no"}}
+        result = score_frontier.score_driver(
+            "ai_governance", questions, answers, collected_dir=collected
+        )
+        # L300 ratio should be 0.0 (from facilitator "no"), not 0.5 (from evaluator "partial").
+        assert result["level_breakdown"]["300"]["ratio"] == pytest.approx(0.0)
+
+    def test_evaluator_coverage_q13_classified_as_auto(self, manifest_data: dict) -> None:
+        """After manifest update, coverage shows 3 auto-evaluators (Q16 + Q17 + Q13)."""
+        questions = manifest_data["questions"]
+        coverage = score_frontier.compute_evaluator_coverage(questions)
+        assert coverage["questions"]["auto_evaluable"] == 3

--- a/docs/reference/frontier-assessment-coverage.md
+++ b/docs/reference/frontier-assessment-coverage.md
@@ -18,8 +18,8 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | State | Count | Share |
 |-------|-------|-------|
-| ✅ Auto | 2 | 8.0% |
-| 📝 Manual | 23 | 92.0% |
+| ✅ Auto | 3 | 12.0% |
+| 📝 Manual | 22 | 88.0% |
 | ⚠️ Unimplemented | 0 | 0.0% |
 | **Total** | 25 | 100% |
 
@@ -29,7 +29,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 |---|---|---|---|---|
 | AI Strategy & Experience | 5 | 0 | 5 | 0 |
 | Business Strategy | 5 | 0 | 5 | 0 |
-| AI Governance & Security | 5 | 0 | 5 | 0 |
+| AI Governance & Security | 5 | 1 | 4 | 0 |
 | Technology & Data | 5 | 2 | 3 | 0 |
 | Organization & Culture | 5 | 0 | 5 | 0 |
 
@@ -61,7 +61,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 |---|---|---|---|---|---|
 | Q11 | 100 | Does the organization have any informal guardrails (acceptable use guidance, ... | 📝 Manual | `informal_guardrails_in_place` | Facilitator-answered. |
 | Q12 | 200 | In some business units, are platform controls (DLP, audit logging) applied to... | 📝 Manual | `bu_level_platform_controls_and_written_policy` | Facilitator-answered. |
-| Q13 | 300 | Are agents classified into Zone-tiered Managed Environments with comprehensiv... | 📝 Manual | `zone_classification_with_audit_supervision_and_model_risk` | Facilitator-answered. |
+| Q13 | 300 | Are agents classified into Zone-tiered Managed Environments with comprehensiv... | ✅ Auto | `zone_classification_with_audit_supervision_and_model_risk` | Auto-evaluator caps suggested answer at 'partial' because model-risk overlay (the third L300 signal) is not telemetry-verifiable. Facilitator must confirm model risk separately to upgrade to 'yes'. |
 | Q14 | 400 | Do risk metrics flow into a risk committee on a documented cadence, supported... | 📝 Manual | `risk_metrics_to_committee_with_tested_runbooks` | Facilitator-answered. |
 | Q15 | 500 | Does the organization operate continuous control monitoring with risk-tier-ba... | 📝 Manual | `continuous_monitoring_with_release_gates_and_examiner_drills` | Facilitator-answered. |
 
@@ -91,7 +91,6 @@ The following questions have `pass_condition` strings populated, suggesting they
 
 - **Q01** (AI Strategy & Experience, L100): pass_condition `ai_initiative_owner_identified` — *plausible automation source: Graph API: query Entra directory roles for named CIO/CDAO assignment*
 - **Q03** (AI Strategy & Experience, L300): pass_condition `enterprise_ai_strategy_published_with_portfolio` — *plausible automation source: SharePoint PnP search for AI strategy document in Governance Committee site*
-- **Q13** (AI Governance & Security, L300): pass_condition `zone_classification_with_audit_supervision_and_model_risk` — *plausible automation source: PPAC environment list API: check for managed environment groups with zone tags*
 - **Q18** (Technology & Data, L300): pass_condition `env_groups_with_inventory_siem_rag_and_lineage` — *plausible automation source: PPAC Environment Groups API; Sentinel workspace connectivity; SharePoint permission scan logs*
 
 ## How to wire up an evaluator (future)

--- a/scripts/generate_coverage_matrix.py
+++ b/scripts/generate_coverage_matrix.py
@@ -306,11 +306,6 @@ _FRONTIER_EVALUATOR_CANDIDATES = [
         "SharePoint PnP search for AI strategy document in Governance Committee site",
     ),
     (
-        "Q13", "ai_governance", 300,
-        "zone_classification_with_audit_supervision_and_model_risk",
-        "PPAC environment list API: check for managed environment groups with zone tags",
-    ),
-    (
         "Q18", "technology_data", 300,
         "env_groups_with_inventory_siem_rag_and_lineage",
         "PPAC Environment Groups API; Sentinel workspace connectivity; SharePoint permission scan logs",
@@ -410,7 +405,7 @@ def render_frontier(manifest: dict) -> str:
                 qtext = qtext[:77] + "..."
             qtext = qtext.replace("|", "\\|")
             pc = q.get("pass_condition", "")
-            notes = "Facilitator-answered." if state == "manual_only" else ""
+            notes = "Facilitator-answered." if state == "manual_only" else q.get("notes", "")
             lines.append(
                 f"| {q['question_id']} | {q['level']} | {qtext}"
                 f" | {STATE_ICON[state]} {STATE_LABEL[state]}"


### PR DESCRIPTION
Implements Q13 evaluator (zone_classification_with_audit_supervision_and_model_risk, L300 AI Governance) consuming PPAC env tags/groups + Purview audit log config.

**Two of three required L300 signals auto-verified:**
- Zone-classified Managed Environments (PPAC tags or env-group naming)
- UnifiedAuditLogIngestionEnabled (Purview audit_config)

**Third signal (model-risk overlay) is structurally non-telemetry-verifiable.**

**Auto-cap design:** evaluator NEVER returns 'yes' — maximum auto-confirmable answer is 'partial' with evidence noting model-risk requires facilitator confirmation. Facilitator can upgrade to 'yes' or downgrade to 'no' via manual answer (always wins per framework design).

**Coverage:** 3/25 questions now auto-evaluated (was 2/25). Q16, Q17 unchanged.

**Validation:** All 8 gates pass — ruff, 83 pytest (11 new Q13 tests + 8 updated coverage assertions), drift, both coverage matrix checks, mkdocs --strict, language rules, control structure.