### PR TITLE
feat(frontier): add Q01 evaluator + Graph AI-leadership job-title enumeration

### DIFF
--- a/assessment/collectors/Collect-Graph.ps1
+++ b/assessment/collectors/Collect-Graph.ps1
@@ -4,8 +4,8 @@
 
 .DESCRIPTION
     Enumerates Conditional Access policies, FSI-Agent security groups, privileged role
-    assignments, Copilot Studio service principals, and tenant security settings via
-    Microsoft Graph.
+    assignments, Copilot Studio service principals, tenant security settings, and
+    AI-leadership job titles via Microsoft Graph.
 
     Outputs a structured JSON file (graph.json) consumed by the assessment engine.
 
@@ -31,13 +31,14 @@
 
 .OUTPUTS
     graph.json — JSON file with CA policies, security groups, privileged roles,
-    service principals, information barriers, and tenant settings.
+    service principals, information barriers, tenant settings, and AI-leadership users.
 
 .NOTES
     Part of the FSI Agent Governance Assessment Engine — Graph Collector.
-    Required Graph scopes: Policy.Read.All, Group.Read.All, Directory.Read.All, AuditLog.Read.All.
+    Required Graph scopes: Policy.Read.All, Group.Read.All, Directory.Read.All,
+    AuditLog.Read.All, User.Read.All.
     Exit codes: 0 = success, 1 = partial failure (some sections null), 2 = total failure.
-    Version: 1.0.0
+    Version: 1.1.0
 #>
 
 #Requires -Version 7.0
@@ -321,6 +322,89 @@ catch {
 }
 
 # ═══════════════════════════════════════════════════════════════════════
+# Section 7: AI Leadership Job Titles
+# Supports: Frontier Q01 (ai_initiative_owner_identified) — AI Strategy L100
+# Prereq: User.Read.All Graph scope (incremental; Graph auth already required)
+# ═══════════════════════════════════════════════════════════════════════
+$aiLeadershipUsers = $null
+try {
+    Write-Verbose "Section 7: Enumerating AI-leadership job titles..."
+
+    # AI-leadership keyword fragments for post-filtering
+    $aiKeywords = @(
+        'Chief Data Officer', 'Chief Information Officer', 'Chief AI Officer',
+        'Chief Digital Officer', 'Chief Analytics Officer',
+        'Chief Data and Analytics Officer', 'Chief Technology Officer',
+        'Head of AI', 'Head of Data', 'Head of Digital',
+        'AI Governance Lead', 'AI Officer',
+        'Director of AI', 'VP of AI', 'VP of Data', 'VP of Digital',
+        'CDO', 'CIO', 'CTO'
+    )
+    $selectProps = @('DisplayName', 'UserPrincipalName', 'JobTitle', 'Department')
+
+    # Two narrow server-side filters to limit API response volume
+    $rawUsers = @()
+    try {
+        $rawUsers += @(Get-MgUser -Filter "startswith(jobTitle,'Chief')" `
+            -Property $selectProps -All -ErrorAction Stop)
+    }
+    catch {
+        $warnings.Add("Section 7 filter 'Chief' failed: $($_.Exception.Message)")
+        Write-Warning $warnings[-1]
+    }
+    try {
+        $rawUsers += @(Get-MgUser -Filter "startswith(jobTitle,'Head of') or startswith(jobTitle,'VP of') or startswith(jobTitle,'Director of') or startswith(jobTitle,'AI ')" `
+            -Property $selectProps -All -ErrorAction Stop)
+    }
+    catch {
+        $warnings.Add("Section 7 filter 'Head/VP/Director/AI' failed: $($_.Exception.Message)")
+        Write-Warning $warnings[-1]
+    }
+
+    # Deduplicate by UserPrincipalName
+    $uniqueUsers = @($rawUsers | Sort-Object UserPrincipalName -Unique)
+
+    # Post-filter: match job titles against canonical AI-leadership keywords
+    $matchedUsers = @(foreach ($user in $uniqueUsers) {
+        if (-not $user.JobTitle) { continue }
+        $titleLower = $user.JobTitle.ToLower()
+        $matchedKeyword = $null
+        foreach ($kw in $aiKeywords) {
+            $kwLower = $kw.ToLower()
+            # Short acronyms (CDO, CIO, CTO): require word boundary
+            if ($kwLower.Length -le 3) {
+                if ($titleLower -match "\b$([regex]::Escape($kwLower))\b") {
+                    $matchedKeyword = $kw
+                    break
+                }
+            }
+            else {
+                if ($titleLower.Contains($kwLower)) {
+                    $matchedKeyword = $kw
+                    break
+                }
+            }
+        }
+        if ($matchedKeyword) {
+            [PSCustomObject]@{
+                DisplayName       = $user.DisplayName
+                UserPrincipalName = $user.UserPrincipalName
+                JobTitle          = $user.JobTitle
+                Department        = $user.Department
+                MatchedKeyword    = $matchedKeyword
+            }
+        }
+    })
+
+    $aiLeadershipUsers = $matchedUsers
+    Write-Verbose "  Found $($aiLeadershipUsers.Count) user(s) with AI-leadership job titles."
+}
+catch {
+    $warnings.Add("Section 7 (AI Leadership Job Titles) failed: $($_.Exception.Message)")
+    Write-Warning $warnings[-1]
+}
+
+# ═══════════════════════════════════════════════════════════════════════
 # Build Output
 # ═══════════════════════════════════════════════════════════════════════
 $result = [ordered]@{
@@ -330,6 +414,7 @@ $result = [ordered]@{
     privilegedRoleAssignments  = $privilegedRoleAssignments
     copilotServicePrincipals   = $copilotServicePrincipals
     tenantSecuritySettings     = $tenantSecuritySettings
+    aiLeadershipUsers          = $aiLeadershipUsers
     _metadata                  = [ordered]@{
         collector   = 'Collect-Graph'
         timestamp   = (Get-Date -Format 'o')
@@ -348,7 +433,8 @@ try { Disconnect-MgGraph -ErrorAction SilentlyContinue } catch { }
 # ─── Exit Code ───────────────────────────────────────────────────────
 $sectionValues = @(
     $conditionalAccessPolicies, $fsiSecurityGroups, $informationBarriers,
-    $privilegedRoleAssignments, $copilotServicePrincipals, $tenantSecuritySettings
+    $privilegedRoleAssignments, $copilotServicePrincipals, $tenantSecuritySettings,
+    $aiLeadershipUsers
 )
 $nullSections = @($sectionValues | Where-Object { $null -eq $_ })
 

--- a/assessment/engine/score_frontier.py
+++ b/assessment/engine/score_frontier.py
@@ -678,12 +678,129 @@ def _eval_zone_classification_with_audit_supervision_and_model_risk(
     return "no", evidence
 
 
+# ---------------------------------------------------------------------------
+# Q01 evaluator — AI initiative owner identified
+# ---------------------------------------------------------------------------
+
+# Canonical AI-leadership job title keywords (case-insensitive substring match).
+# Short tokens ("AI", "CDO", "CIO", "CTO") require word-boundary matching to
+# avoid false positives (e.g. "MAID", "ACIDOTIC").
+AI_LEADERSHIP_TITLES: tuple[str, ...] = (
+    "chief data officer",
+    "chief information officer",
+    "chief ai officer",
+    "chief digital officer",
+    "chief analytics officer",
+    "chief data and analytics officer",
+    "chief technology officer",
+    "head of ai",
+    "head of data",
+    "head of digital",
+    "ai governance lead",
+    "ai officer",
+    "director of ai",
+    "vp of ai",
+    "vp of data",
+    "vp of digital",
+)
+
+# Short acronyms that require word-boundary matching.
+_AI_LEADERSHIP_ACRONYMS: tuple[str, ...] = ("cdo", "cio", "cto")
+
+_ACRONYM_PATTERN = re.compile(
+    r"\b(?:" + "|".join(re.escape(a) for a in _AI_LEADERSHIP_ACRONYMS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def _match_ai_leadership_title(job_title: str) -> str | None:
+    """Return the matched keyword phrase if *job_title* matches, else ``None``."""
+    lower = job_title.lower()
+    for phrase in AI_LEADERSHIP_TITLES:
+        if phrase in lower:
+            return phrase.title()
+    if _ACRONYM_PATTERN.search(lower):
+        return _ACRONYM_PATTERN.search(lower).group(0).upper()  # type: ignore[union-attr]
+    return None
+
+
+def _eval_ai_initiative_owner_identified(
+    collected_dir: Path,
+) -> tuple[str | None, str]:
+    """Q01 evaluator: check graph.json for AI-leadership job titles.
+
+    Returns:
+      - ("yes", evidence) — at least one user with an AI-leadership title found.
+      - ("partial", evidence) — no AI titles but senior admin roles assigned.
+      - ("no", evidence) — neither AI titles nor senior admin assignments.
+      - (None, evidence) — graph.json missing or both data sections errored.
+    """
+    graph, err = _load_collected_json(collected_dir, "graph.json")
+    if graph is None:
+        return None, f"Graph data unavailable: {err}"
+
+    metadata = graph.get("_metadata") or {}
+
+    # --- Primary signal: AI leadership job titles (Section 7) ---
+    ai_users = graph.get("aiLeadershipUsers")
+    section7_available = ai_users is not None
+
+    matched_users: list[tuple[str, str]] = []  # (displayName, matchedKeyword)
+    if isinstance(ai_users, list):
+        for user in ai_users:
+            display = user.get("DisplayName") or user.get("displayName") or "Unknown"
+            keyword = user.get("MatchedKeyword") or user.get("matchedKeyword") or ""
+            if keyword:
+                matched_users.append((display, keyword))
+            else:
+                # Re-check title in case MatchedKeyword is absent
+                title = user.get("JobTitle") or user.get("jobTitle") or ""
+                kw = _match_ai_leadership_title(title)
+                if kw:
+                    matched_users.append((display, kw))
+
+    if matched_users:
+        if len(matched_users) > 5:
+            shown = matched_users[:3]
+            remainder = len(matched_users) - 3
+            listing = ", ".join(f"'{n} ({k})'" for n, k in shown)
+            listing += f" and {remainder} more"
+        else:
+            listing = ", ".join(f"'{n} ({k})'" for n, k in matched_users)
+        return (
+            "yes",
+            f"Found {len(matched_users)} user(s) with AI-leadership titles: {listing}",
+        )
+
+    # --- Secondary signal: privileged role assignments (Section 4) ---
+    priv_roles = graph.get("privilegedRoleAssignments")
+    section4_available = priv_roles is not None
+
+    if not section7_available and not section4_available:
+        # Both sections failed or missing — check for errors in metadata.
+        errors = metadata.get("errors") or metadata.get("warnings") or []
+        if errors:
+            first = errors[0] if isinstance(errors[0], str) else str(errors[0])
+            return None, f"Graph data unavailable: collector reported errors ({first})"
+        return None, "Graph data unavailable: neither aiLeadershipUsers nor privilegedRoleAssignments present"
+
+    if isinstance(priv_roles, list) and len(priv_roles) > 0:
+        return (
+            "partial",
+            f"No AI-specific titles found; {len(priv_roles)} senior platform admin "
+            f"assignment(s) present (informal accountability)",
+        )
+
+    return "no", "No AI-leadership titles or senior admin assignments found in tenant"
+
+
 # --- Evaluator registry ---------------------------------------------------
 
 EVALUATORS: dict[str, object] = {
     "any_environment_visibility_for_agents": _eval_any_environment_visibility_for_agents,
     "tagged_environments_with_basic_telemetry": _eval_tagged_environments_with_basic_telemetry,
     "zone_classification_with_audit_supervision_and_model_risk": _eval_zone_classification_with_audit_supervision_and_model_risk,
+    "ai_initiative_owner_identified": _eval_ai_initiative_owner_identified,
 }
 
 

--- a/assessment/manifest/frontier-readiness.json
+++ b/assessment/manifest/frontier-readiness.json
@@ -48,9 +48,9 @@
       "fsi_context": "Examiners begin with 'who is accountable for AI?' An identifiable owner is the minimum starting point for any AI program; without one, the firm cannot answer the first supervisory question.",
       "answer_format": "yes_no_partial",
       "scoring_weight": 1.0,
-      "auto_evaluable": false,
+      "auto_evaluable": true,
       "pass_condition": "ai_initiative_owner_identified",
-      "collection_methods": ["Manual"],
+      "collection_methods": ["Manual", "Graph_API"],
       "regulatory_relevance": ["FINRA-3110"]
     },
     {

--- a/assessment/tests/fixtures/graph_many_ai_users.json
+++ b/assessment/tests/fixtures/graph_many_ai_users.json
@@ -1,0 +1,72 @@
+{
+  "_metadata": {
+    "collector": "Collect-Graph",
+    "timestamp": "2026-05-11T00:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "conditionalAccessPolicies": [],
+  "fsiSecurityGroups": [],
+  "informationBarriers": [],
+  "privilegedRoleAssignments": [],
+  "copilotServicePrincipals": [],
+  "tenantSecuritySettings": {},
+  "aiLeadershipUsers": [
+    {
+      "DisplayName": "User One",
+      "UserPrincipalName": "u1@contoso.com",
+      "JobTitle": "Chief Data Officer",
+      "Department": "Data",
+      "MatchedKeyword": "Chief Data Officer"
+    },
+    {
+      "DisplayName": "User Two",
+      "UserPrincipalName": "u2@contoso.com",
+      "JobTitle": "Chief AI Officer",
+      "Department": "AI",
+      "MatchedKeyword": "Chief AI Officer"
+    },
+    {
+      "DisplayName": "User Three",
+      "UserPrincipalName": "u3@contoso.com",
+      "JobTitle": "Head of AI",
+      "Department": "Technology",
+      "MatchedKeyword": "Head of AI"
+    },
+    {
+      "DisplayName": "User Four",
+      "UserPrincipalName": "u4@contoso.com",
+      "JobTitle": "VP of AI",
+      "Department": "Engineering",
+      "MatchedKeyword": "VP of AI"
+    },
+    {
+      "DisplayName": "User Five",
+      "UserPrincipalName": "u5@contoso.com",
+      "JobTitle": "Director of AI",
+      "Department": "Research",
+      "MatchedKeyword": "Director of AI"
+    },
+    {
+      "DisplayName": "User Six",
+      "UserPrincipalName": "u6@contoso.com",
+      "JobTitle": "AI Governance Lead",
+      "Department": "Compliance",
+      "MatchedKeyword": "AI Governance Lead"
+    },
+    {
+      "DisplayName": "User Seven",
+      "UserPrincipalName": "u7@contoso.com",
+      "JobTitle": "Chief Digital Officer",
+      "Department": "Digital",
+      "MatchedKeyword": "Chief Digital Officer"
+    },
+    {
+      "DisplayName": "User Eight",
+      "UserPrincipalName": "u8@contoso.com",
+      "JobTitle": "Head of Data",
+      "Department": "Data Engineering",
+      "MatchedKeyword": "Head of Data"
+    }
+  ]
+}

--- a/assessment/tests/fixtures/graph_with_ai_leadership.json
+++ b/assessment/tests/fixtures/graph_with_ai_leadership.json
@@ -1,0 +1,37 @@
+{
+  "_metadata": {
+    "collector": "Collect-Graph",
+    "timestamp": "2026-05-11T00:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "conditionalAccessPolicies": [],
+  "fsiSecurityGroups": [],
+  "informationBarriers": [],
+  "privilegedRoleAssignments": [
+    {
+      "RoleDefinitionId": "role-pp-admin",
+      "RoleName": "Power Platform Administrator",
+      "PrincipalId": "user-003",
+      "DirectoryScopeId": "/"
+    }
+  ],
+  "copilotServicePrincipals": [],
+  "tenantSecuritySettings": {},
+  "aiLeadershipUsers": [
+    {
+      "DisplayName": "Jane Doe",
+      "UserPrincipalName": "jane.doe@contoso.com",
+      "JobTitle": "Chief Data Officer",
+      "Department": "Data & Analytics",
+      "MatchedKeyword": "Chief Data Officer"
+    },
+    {
+      "DisplayName": "Bob Smith",
+      "UserPrincipalName": "bob.smith@contoso.com",
+      "JobTitle": "Head of AI",
+      "Department": "Technology",
+      "MatchedKeyword": "Head of AI"
+    }
+  ]
+}

--- a/assessment/tests/fixtures/graph_with_neither_signal.json
+++ b/assessment/tests/fixtures/graph_with_neither_signal.json
@@ -1,0 +1,15 @@
+{
+  "_metadata": {
+    "collector": "Collect-Graph",
+    "timestamp": "2026-05-11T00:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "conditionalAccessPolicies": [],
+  "fsiSecurityGroups": [],
+  "informationBarriers": [],
+  "privilegedRoleAssignments": [],
+  "copilotServicePrincipals": [],
+  "tenantSecuritySettings": {},
+  "aiLeadershipUsers": []
+}

--- a/assessment/tests/fixtures/graph_with_only_admin_assignments.json
+++ b/assessment/tests/fixtures/graph_with_only_admin_assignments.json
@@ -1,0 +1,22 @@
+{
+  "_metadata": {
+    "collector": "Collect-Graph",
+    "timestamp": "2026-05-11T00:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "conditionalAccessPolicies": [],
+  "fsiSecurityGroups": [],
+  "informationBarriers": [],
+  "privilegedRoleAssignments": [
+    {
+      "RoleDefinitionId": "role-pp-admin",
+      "RoleName": "Power Platform Administrator",
+      "PrincipalId": "user-001",
+      "DirectoryScopeId": "/"
+    }
+  ],
+  "copilotServicePrincipals": [],
+  "tenantSecuritySettings": {},
+  "aiLeadershipUsers": []
+}

--- a/assessment/tests/fixtures/graph_with_section7_errored.json
+++ b/assessment/tests/fixtures/graph_with_section7_errored.json
@@ -1,0 +1,18 @@
+{
+  "_metadata": {
+    "collector": "Collect-Graph",
+    "timestamp": "2026-05-11T00:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [
+      "Section 7 (AI Leadership Job Titles) failed: Get-MgUser permission denied",
+      "Section 4 (Privileged Role Assignments) failed: timeout"
+    ]
+  },
+  "conditionalAccessPolicies": [],
+  "fsiSecurityGroups": [],
+  "informationBarriers": [],
+  "privilegedRoleAssignments": null,
+  "copilotServicePrincipals": [],
+  "tenantSecuritySettings": {},
+  "aiLeadershipUsers": null
+}

--- a/assessment/tests/test_score_frontier.py
+++ b/assessment/tests/test_score_frontier.py
@@ -418,11 +418,11 @@ class TestEvaluatorCoverage:
     """Unit tests for compute_evaluator_coverage()."""
 
     def test_v1_counts_after_q16_q17_wiring(self, manifest_data: dict) -> None:
-        """Real frontier-readiness.json post-Q16/Q17/Q13: 3 auto, 22 manual, 0 unimplemented."""
+        """Real frontier-readiness.json post-Q16/Q17/Q13/Q01: 4 auto, 21 manual, 0 unimplemented."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 3
-        assert coverage["questions"]["manual_only"] == 22
+        assert coverage["questions"]["auto_evaluable"] == 4
+        assert coverage["questions"]["manual_only"] == 21
         assert coverage["questions"]["unimplemented_evaluator"] == 0
         assert coverage["total_questions"] == 25
 
@@ -691,10 +691,10 @@ class TestFrontierEvaluators:
         assert result["questions_answered"] >= 1
 
     def test_evaluator_coverage_q16_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage matrix counts Q16+Q17+Q13 as auto_evaluable: 3."""
+        """After manifest update, coverage matrix counts Q16+Q17+Q13+Q01 as auto_evaluable: 4."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 3
+        assert coverage["questions"]["auto_evaluable"] == 4
 
     def test_run_includes_evaluator_results_in_output(self, tmp_path: Path) -> None:
         """End-to-end via run() populates evaluator_results.Q16 in output JSON."""
@@ -822,11 +822,11 @@ class TestFrontierQ17Evaluator:
         assert result["level_breakdown"]["200"]["ratio"] == pytest.approx(1.0)
 
     def test_evaluator_coverage_q17_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage counts Q16 + Q17 as auto_evaluable: 2."""
+        """After manifest update, coverage counts Q16 + Q17 + Q13 + Q01 as auto_evaluable: 4."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        # Updated: Q13 is now also auto-evaluable → 3 total.
-        assert coverage["questions"]["auto_evaluable"] == 3
+        # Updated: Q13 + Q01 are now also auto-evaluable → 4 total.
+        assert coverage["questions"]["auto_evaluable"] == 4
 
 
 # ---------------------------------------------------------------------------
@@ -975,7 +975,155 @@ class TestFrontierQ13Evaluator:
         assert result["level_breakdown"]["300"]["ratio"] == pytest.approx(0.0)
 
     def test_evaluator_coverage_q13_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage shows 3 auto-evaluators (Q16 + Q17 + Q13)."""
+        """After manifest update, coverage shows 4 auto-evaluators (Q16 + Q17 + Q13 + Q01)."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 3
+        assert coverage["questions"]["auto_evaluable"] == 4
+
+
+# ---------------------------------------------------------------------------
+# TestFrontierQ01Evaluator — Q01 evaluator tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_graph_collected(tmp_path: Path, fixture_name: str) -> Path:
+    """Copy a Graph fixture into a temp collected/ dir for evaluator testing."""
+    collected = tmp_path / "collected"
+    collected.mkdir(exist_ok=True)
+    data = load_fixture(fixture_name)
+    write_json(collected / "graph.json", data)
+    return collected
+
+
+class TestFrontierQ01Evaluator:
+    """Tests for the Q01 evaluator (ai_initiative_owner_identified)."""
+
+    def test_evaluator_q01_yes_with_ai_leadership_titles(self, tmp_path: Path) -> None:
+        """Graph fixture with 2 AI-leadership users → ('yes', evidence listing them)."""
+        collected = _setup_graph_collected(tmp_path, "graph_with_ai_leadership.json")
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        assert answer == "yes"
+        assert "2 user(s)" in evidence
+        assert "Jane Doe" in evidence
+        assert "Bob Smith" in evidence
+        assert "Chief Data Officer" in evidence
+        assert "Head of AI" in evidence
+
+    def test_evaluator_q01_partial_with_only_senior_admin_assignments(
+        self, tmp_path: Path
+    ) -> None:
+        """Graph has zero AI titles but Power Platform Admin assigned → ('partial', evidence)."""
+        collected = _setup_graph_collected(
+            tmp_path, "graph_with_only_admin_assignments.json"
+        )
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        assert answer == "partial"
+        assert "1 senior platform admin" in evidence
+        assert "informal accountability" in evidence
+
+    def test_evaluator_q01_no_with_neither_signal(self, tmp_path: Path) -> None:
+        """Graph has no AI titles AND no privileged role assignments → ('no', evidence)."""
+        collected = _setup_graph_collected(
+            tmp_path, "graph_with_neither_signal.json"
+        )
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        assert answer == "no"
+        assert "No AI-leadership titles" in evidence
+
+    def test_evaluator_q01_inconclusive_when_graph_missing(self, tmp_path: Path) -> None:
+        """No graph.json file → (None, evidence about missing)."""
+        collected = tmp_path / "collected"
+        collected.mkdir()
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        assert answer is None
+        assert "Graph data unavailable" in evidence
+        assert "not found" in evidence
+
+    def test_evaluator_q01_inconclusive_when_section7_errored(
+        self, tmp_path: Path
+    ) -> None:
+        """graph.json with aiLeadershipUsers: null AND Section 4 also null → (None, ...)."""
+        collected = _setup_graph_collected(
+            tmp_path, "graph_with_section7_errored.json"
+        )
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        assert answer is None
+        assert "Graph data unavailable" in evidence
+
+    def test_evaluator_q01_truncates_long_match_list(self, tmp_path: Path) -> None:
+        """Graph fixture with 8 AI-leadership users → evidence shows 3 + 'and 5 more'."""
+        collected = _setup_graph_collected(tmp_path, "graph_many_ai_users.json")
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        assert answer == "yes"
+        assert "8 user(s)" in evidence
+        assert "and 5 more" in evidence
+
+    def test_evaluator_q01_case_insensitive_matching(self, tmp_path: Path) -> None:
+        """Graph user with mixed-case jobTitle 'chief data OFFICER' → matched."""
+        collected = tmp_path / "collected"
+        collected.mkdir(exist_ok=True)
+        graph_data = {
+            "_metadata": {"collector": "Collect-Graph", "warnings": []},
+            "aiLeadershipUsers": [
+                {
+                    "DisplayName": "Mixed Case User",
+                    "UserPrincipalName": "mc@contoso.com",
+                    "JobTitle": "chief data OFFICER",
+                    "Department": "Data",
+                    "MatchedKeyword": ""
+                }
+            ],
+            "privilegedRoleAssignments": [],
+        }
+        write_json(collected / "graph.json", graph_data)
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        assert answer == "yes"
+        assert "Mixed Case User" in evidence
+
+    def test_evaluator_q01_avoids_false_positive_on_word_ai(
+        self, tmp_path: Path
+    ) -> None:
+        """Graph user with jobTitle 'Maintenance Manager' should NOT match."""
+        collected = tmp_path / "collected"
+        collected.mkdir(exist_ok=True)
+        graph_data = {
+            "_metadata": {"collector": "Collect-Graph", "warnings": []},
+            "aiLeadershipUsers": [
+                {
+                    "DisplayName": "Maint Worker",
+                    "UserPrincipalName": "maint@contoso.com",
+                    "JobTitle": "Maintenance Manager",
+                    "Department": "Facilities",
+                    "MatchedKeyword": ""
+                }
+            ],
+            "privilegedRoleAssignments": [],
+        }
+        write_json(collected / "graph.json", graph_data)
+        answer, evidence = score_frontier._eval_ai_initiative_owner_identified(collected)
+        # "Maintenance" contains "ai" but should not match — no valid keyword
+        assert answer == "no"
+        assert "No AI-leadership titles" in evidence
+
+    def test_score_driver_q01_facilitator_wins_over_evaluator(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator answers 'no' while evaluator returns 'yes' → facilitator wins."""
+        collected = _setup_graph_collected(
+            tmp_path, "graph_with_ai_leadership.json"
+        )
+        questions = manifest_data["questions"]
+        answers = {"Q01": {"value": "no"}}
+        result = score_frontier.score_driver(
+            "ai_strategy", questions, answers, collected_dir=collected
+        )
+        # L100 ratio should be 0.0 (from "no"), not 1.0 (from evaluator "yes")
+        assert result["level_breakdown"]["100"]["ratio"] == pytest.approx(0.0)
+
+    def test_evaluator_coverage_q01_classified_as_auto(
+        self, manifest_data: dict
+    ) -> None:
+        """After manifest update, coverage shows 4 auto-evaluators (Q16 + Q17 + Q13 + Q01)."""
+        questions = manifest_data["questions"]
+        coverage = score_frontier.compute_evaluator_coverage(questions)
+        assert coverage["questions"]["auto_evaluable"] == 4

--- a/docs/reference/frontier-assessment-coverage.md
+++ b/docs/reference/frontier-assessment-coverage.md
@@ -18,8 +18,8 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | State | Count | Share |
 |-------|-------|-------|
-| ✅ Auto | 3 | 12.0% |
-| 📝 Manual | 22 | 88.0% |
+| ✅ Auto | 4 | 16.0% |
+| 📝 Manual | 21 | 84.0% |
 | ⚠️ Unimplemented | 0 | 0.0% |
 | **Total** | 25 | 100% |
 
@@ -27,7 +27,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | Driver | Total Questions | Auto | Manual | Unimplemented |
 |---|---|---|---|---|
-| AI Strategy & Experience | 5 | 0 | 5 | 0 |
+| AI Strategy & Experience | 5 | 1 | 4 | 0 |
 | Business Strategy | 5 | 0 | 5 | 0 |
 | AI Governance & Security | 5 | 1 | 4 | 0 |
 | Technology & Data | 5 | 2 | 3 | 0 |
@@ -39,7 +39,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | Q ID | Level | Question | State | Pass Condition | Notes |
 |---|---|---|---|---|---|
-| Q01 | 100 | Has the organization identified at least one named individual responsible for... | 📝 Manual | `ai_initiative_owner_identified` | Facilitator-answered. |
+| Q01 | 100 | Has the organization identified at least one named individual responsible for... | ✅ Auto | `ai_initiative_owner_identified` |  |
 | Q02 | 200 | Within at least one business unit, do AI agent investments follow recurring, ... | 📝 Manual | `bu_level_repeatable_intake_pattern` | Facilitator-answered. |
 | Q03 | 300 | Has the organization published an enterprise AI strategy reviewed by a Govern... | 📝 Manual | `enterprise_ai_strategy_published_with_portfolio` | Facilitator-answered. |
 | Q04 | 400 | Is the AI strategy refreshed on a documented cadence aligned to the firm's go... | 📝 Manual | `strategy_refresh_cadence_with_board_reporting` | Facilitator-answered. |
@@ -89,7 +89,6 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 The following questions have `pass_condition` strings populated, suggesting they could be auto-evaluated in a future release if a bespoke evaluator is implemented. Currently all are facilitator-answered.
 
-- **Q01** (AI Strategy & Experience, L100): pass_condition `ai_initiative_owner_identified` — *plausible automation source: Graph API: query Entra directory roles for named CIO/CDAO assignment*
 - **Q03** (AI Strategy & Experience, L300): pass_condition `enterprise_ai_strategy_published_with_portfolio` — *plausible automation source: SharePoint PnP search for AI strategy document in Governance Committee site*
 - **Q18** (Technology & Data, L300): pass_condition `env_groups_with_inventory_siem_rag_and_lineage` — *plausible automation source: PPAC Environment Groups API; Sentinel workspace connectivity; SharePoint permission scan logs*
 

--- a/scripts/generate_coverage_matrix.py
+++ b/scripts/generate_coverage_matrix.py
@@ -296,11 +296,6 @@ def classify_frontier_question_state(question: dict) -> str:
 # Plausible future evaluator candidates: (q_id, driver_id, level, pass_condition, source)
 _FRONTIER_EVALUATOR_CANDIDATES = [
     (
-        "Q01", "ai_strategy", 100,
-        "ai_initiative_owner_identified",
-        "Graph API: query Entra directory roles for named CIO/CDAO assignment",
-    ),
-    (
         "Q03", "ai_strategy", 300,
         "enterprise_ai_strategy_published_with_portfolio",
         "SharePoint PnP search for AI strategy document in Governance Committee site",


### PR DESCRIPTION
## Summary

Adds Q01 (`ai_initiative_owner_identified`, L100 AI Strategy & Experience) as the **fourth** auto-evaluator in the Frontier Readiness assessment, lifting coverage from 3/25 (12%) to **4/25 (16%)**.

Builds on the framework from #215 (registry + facilitator-wins precedence) and the collector-extension pattern from #216 (Q17 extending `Collect-PPAC.ps1`).

## Changes

### Collector — `assessment/collectors/Collect-Graph.ps1`

- **NEW Section 7: AI Leadership Job Titles** — uses two narrow `Get-MgUser` `startswith` queries (`Chief …`, `Head of …`) and post-filters to a canonical keyword list (`Chief AI Officer`, `Chief Data Officer`, `Chief Information Officer`, `Head of AI`, `AI Governance Lead`, etc.).
- Output schema: `aiLeadershipUsers[]` with `DisplayName`, `UserPrincipalName`, `JobTitle`, `Department`, `MatchedKeyword`.
- Empty result → `[]`; section error → `null` (consistent with PR #216 convention).
- Requires `User.Read.All` Graph scope (collector already requires Graph auth — additive only).

### Evaluator — `assessment/engine/score_frontier.py`

- `_eval_ai_initiative_owner_identified(collected_dir)`:
  - **yes** — ≥1 user with AI-leadership title found (Section 7 primary signal). Evidence lists matched users.
  - **partial** — no AI titles but ≥1 senior platform admin assignment (informal accountability proxy from existing Section 4 `privilegedRoleAssignments`).
  - **no** — neither signal present.
  - **None** — `graph.json` missing or both data sections errored.
- Short acronyms (`CDO`, `CIO`, `CTO`) use compiled word-boundary regex to avoid false positives like `Maintenance` matching `ai` or `ACIDOTIC` matching `cdo`.
- Registered in `EVALUATORS` registry alongside Q16, Q17, Q13.

### Manifest — `assessment/manifest/frontier-readiness.json`

- Q01: `auto_evaluable: true`, `collection_methods: ["Manual", "Graph_API"]`.

### Docs — `docs/reference/frontier-assessment-coverage.md`

- Regenerated: 4/25 (16%) Auto. Q01 row marked ✅ Auto.

### Generator — `scripts/generate_coverage_matrix.py`

- Q01 removed from `_FRONTIER_EVALUATOR_CANDIDATES` (only Q03, Q18 remain as future candidates).

### Tests — `assessment/tests/test_score_frontier.py` + 5 fixtures

- `TestFrontierQ01Evaluator` (10 new tests):
  - Yes/partial/no happy paths
  - Inconclusive when `graph.json` missing
  - Inconclusive when both Section 7 and Section 4 errored
  - Truncated evidence (`8 user(s)` → `and 5 more`)
  - Case-insensitive matching (`chief data OFFICER`)
  - **False-positive guard**: `Maintenance Manager` must NOT match
  - Facilitator-wins precedence (facilitator `no` overrides evaluator `yes`)
- 5 new fixtures: `graph_with_ai_leadership`, `graph_with_only_admin_assignments`, `graph_with_neither_signal`, `graph_with_section7_errored`, `graph_many_ai_users`.

## Local validation

| Gate | Result |
|---|---|
| `pytest assessment/tests/` | **93 passed** (was 83 after Q13) |
| `ruff check` | All checks passed |
| `generate_coverage_matrix.py --type frontier --check` | OK |
| `generate_coverage_matrix.py --check` (controls) | OK |
| `check_manifest_doc_drift.py --check` | OK |
| `verify_language_rules.py` | No prohibited language found |

## Frontier coverage status (post-merge)

| Question | Driver | Level | Status |
|---|---|---|---|
| Q01 | AI Strategy & Experience | L100 | ✅ Auto (Graph: AI-leadership titles) |
| Q13 | AI Governance | L300 | ✅ Auto (PPAC + Purview, partial-cap) |
| Q16 | Technology & Data | L100 | ✅ Auto (PPAC env visibility) |
| Q17 | Technology & Data | L200 | ✅ Auto (PPAC + Sentinel) |
| Q03, Q18 | — | — | 📝 Manual (future evaluator candidates) |
| Other 19 | — | — | 📝 Manual (strategic, by design) |

## Notes

- This PR was rebased onto `main` after #218 (Q13) merged. Conflict resolution merged both Q13 and Q01 evaluator blocks side-by-side in `score_frontier.py`, `test_score_frontier.py`, and updated `compute_evaluator_coverage` assertions to reflect 4 auto / 21 manual.
- Coverage line in commit message reflects post-merge total (4/25), not the per-PR delta.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
