### PR TITLE
feat(frontier): add Q18 + Q03 evaluators — Frontier auto-evaluable backlog complete (4 → 6/25)

### DIFF
--- a/assessment/engine/score_frontier.py
+++ b/assessment/engine/score_frontier.py
@@ -794,6 +794,265 @@ def _eval_ai_initiative_owner_identified(
     return "no", "No AI-leadership titles or senior admin assignments found in tenant"
 
 
+# ---------------------------------------------------------------------------
+# Q18 evaluator — Environment Groups with inventory, SIEM, RAG, and lineage
+# ---------------------------------------------------------------------------
+
+
+def _q18_env_groups_present(ppac: dict) -> bool:
+    """Check whether tiered environment groups are operational."""
+    env_groups = ppac.get("environmentGroups")
+    if isinstance(env_groups, list) and len(env_groups) > 0:
+        return True
+    environments = ppac.get("environments")
+    if isinstance(environments, list):
+        for env in environments:
+            if env.get("EnvironmentGroupId"):
+                return True
+    return False
+
+
+def _q18_siem_present(sentinel: dict) -> bool:
+    """Check whether SIEM integration (data connectors) is present."""
+    dc = sentinel.get("dataConnectors")
+    if dc is None:
+        return False
+    if dc.get("Office365Enabled") is True or dc.get("McasEnabled") is True:
+        return True
+    total = dc.get("TotalConnectors", 0)
+    summary = dc.get("ConnectorSummary") or []
+    return total > 0 and len(summary) > 0
+
+
+def _q18_sp_scan_present(sharepoint: dict) -> bool:
+    """Check whether item-level permission scanning ran at deployment."""
+    ilp = sharepoint.get("itemLevelPermissions")
+    if not isinstance(ilp, list) or len(ilp) == 0:
+        return False
+    for site in ilp:
+        if site.get("SampledItems", 0) > 0:
+            return True
+    return False
+
+
+def _eval_env_groups_with_inventory_siem_rag_and_lineage(
+    collected_dir: Path,
+) -> tuple[str | None, str]:
+    """Q18 evaluator: tiered env groups + SIEM + item-level scan + agent inventory + RAG/lineage.
+
+    Checks three of five L300 Tech & Data signals from telemetry:
+      1. Tiered Environment Groups operational (PPAC env groups)
+      2. SIEM integration (Sentinel data connectors)
+      3. Item-level permission scanning (SharePoint scan)
+
+    The remaining signals are structurally non-telemetry-verifiable:
+      - Agent inventory is not collected by any existing collector
+      - RAG-integrity validation + data lineage documentation are facilitator-only
+
+    **Auto-cap rule:** This evaluator NEVER returns ``"yes"``. The maximum
+    auto-confirmable answer is ``"partial"`` because agent inventory is not
+    collected, and RAG-integrity + data lineage are facilitator-only signals.
+
+    Returns:
+      - ``("partial", evidence)`` — 1-3 of 3 telemetry signals present.
+      - ``("no", evidence)`` — 0 of 3 telemetry signals present.
+      - ``(None, evidence)`` — all three collector files missing or errored.
+    """
+    agent_inventory_caveat = "agent inventory not collected (out of scope)"
+    rag_lineage_caveat = "RAG-integrity + data lineage require facilitator confirmation"
+
+    # --- Load PPAC data ---
+    ppac, ppac_err = _load_collected_json(collected_dir, "ppac.json")
+    ppac_available = False
+    env_groups_signal = False
+    env_groups_evidence = ""
+
+    if ppac is not None:
+        metadata = ppac.get("_metadata") or {}
+        errors = metadata.get("errors") or []
+        if errors:
+            first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+            ppac_err = f"collector reported errors ({first_error})"
+        else:
+            ppac_available = True
+            env_groups_signal = _q18_env_groups_present(ppac)
+
+    if ppac_available:
+        if env_groups_signal:
+            env_groups_list = ppac.get("environmentGroups") or []
+            tiered_count = sum(
+                1 for g in env_groups_list
+                if any(kw in (g.get("DisplayName") or "").lower() for kw in ["tier", "zone", "prod"])
+            )
+            env_groups_evidence = (
+                f"PPAC env groups present ({len(env_groups_list)} total"
+                f"{f', {tiered_count} tiered' if tiered_count > 0 else ''})"
+            )
+        else:
+            env_groups_evidence = "PPAC env groups absent"
+    else:
+        env_groups_evidence = f"PPAC data unavailable: {ppac_err}"
+
+    # --- Load Sentinel data ---
+    sentinel, sentinel_err = _load_collected_json(collected_dir, "sentinel.json")
+    sentinel_available = False
+    siem_signal = False
+    siem_evidence = ""
+
+    if sentinel is not None:
+        metadata = sentinel.get("_metadata") or {}
+        errors = metadata.get("errors") or []
+        if errors:
+            first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+            sentinel_err = f"collector reported errors ({first_error})"
+        else:
+            sentinel_available = True
+            siem_signal = _q18_siem_present(sentinel)
+
+    if sentinel_available:
+        if siem_signal:
+            dc = sentinel.get("dataConnectors") or {}
+            connectors = []
+            if dc.get("Office365Enabled"):
+                connectors.append("Office365")
+            if dc.get("McasEnabled"):
+                connectors.append("MCAS")
+            connector_desc = ", ".join(connectors) if connectors else f"{dc.get('TotalConnectors', 0)} connectors"
+            siem_evidence = f"Sentinel SIEM connector(s) enabled ({connector_desc})"
+        else:
+            siem_evidence = "no SIEM connectors enabled"
+    else:
+        siem_evidence = f"Sentinel data unavailable: {sentinel_err}"
+
+    # --- Load SharePoint data ---
+    sharepoint, sharepoint_err = _load_collected_json(collected_dir, "sharepoint.json")
+    sharepoint_available = False
+    sp_scan_signal = False
+    sp_scan_evidence = ""
+
+    if sharepoint is not None:
+        metadata = sharepoint.get("_metadata") or {}
+        errors = metadata.get("errors") or []
+        if errors:
+            first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+            sharepoint_err = f"collector reported errors ({first_error})"
+        else:
+            sharepoint_available = True
+            sp_scan_signal = _q18_sp_scan_present(sharepoint)
+
+    if sharepoint_available:
+        if sp_scan_signal:
+            ilp = sharepoint.get("itemLevelPermissions") or []
+            total_sampled = sum(site.get("SampledItems", 0) for site in ilp)
+            sp_scan_evidence = f"SharePoint item-level scan ran ({len(ilp)} sites, {total_sampled} sampled items)"
+            crossref = sharepoint.get("groundingCrossRef")
+            if isinstance(crossref, dict) and crossref.get("ApprovedFound", 0) > 0:
+                sp_scan_evidence += f"; grounding cross-reference confirmed {crossref['ApprovedFound']} approved site(s)"
+        else:
+            sp_scan_evidence = "SharePoint item-level scan absent"
+    else:
+        sp_scan_evidence = f"SharePoint data unavailable: {sharepoint_err}"
+
+    # --- All sources unavailable → inconclusive ---
+    if not ppac_available and not sentinel_available and not sharepoint_available:
+        return None, (
+            f"All three data sources unavailable: {ppac_err}; {sentinel_err}; {sharepoint_err}"
+        )
+
+    # --- Count telemetry signals present ---
+    signal_count = sum([env_groups_signal, siem_signal, sp_scan_signal])
+
+    evidence = (
+        f"{env_groups_evidence}; {siem_evidence}; {sp_scan_evidence}; "
+        f"{agent_inventory_caveat}; {rag_lineage_caveat}"
+    )
+
+    if signal_count == 0:
+        return "no", evidence
+    return "partial", evidence
+
+
+# ---------------------------------------------------------------------------
+# Q03 evaluator — Enterprise AI strategy published with portfolio
+# ---------------------------------------------------------------------------
+
+AI_STRATEGY_KEYWORDS = (
+    "ai strategy",
+    "ai governance",
+    "ai council",
+    "ai portfolio",
+    "agent portfolio",
+    "frontier",
+    "executive sponsor",
+    "governance committee",
+)
+
+
+def _eval_enterprise_ai_strategy_published_with_portfolio(
+    collected_dir: Path,
+) -> tuple[str | None, str]:
+    """Q03 evaluator: enterprise AI strategy published with portfolio-level inventory.
+
+    Checks SharePoint site inventory for strategic AI/portfolio naming patterns.
+    This is a weak heuristic but acceptable because the evaluator is capped at
+    ``"partial"`` — the presence of matching site names suggests strategy
+    publication, but "reviewed by Governance Committee", "with portfolio",
+    and "active governance" are facilitator-only judgements.
+
+    **Auto-cap rule:** This evaluator NEVER returns ``"yes"``. The maximum
+    auto-confirmable answer is ``"partial"`` because site naming is telemetry-
+    verifiable but governance review + portfolio scope are facilitator-only.
+
+    Returns:
+      - ``("partial", evidence)`` — 1+ SharePoint site name matches keywords.
+      - ``("no", evidence)`` — SharePoint collected but no matching sites.
+      - ``(None, evidence)`` — sharepoint.json missing or errored.
+    """
+    portfolio_governance_caveat = "portfolio scope and active governance require facilitator confirmation"
+
+    sharepoint, err = _load_collected_json(collected_dir, "sharepoint.json")
+    if sharepoint is None:
+        return None, f"SharePoint data unavailable: {err}"
+
+    metadata = sharepoint.get("_metadata") or {}
+    errors = metadata.get("errors") or []
+    if errors:
+        first_error = errors[0] if isinstance(errors[0], str) else str(errors[0])
+        return None, f"SharePoint data unavailable: collector reported errors ({first_error})"
+
+    site_inventory = sharepoint.get("siteInventory")
+    if not isinstance(site_inventory, list):
+        return None, "SharePoint data unavailable: siteInventory field absent or invalid"
+
+    if len(site_inventory) == 0:
+        return "no", "SharePoint collected zero sites"
+
+    # Case-insensitive substring matching against AI strategy keywords
+    matched_sites: list[tuple[str, str]] = []  # (DisplayName, matched_keyword)
+    for site in site_inventory:
+        display = site.get("DisplayName") or ""
+        lower_display = display.lower()
+        for keyword in AI_STRATEGY_KEYWORDS:
+            if keyword in lower_display:
+                matched_sites.append((display, keyword))
+                break
+
+    if matched_sites:
+        if len(matched_sites) > 3:
+            shown = matched_sites[:3]
+            remainder = len(matched_sites) - 3
+            listing = ", ".join(f"'{n}' (matched '{k}')" for n, k in shown)
+            listing += f" and {remainder} more"
+        else:
+            listing = ", ".join(f"'{n}' (matched '{k}')" for n, k in matched_sites)
+        return (
+            "partial",
+            f"SharePoint site(s) suggest strategy publication: {listing}; {portfolio_governance_caveat}",
+        )
+
+    return "no", "No SharePoint site name matched AI strategy/portfolio keywords"
+
+
 # --- Evaluator registry ---------------------------------------------------
 
 EVALUATORS: dict[str, object] = {
@@ -801,6 +1060,8 @@ EVALUATORS: dict[str, object] = {
     "tagged_environments_with_basic_telemetry": _eval_tagged_environments_with_basic_telemetry,
     "zone_classification_with_audit_supervision_and_model_risk": _eval_zone_classification_with_audit_supervision_and_model_risk,
     "ai_initiative_owner_identified": _eval_ai_initiative_owner_identified,
+    "env_groups_with_inventory_siem_rag_and_lineage": _eval_env_groups_with_inventory_siem_rag_and_lineage,
+    "enterprise_ai_strategy_published_with_portfolio": _eval_enterprise_ai_strategy_published_with_portfolio,
 }
 
 

--- a/assessment/manifest/frontier-readiness.json
+++ b/assessment/manifest/frontier-readiness.json
@@ -74,10 +74,11 @@
       "fsi_context": "A defined enterprise AI strategy with portfolio governance helps meet OCC 2011-12 model risk expectations and gives examiners a documented chain of accountability from sponsor to agent.",
       "answer_format": "yes_no_partial",
       "scoring_weight": 1.0,
-      "auto_evaluable": false,
+      "auto_evaluable": true,
       "pass_condition": "enterprise_ai_strategy_published_with_portfolio",
-      "collection_methods": ["Manual"],
-      "regulatory_relevance": ["FINRA-3110", "OCC-2011-12"]
+      "collection_methods": ["Manual", "SharePoint_API"],
+      "regulatory_relevance": ["FINRA-3110", "OCC-2011-12"],
+      "notes": "Auto-evaluator capped at 'partial' — site naming heuristic detects strategy publication, but governance review + portfolio scope are facilitator-only."
     },
     {
       "question_id": "Q04",
@@ -270,10 +271,11 @@
       "fsi_context": "Defined maturity requires the substrate evidence stack — tiered environments, automated inventory, SIEM, RAG integrity, and lineage — that examiners use to verify the data the agent retrieved is the record under FINRA 4511 / SEC 17a-4.",
       "answer_format": "yes_no_partial",
       "scoring_weight": 1.0,
-      "auto_evaluable": false,
+      "auto_evaluable": true,
       "pass_condition": "env_groups_with_inventory_siem_rag_and_lineage",
-      "collection_methods": ["Manual"],
-      "regulatory_relevance": ["FINRA-4511", "SEC-17a-4", "GLBA-501b"]
+      "collection_methods": ["Manual", "PPAC_API", "Sentinel_API", "SharePoint_API"],
+      "regulatory_relevance": ["FINRA-4511", "SEC-17a-4", "GLBA-501b"],
+      "notes": "Auto-evaluator capped at 'partial' — 3/5 signals are telemetry-verifiable (env groups, SIEM, SP scan), but agent inventory is not collected and RAG-integrity + lineage are facilitator-only."
     },
     {
       "question_id": "Q19",

--- a/assessment/tests/fixtures/ppac_empty_env_groups.json
+++ b/assessment/tests/fixtures/ppac_empty_env_groups.json
@@ -1,0 +1,17 @@
+{
+  "_metadata": {
+    "collector": "Collect-PPAC",
+    "errors": [],
+    "warnings": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Prod",
+      "EnvironmentName": "env-1",
+      "EnvironmentSku": "Production",
+      "Tags": {},
+      "EnvironmentGroupId": null
+    }
+  ],
+  "environmentGroups": []
+}

--- a/assessment/tests/fixtures/sentinel_no_connectors.json
+++ b/assessment/tests/fixtures/sentinel_no_connectors.json
@@ -1,0 +1,20 @@
+{
+  "_metadata": {
+    "collector": "Collect-Sentinel",
+    "warnings": [],
+    "errors": []
+  },
+  "workspace": {
+    "WorkspaceId": "ws-1",
+    "WorkspaceName": "fsi-siem",
+    "ProvisioningState": "Succeeded",
+    "Sku": "PerGB2018"
+  },
+  "dataConnectors": {
+    "TotalConnectors": 0,
+    "ConnectorSummary": [],
+    "Office365Enabled": false,
+    "McasEnabled": false
+  },
+  "kqlAuditCheck": null
+}

--- a/assessment/tests/fixtures/sentinel_with_connector_only.json
+++ b/assessment/tests/fixtures/sentinel_with_connector_only.json
@@ -1,0 +1,27 @@
+{
+  "_metadata": {
+    "collector": "Collect-Sentinel",
+    "warnings": [],
+    "errors": []
+  },
+  "workspace": {
+    "WorkspaceId": "ws-1",
+    "WorkspaceName": "fsi-siem",
+    "ProvisioningState": "Succeeded",
+    "Sku": "PerGB2018"
+  },
+  "dataConnectors": {
+    "TotalConnectors": 1,
+    "ConnectorSummary": [
+      {
+        "Id": "/.../Office365",
+        "Name": "Office365",
+        "Kind": "Office365",
+        "Etag": "1"
+      }
+    ],
+    "Office365Enabled": true,
+    "McasEnabled": false
+  },
+  "kqlAuditCheck": null
+}

--- a/assessment/tests/fixtures/sharepoint_empty_inventory.json
+++ b/assessment/tests/fixtures/sharepoint_empty_inventory.json
@@ -1,0 +1,7 @@
+{
+  "_metadata": {
+    "collector": "Collect-SharePoint",
+    "warnings": []
+  },
+  "siteInventory": []
+}

--- a/assessment/tests/fixtures/sharepoint_errored.json
+++ b/assessment/tests/fixtures/sharepoint_errored.json
@@ -1,0 +1,8 @@
+{
+  "_metadata": {
+    "collector": "Collect-SharePoint",
+    "warnings": ["Section 1 (Site Inventory) failed: Graph API error"],
+    "errors": ["Graph API error"]
+  },
+  "siteInventory": null
+}

--- a/assessment/tests/fixtures/sharepoint_no_ai_sites.json
+++ b/assessment/tests/fixtures/sharepoint_no_ai_sites.json
@@ -1,0 +1,15 @@
+{
+  "_metadata": {
+    "collector": "Collect-SharePoint",
+    "warnings": []
+  },
+  "siteInventory": [
+    {
+      "Id": "site-2",
+      "DisplayName": "HR Policies",
+      "WebUrl": "https://contoso.sharepoint.com/sites/hr",
+      "CreatedDateTime": "2026-05-01T00:00:00Z",
+      "IsPersonalSite": false
+    }
+  ]
+}

--- a/assessment/tests/fixtures/sharepoint_no_scan.json
+++ b/assessment/tests/fixtures/sharepoint_no_scan.json
@@ -1,0 +1,8 @@
+{
+  "_metadata": {
+    "collector": "Collect-SharePoint",
+    "warnings": []
+  },
+  "itemLevelPermissions": [],
+  "groundingCrossRef": null
+}

--- a/assessment/tests/fixtures/sharepoint_with_ai_strategy_site.json
+++ b/assessment/tests/fixtures/sharepoint_with_ai_strategy_site.json
@@ -1,0 +1,15 @@
+{
+  "_metadata": {
+    "collector": "Collect-SharePoint",
+    "warnings": []
+  },
+  "siteInventory": [
+    {
+      "Id": "site-1",
+      "DisplayName": "AI Strategy Council",
+      "WebUrl": "https://contoso.sharepoint.com/sites/aistrategy",
+      "CreatedDateTime": "2026-05-01T00:00:00Z",
+      "IsPersonalSite": false
+    }
+  ]
+}

--- a/assessment/tests/fixtures/sharepoint_with_scan_and_crossref.json
+++ b/assessment/tests/fixtures/sharepoint_with_scan_and_crossref.json
@@ -1,0 +1,23 @@
+{
+  "_metadata": {
+    "collector": "Collect-SharePoint",
+    "warnings": []
+  },
+  "itemLevelPermissions": [
+    {
+      "SiteId": "site-001",
+      "DisplayName": "Agent KB",
+      "WebUrl": "https://contoso.sharepoint.com/sites/agentkb",
+      "SampledItems": 12,
+      "FlaggedItems": [],
+      "FlaggedCount": 0
+    }
+  ],
+  "groundingCrossRef": {
+    "ApprovedSitesTotal": 1,
+    "ApprovedFound": 1,
+    "ApprovedMissing": [],
+    "UnapprovedSiteCount": 0,
+    "UnapprovedSites": []
+  }
+}

--- a/assessment/tests/test_score_frontier.py
+++ b/assessment/tests/test_score_frontier.py
@@ -418,11 +418,11 @@ class TestEvaluatorCoverage:
     """Unit tests for compute_evaluator_coverage()."""
 
     def test_v1_counts_after_q16_q17_wiring(self, manifest_data: dict) -> None:
-        """Real frontier-readiness.json post-Q16/Q17/Q13/Q01: 4 auto, 21 manual, 0 unimplemented."""
+        """Real frontier-readiness.json post-Q16/Q17/Q13/Q01/Q18/Q03: 6 auto, 19 manual, 0 unimplemented."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 4
-        assert coverage["questions"]["manual_only"] == 21
+        assert coverage["questions"]["auto_evaluable"] == 6
+        assert coverage["questions"]["manual_only"] == 19
         assert coverage["questions"]["unimplemented_evaluator"] == 0
         assert coverage["total_questions"] == 25
 
@@ -691,10 +691,10 @@ class TestFrontierEvaluators:
         assert result["questions_answered"] >= 1
 
     def test_evaluator_coverage_q16_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage matrix counts Q16+Q17+Q13+Q01 as auto_evaluable: 4."""
+        """After manifest update, coverage matrix counts Q16+Q17+Q13+Q01+Q18+Q03 as auto_evaluable: 6."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 4
+        assert coverage["questions"]["auto_evaluable"] == 6
 
     def test_run_includes_evaluator_results_in_output(self, tmp_path: Path) -> None:
         """End-to-end via run() populates evaluator_results.Q16 in output JSON."""
@@ -822,11 +822,11 @@ class TestFrontierQ17Evaluator:
         assert result["level_breakdown"]["200"]["ratio"] == pytest.approx(1.0)
 
     def test_evaluator_coverage_q17_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage counts Q16 + Q17 + Q13 + Q01 as auto_evaluable: 4."""
+        """After manifest update, coverage counts Q16 + Q17 + Q13 + Q01 + Q18 + Q03 as auto_evaluable: 6."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        # Updated: Q13 + Q01 are now also auto-evaluable → 4 total.
-        assert coverage["questions"]["auto_evaluable"] == 4
+        # Updated: Q13 + Q01 + Q18 + Q03 are now also auto-evaluable → 6 total.
+        assert coverage["questions"]["auto_evaluable"] == 6
 
 
 # ---------------------------------------------------------------------------
@@ -975,10 +975,10 @@ class TestFrontierQ13Evaluator:
         assert result["level_breakdown"]["300"]["ratio"] == pytest.approx(0.0)
 
     def test_evaluator_coverage_q13_classified_as_auto(self, manifest_data: dict) -> None:
-        """After manifest update, coverage shows 4 auto-evaluators (Q16 + Q17 + Q13 + Q01)."""
+        """After manifest update, coverage shows 6 auto-evaluators (Q16 + Q17 + Q13 + Q01 + Q18 + Q03)."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 4
+        assert coverage["questions"]["auto_evaluable"] == 6
 
 
 # ---------------------------------------------------------------------------
@@ -1123,7 +1123,339 @@ class TestFrontierQ01Evaluator:
     def test_evaluator_coverage_q01_classified_as_auto(
         self, manifest_data: dict
     ) -> None:
-        """After manifest update, coverage shows 4 auto-evaluators (Q16 + Q17 + Q13 + Q01)."""
+        """After manifest update, coverage shows 6 auto-evaluators (Q16 + Q17 + Q13 + Q01 + Q18 + Q03)."""
         questions = manifest_data["questions"]
         coverage = score_frontier.compute_evaluator_coverage(questions)
-        assert coverage["questions"]["auto_evaluable"] == 4
+        assert coverage["questions"]["auto_evaluable"] == 6
+
+
+# ---------------------------------------------------------------------------
+# TestFrontierQ18Evaluator — Q18 evaluator tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_q18_collected(
+    tmp_path: Path,
+    ppac_fixture: str | None = None,
+    sentinel_fixture: str | None = None,
+    sharepoint_fixture: str | None = None,
+) -> Path:
+    """Copy Q18 fixtures into temp collected/ dir for evaluator testing."""
+    collected = tmp_path / "collected"
+    collected.mkdir(exist_ok=True)
+    if ppac_fixture:
+        data = load_fixture(ppac_fixture)
+        write_json(collected / "ppac.json", data)
+    if sentinel_fixture:
+        data = load_fixture(sentinel_fixture)
+        write_json(collected / "sentinel.json", data)
+    if sharepoint_fixture:
+        data = load_fixture(sharepoint_fixture)
+        write_json(collected / "sharepoint.json", data)
+    return collected
+
+
+class TestFrontierQ18Evaluator:
+    """Tests for the Q18 evaluator (env_groups_with_inventory_siem_rag_and_lineage)."""
+
+    def test_evaluator_q18_partial_when_all_3_signals_present(
+        self, tmp_path: Path
+    ) -> None:
+        """All 3 telemetry signals (env groups, SIEM, SP scan) → ('partial', evidence)."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_with_env_group.json",
+            "sentinel_with_connector_only.json",
+            "sharepoint_with_scan_and_crossref.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer == "partial"
+        assert "env groups present" in evidence
+        assert "SIEM connector(s) enabled" in evidence
+        assert "item-level scan ran" in evidence
+        assert "agent inventory not collected" in evidence
+        assert "RAG-integrity + data lineage require facilitator confirmation" in evidence
+
+    def test_evaluator_q18_partial_when_only_env_groups_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Only env groups signal → ('partial', evidence noting SIEM + SP absent)."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_with_env_group.json",
+            "sentinel_no_connectors.json",
+            "sharepoint_no_scan.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer == "partial"
+        assert "env groups present" in evidence
+        assert "no SIEM connectors enabled" in evidence
+        assert "item-level scan absent" in evidence
+
+    def test_evaluator_q18_partial_when_only_siem_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Only SIEM signal → ('partial', evidence noting env groups + SP absent)."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_empty_env_groups.json",
+            "sentinel_with_connector_only.json",
+            "sharepoint_no_scan.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer == "partial"
+        assert "env groups absent" in evidence
+        assert "SIEM connector(s) enabled" in evidence
+        assert "item-level scan absent" in evidence
+
+    def test_evaluator_q18_partial_when_only_sp_scan_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Only SP scan signal → ('partial', evidence noting env groups + SIEM absent)."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_empty_env_groups.json",
+            "sentinel_no_connectors.json",
+            "sharepoint_with_scan_and_crossref.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer == "partial"
+        assert "env groups absent" in evidence
+        assert "no SIEM connectors enabled" in evidence
+        assert "item-level scan ran" in evidence
+
+    def test_evaluator_q18_no_when_no_signals(self, tmp_path: Path) -> None:
+        """Zero telemetry signals → ('no', evidence)."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_empty_env_groups.json",
+            "sentinel_no_connectors.json",
+            "sharepoint_no_scan.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer == "no"
+        assert "env groups absent" in evidence
+        assert "no SIEM connectors enabled" in evidence
+        assert "item-level scan absent" in evidence
+
+    def test_evaluator_q18_inconclusive_when_all_sources_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """No ppac.json, sentinel.json, or sharepoint.json → (None, evidence)."""
+        collected = _setup_q18_collected(tmp_path)
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer is None
+        assert "All three data sources unavailable" in evidence
+
+    def test_evaluator_q18_inconclusive_when_all_sources_errored(
+        self, tmp_path: Path
+    ) -> None:
+        """All three collectors have errors → (None, evidence)."""
+        collected = _setup_q18_collected(
+            tmp_path, "ppac_with_errors.json", "sentinel_no_workspace.json", "sharepoint_errored.json"
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer is None
+        assert "All three data sources unavailable" in evidence
+
+    def test_evaluator_q18_NEVER_returns_yes(self, tmp_path: Path) -> None:
+        """Even with all 3 signals present, evaluator returns 'partial' not 'yes'."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_with_env_group.json",
+            "sentinel_with_connector_only.json",
+            "sharepoint_with_scan_and_crossref.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer != "yes", "Q18 evaluator must NEVER return 'yes' — agent inventory + RAG/lineage are not auto-verifiable"
+        assert answer == "partial"
+
+    def test_evaluator_q18_evidence_names_missing_signals(self, tmp_path: Path) -> None:
+        """Evidence explicitly names which signals are missing."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_with_env_group.json",
+            "sentinel_no_connectors.json",
+            "sharepoint_no_scan.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert answer == "partial"
+        assert "no SIEM connectors enabled" in evidence
+        assert "item-level scan absent" in evidence
+
+    def test_evaluator_q18_evidence_includes_facilitator_caveats(
+        self, tmp_path: Path
+    ) -> None:
+        """Evidence must mention agent inventory + RAG-integrity + lineage caveats."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_with_env_group.json",
+            "sentinel_with_connector_only.json",
+            "sharepoint_with_scan_and_crossref.json",
+        )
+        answer, evidence = score_frontier._eval_env_groups_with_inventory_siem_rag_and_lineage(collected)
+        assert "agent inventory not collected" in evidence
+        assert "RAG-integrity + data lineage require facilitator confirmation" in evidence
+
+    def test_score_driver_q18_facilitator_can_upgrade_to_yes(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator says 'yes' while evaluator returns 'partial' → facilitator wins."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_with_env_group.json",
+            "sentinel_with_connector_only.json",
+            "sharepoint_with_scan_and_crossref.json",
+        )
+        questions = manifest_data["questions"]
+        answers = {"Q18": {"value": "yes"}}
+        result = score_frontier.score_driver(
+            "technology_data", questions, answers, collected_dir=collected
+        )
+        # L300 ratio should be 1.0 (from facilitator "yes"), not 0.5 (from evaluator "partial")
+        assert result["level_breakdown"]["300"]["ratio"] == pytest.approx(1.0)
+
+    def test_score_driver_q18_facilitator_can_downgrade_to_no(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator says 'no' while evaluator returns 'partial' → facilitator wins."""
+        collected = _setup_q18_collected(
+            tmp_path,
+            "ppac_with_env_group.json",
+            "sentinel_with_connector_only.json",
+            "sharepoint_with_scan_and_crossref.json",
+        )
+        questions = manifest_data["questions"]
+        answers = {"Q18": {"value": "no"}}
+        result = score_frontier.score_driver(
+            "technology_data", questions, answers, collected_dir=collected
+        )
+        # L300 ratio should be 0.0 (from facilitator "no"), not 0.5 (from evaluator "partial")
+        assert result["level_breakdown"]["300"]["ratio"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# TestFrontierQ03Evaluator — Q03 evaluator tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_q03_collected(tmp_path: Path, fixture_name: str) -> Path:
+    """Copy a SharePoint fixture into temp collected/ dir for Q03 testing."""
+    collected = tmp_path / "collected"
+    collected.mkdir(exist_ok=True)
+    data = load_fixture(fixture_name)
+    write_json(collected / "sharepoint.json", data)
+    return collected
+
+
+class TestFrontierQ03Evaluator:
+    """Tests for the Q03 evaluator (enterprise_ai_strategy_published_with_portfolio)."""
+
+    def test_evaluator_q03_partial_when_strategy_site_found(
+        self, tmp_path: Path
+    ) -> None:
+        """SharePoint site with AI strategy keyword → ('partial', evidence)."""
+        collected = _setup_q03_collected(tmp_path, "sharepoint_with_ai_strategy_site.json")
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer == "partial"
+        assert "AI Strategy Council" in evidence
+        assert "matched 'ai strategy'" in evidence
+        assert "portfolio scope and active governance require facilitator confirmation" in evidence
+
+    def test_evaluator_q03_no_when_no_matching_sites(self, tmp_path: Path) -> None:
+        """SharePoint collected but no AI-related site names → ('no', evidence)."""
+        collected = _setup_q03_collected(tmp_path, "sharepoint_no_ai_sites.json")
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer == "no"
+        assert "No SharePoint site name matched AI strategy/portfolio keywords" in evidence
+
+    def test_evaluator_q03_no_when_empty_inventory(self, tmp_path: Path) -> None:
+        """SharePoint collected zero sites → ('no', evidence)."""
+        collected = _setup_q03_collected(tmp_path, "sharepoint_empty_inventory.json")
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer == "no"
+        assert "SharePoint collected zero sites" in evidence
+
+    def test_evaluator_q03_inconclusive_when_sharepoint_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """No sharepoint.json file → (None, evidence)."""
+        collected = tmp_path / "collected"
+        collected.mkdir()
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer is None
+        assert "SharePoint data unavailable" in evidence
+        assert "not found" in evidence
+
+    def test_evaluator_q03_inconclusive_when_sharepoint_errored(
+        self, tmp_path: Path
+    ) -> None:
+        """SharePoint collector reported errors → (None, evidence)."""
+        collected = _setup_q03_collected(tmp_path, "sharepoint_errored.json")
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer is None
+        assert "SharePoint data unavailable" in evidence
+        assert "collector reported errors" in evidence
+
+    def test_evaluator_q03_NEVER_returns_yes(self, tmp_path: Path) -> None:
+        """Even with matching site, evaluator returns 'partial' not 'yes'."""
+        collected = _setup_q03_collected(tmp_path, "sharepoint_with_ai_strategy_site.json")
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer != "yes", "Q03 evaluator must NEVER return 'yes' — governance review + portfolio scope are facilitator-only"
+        assert answer == "partial"
+
+    def test_evaluator_q03_case_insensitive_matching(self, tmp_path: Path) -> None:
+        """Site name 'AI GOVERNANCE' (all caps) should match 'ai governance' keyword."""
+        collected = tmp_path / "collected"
+        collected.mkdir(exist_ok=True)
+        sp_data = {
+            "_metadata": {"collector": "Collect-SharePoint", "warnings": []},
+            "siteInventory": [
+                {
+                    "Id": "site-3",
+                    "DisplayName": "AI GOVERNANCE Portal",
+                    "WebUrl": "https://contoso.sharepoint.com/sites/aigovportal",
+                    "CreatedDateTime": "2026-05-01T00:00:00Z",
+                    "IsPersonalSite": False,
+                }
+            ],
+        }
+        write_json(collected / "sharepoint.json", sp_data)
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer == "partial"
+        assert "AI GOVERNANCE Portal" in evidence
+
+    def test_evaluator_q03_matches_multiple_keywords(self, tmp_path: Path) -> None:
+        """Site name containing both 'ai governance' and 'frontier' matches on first keyword."""
+        collected = tmp_path / "collected"
+        collected.mkdir(exist_ok=True)
+        sp_data = {
+            "_metadata": {"collector": "Collect-SharePoint", "warnings": []},
+            "siteInventory": [
+                {
+                    "Id": "site-4",
+                    "DisplayName": "AI Governance & Frontier Council",
+                    "WebUrl": "https://contoso.sharepoint.com/sites/aigov-frontier",
+                    "CreatedDateTime": "2026-05-01T00:00:00Z",
+                    "IsPersonalSite": False,
+                }
+            ],
+        }
+        write_json(collected / "sharepoint.json", sp_data)
+        answer, evidence = score_frontier._eval_enterprise_ai_strategy_published_with_portfolio(collected)
+        assert answer == "partial"
+        assert "AI Governance & Frontier Council" in evidence
+
+    def test_score_driver_q03_facilitator_can_upgrade_to_yes(
+        self, tmp_path: Path, manifest_data: dict
+    ) -> None:
+        """Facilitator says 'yes' while evaluator returns 'partial' → facilitator wins."""
+        collected = _setup_q03_collected(tmp_path, "sharepoint_with_ai_strategy_site.json")
+        questions = manifest_data["questions"]
+        answers = {"Q03": {"value": "yes"}}
+        result = score_frontier.score_driver(
+            "ai_strategy", questions, answers, collected_dir=collected
+        )
+        # L300 ratio should be 1.0 (from facilitator "yes"), not 0.5 (from evaluator "partial")
+        assert result["level_breakdown"]["300"]["ratio"] == pytest.approx(1.0)
+

--- a/docs/reference/frontier-assessment-coverage.md
+++ b/docs/reference/frontier-assessment-coverage.md
@@ -18,8 +18,8 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | State | Count | Share |
 |-------|-------|-------|
-| ✅ Auto | 4 | 16.0% |
-| 📝 Manual | 21 | 84.0% |
+| ✅ Auto | 6 | 24.0% |
+| 📝 Manual | 19 | 76.0% |
 | ⚠️ Unimplemented | 0 | 0.0% |
 | **Total** | 25 | 100% |
 
@@ -27,10 +27,10 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 | Driver | Total Questions | Auto | Manual | Unimplemented |
 |---|---|---|---|---|
-| AI Strategy & Experience | 5 | 1 | 4 | 0 |
+| AI Strategy & Experience | 5 | 2 | 3 | 0 |
 | Business Strategy | 5 | 0 | 5 | 0 |
 | AI Governance & Security | 5 | 1 | 4 | 0 |
-| Technology & Data | 5 | 2 | 3 | 0 |
+| Technology & Data | 5 | 3 | 2 | 0 |
 | Organization & Culture | 5 | 0 | 5 | 0 |
 
 ## Per-question detail
@@ -41,7 +41,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 |---|---|---|---|---|---|
 | Q01 | 100 | Has the organization identified at least one named individual responsible for... | ✅ Auto | `ai_initiative_owner_identified` |  |
 | Q02 | 200 | Within at least one business unit, do AI agent investments follow recurring, ... | 📝 Manual | `bu_level_repeatable_intake_pattern` | Facilitator-answered. |
-| Q03 | 300 | Has the organization published an enterprise AI strategy reviewed by a Govern... | 📝 Manual | `enterprise_ai_strategy_published_with_portfolio` | Facilitator-answered. |
+| Q03 | 300 | Has the organization published an enterprise AI strategy reviewed by a Govern... | ✅ Auto | `enterprise_ai_strategy_published_with_portfolio` | Auto-evaluator capped at 'partial' — site naming heuristic detects strategy publication, but governance review + portfolio scope are facilitator-only. |
 | Q04 | 400 | Is the AI strategy refreshed on a documented cadence aligned to the firm's go... | 📝 Manual | `strategy_refresh_cadence_with_board_reporting` | Facilitator-answered. |
 | Q05 | 500 | Do named executive sponsors provide quarterly outcome attestation for each pa... | 📝 Manual | `quarterly_sponsor_attestation_with_sunset_criteria` | Facilitator-answered. |
 
@@ -71,7 +71,7 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 |---|---|---|---|---|---|
 | Q16 | 100 | Is there any visibility into which Power Platform environments host AI agents... | ✅ Auto | `any_environment_visibility_for_agents` |  |
 | Q17 | 200 | Are some environments tagged or grouped for agent workloads, with basic telem... | ✅ Auto | `tagged_environments_with_basic_telemetry` |  |
-| Q18 | 300 | Are Environment Groups with tier classification operational, with automated a... | 📝 Manual | `env_groups_with_inventory_siem_rag_and_lineage` | Facilitator-answered. |
+| Q18 | 300 | Are Environment Groups with tier classification operational, with automated a... | ✅ Auto | `env_groups_with_inventory_siem_rag_and_lineage` | Auto-evaluator capped at 'partial' — 3/5 signals are telemetry-verifiable (env groups, SIEM, SP scan), but agent inventory is not collected and RAG-integrity + lineage are facilitator-only. |
 | Q19 | 400 | Does the platform provide integrated telemetry across Sentinel, the Agent 365... | 📝 Manual | `integrated_telemetry_with_curated_templates_and_agent_id` | Facilitator-answered. |
 | Q20 | 500 | Is the platform continuously monitored and version-controlled, with multi-age... | 📝 Manual | `continuous_platform_with_orchestration_limits_and_validated_grounding` | Facilitator-answered. |
 
@@ -89,8 +89,6 @@ It is the honest answer to *what does the Frontier Readiness assessment actually
 
 The following questions have `pass_condition` strings populated, suggesting they could be auto-evaluated in a future release if a bespoke evaluator is implemented. Currently all are facilitator-answered.
 
-- **Q03** (AI Strategy & Experience, L300): pass_condition `enterprise_ai_strategy_published_with_portfolio` — *plausible automation source: SharePoint PnP search for AI strategy document in Governance Committee site*
-- **Q18** (Technology & Data, L300): pass_condition `env_groups_with_inventory_siem_rag_and_lineage` — *plausible automation source: PPAC Environment Groups API; Sentinel workspace connectivity; SharePoint permission scan logs*
 
 ## How to wire up an evaluator (future)
 

--- a/scripts/generate_coverage_matrix.py
+++ b/scripts/generate_coverage_matrix.py
@@ -294,18 +294,7 @@ def classify_frontier_question_state(question: dict) -> str:
 
 
 # Plausible future evaluator candidates: (q_id, driver_id, level, pass_condition, source)
-_FRONTIER_EVALUATOR_CANDIDATES = [
-    (
-        "Q03", "ai_strategy", 300,
-        "enterprise_ai_strategy_published_with_portfolio",
-        "SharePoint PnP search for AI strategy document in Governance Committee site",
-    ),
-    (
-        "Q18", "technology_data", 300,
-        "env_groups_with_inventory_siem_rag_and_lineage",
-        "PPAC Environment Groups API; Sentinel workspace connectivity; SharePoint permission scan logs",
-    ),
-]
+_FRONTIER_EVALUATOR_CANDIDATES: list = []
 
 
 def render_frontier(manifest: dict) -> str:


### PR DESCRIPTION
## Summary

Adds the **final two** Frontier Readiness auto-evaluators (Q18 + Q03), bringing telemetry-driven coverage from **4/25 (16%) → 6/25 (24%)**. After this PR, the Frontier auto-evaluable backlog is **structurally exhausted** — the remaining 19 questions are facilitator-only by design (governance maturity, written attestations, executive judgement) and cannot be derived from M365/PPAC/Sentinel/SharePoint telemetry without overclaiming.

Both evaluators follow the **partial-cap pattern** established by Q13 (PR #218): they read existing collector output, never extend collectors, and **never return `"yes"`** because every Frontier question carries facilitator-only sub-claims that telemetry cannot verify.

## Q18 — `env_groups_with_inventory_siem_rag_and_lineage`

**Driver:** L300 Tech & Data
**Question:** "Are Environment Groups with tier classification operational, with automated agent inventory, SIEM integration, RAG source integrity validation for production agents, item-level permission scanning at deployment, and documented data lineage?"

**3-way correlation across:**
1. **PPAC Environment Groups** — `ppac.json.environmentGroups[]` + per-env `EnvironmentGroupId`/`Tags` (Section 8+9 added in #216)
2. **Sentinel SIEM connectors** — `sentinel.json.dataConnectors.{Office365Enabled, McasEnabled, TotalConnectors}`
3. **SharePoint item-level permission scan** — `sharepoint.json.itemLevelPermissions[].SampledItems` + `groundingCrossRef.ApprovedFound`

**Telemetry gap acknowledged:** Automated agent inventory is **not collected** by any current collector (Sentinel Section 3 is an audit count, not inventory). Q18 evidence string explicitly names this as `"agent inventory not collected (out of scope)"`. RAG-integrity validation + data lineage documentation are facilitator-only and noted as such.

**Verdict logic:**
- All 3 collector files missing/errored → `None`
- 0 of 3 telemetry signals → `"no"`
- 1–3 of 3 telemetry signals → `"partial"` (capped — never `"yes"`)

## Q03 — `enterprise_ai_strategy_published_with_portfolio`

**Driver:** L300 AI Strategy & Experience
**Question:** "Has the organization published an enterprise AI strategy reviewed by a Governance Committee, with a portfolio-level inventory of in-scope agents and named executive sponsors per Frontier Transformation Pattern?"

**SharePoint site-name heuristic** — case-insensitive substring match against 8 multi-word strategic keywords on `siteInventory[].DisplayName`:
- `ai strategy`, `ai governance`, `ai council`, `ai portfolio`
- `agent portfolio`, `frontier`, `executive sponsor`, `governance committee`

All keywords are multi-word so plain substring matching avoids the false-positive risk that would otherwise force word-boundary regex (the trap Q01 had to navigate for short acronyms like "VP" / "CDO").

**Verdict logic:**
- `sharepoint.json` missing/errored → `None`
- `siteInventory` empty or no matches → `"no"`
- 1+ matching site → `"partial"` (capped — "published" is telemetry-verifiable but "with portfolio" + "active governance" are facilitator-only)

## Coverage progression (Frontier Readiness assessment)

| Wave | PRs | Auto | Manual | % Auto |
|------|-----|------|--------|--------|
| Pre-evaluators | — | 0 | 25 | 0% |
| Q16+Q17 framework | #215, #216 | 2 | 23 | 8% |
| Q13 partial-cap | #218 | 3 | 22 | 12% |
| Q01 word-boundary | #219 | 4 | 21 | 16% |
| **Q18+Q03 closeout** | **this PR** | **6** | **19** | **24%** |

**Why we stop here:** The remaining 19 Frontier questions all hinge on facilitator-only signals (board attestation, written policy text, executive interview, regulatory committee minutes, business strategy alignment). Building heuristics for them would either silently overclaim or produce signals so weak that they harm rather than help an assessment. The honest assessment-coverage report (`docs/reference/frontier-assessment-coverage.md`) reflects this structural floor.

## Validation

All 6 CI gates pass locally before push:

| Gate | Result |
|------|--------|
| `pytest assessment/tests/ -q` | **114 passed** (was 93; +21 new) |
| `ruff check assessment scripts` | clean |
| `generate_coverage_matrix.py --type frontier --check` | current |
| `generate_coverage_matrix.py --check` | current |
| `check_manifest_doc_drift.py --check` | no drift |
| `verify_language_rules.py` | no violations |

## Test additions (+21)

**`TestFrontierQ18Evaluator`** (12 tests):
- Partial when all-3, env-only, SIEM-only, SP-scan-only signals present
- `"no"` when zero signals; `None` when all sources missing/errored
- `NEVER_returns_yes` invariant
- Evidence names missing signals + facilitator caveats (RAG-integrity + lineage)
- Driver-level upgrade/downgrade by facilitator override

**`TestFrontierQ03Evaluator`** (9 tests):
- Partial on strategy-site match; case-insensitive matching; multiple-keyword sites
- `"no"` on empty inventory or no matches; `None` on missing/errored file
- `NEVER_returns_yes` invariant
- Driver-level upgrade by facilitator override

## New fixtures (9)

PPAC: `ppac_empty_env_groups.json`
Sentinel: `sentinel_with_connector_only.json`, `sentinel_no_connectors.json`
SharePoint: `sharepoint_with_scan_and_crossref.json`, `sharepoint_no_scan.json`, `sharepoint_with_ai_strategy_site.json`, `sharepoint_no_ai_sites.json`, `sharepoint_errored.json`, `sharepoint_empty_inventory.json`

## Generator update

`scripts/generate_coverage_matrix.py` `_FRONTIER_EVALUATOR_CANDIDATES` list emptied (Q03 + Q18 removed — no longer "future"). The list is now structurally complete; any new Frontier evaluator wiring would require an explicit governance decision to relax the facilitator-only floor.

## Account discipline note

Pushed and merged from `judeper` (personal). Will switch back to `judep_microsoft` (EMU) immediately after merge to preserve Copilot CLI license.

---

After merge, **v1.6.2 tag** will batch all six Frontier-evaluator PRs (#215, #216, #218, #219, this) into a single CHANGELOG entry covering the 0% → 24% Frontier coverage arc.
