### PR TITLE
Wave 3a: BYO MCP terminology + Three flavors of MCP subsection

### DIFF
--- a/docs/controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md
+++ b/docs/controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md
@@ -259,6 +259,7 @@ customEvents
 - [OCC 2011-12: Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [MITRE ATLAS: AI Threat Framework](https://atlas.mitre.org/)
 - [Microsoft Learn: MCP Server Support](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-microsoft-mcp-servers)
+- [MCP Server Governance for FSI — Three flavors of MCP](../../playbooks/advanced-implementations/mcp-server-governance/index.md#three-flavors-of-mcp) — See also for governance differences among Copilot Studio custom MCP, Microsoft-published MCP servers, and Agent 365 BYO MCP when orchestration designs rely on MCP tools.
 - [Microsoft Learn: Copilot Studio Planned Features (2026 Wave 1)](https://learn.microsoft.com/en-us/power-platform/release-plan/2026wave1/microsoft-copilot-studio/planned-features)
 - [Microsoft Learn: Human-in-the-Loop workflows in Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/workflows/human-in-the-loop)
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/)

--- a/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
+++ b/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
@@ -145,6 +145,7 @@ Confirm control effectiveness by verifying:
 - [Agent Management Essentials overview](https://learn.microsoft.com/en-us/microsoft-365/copilot/agent-essentials/agent-essentials-overview)
 - [Agent prerequisites](https://learn.microsoft.com/en-us/microsoft-365/copilot/agent-essentials/agent-prerequisites)
 - [Agent 365 security overview](https://learn.microsoft.com/en-us/security/security-for-ai/agent-365-security)
+- [MCP Server Governance for FSI — Three flavors of MCP](../../playbooks/advanced-implementations/mcp-server-governance/index.md#three-flavors-of-mcp) — See also for BYO MCP terminology and how Agent 365 BYO MCP onboarding differs from Copilot Studio custom MCP and Microsoft-published MCP servers.
 - [Researcher agent with Computer Use](https://learn.microsoft.com/en-us/microsoft-365/copilot/researcher-agent-computer-use)
 - [Microsoft 365 Government roadmap (sovereign cloud feature parity)](https://aka.ms/m365gov-roadmap)
 - [Microsoft Power Platform 2026 Wave 1 release plan](https://learn.microsoft.com/en-us/power-platform/release-plan/2026wave1/microsoft-copilot-studio/planned-features)

--- a/docs/playbooks/advanced-implementations/mcp-server-governance/index.md
+++ b/docs/playbooks/advanced-implementations/mcp-server-governance/index.md
@@ -343,6 +343,7 @@ Configure Microsoft Purview to capture and retain MCP-related audit events:
 ## Additional Resources
 
 - [Microsoft Learn: Create a New MCP Server in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-create-new-server)
+- [Microsoft Learn: Bring Your Own MCP server (BYO MCP)](https://learn.microsoft.com/microsoft-agent-365/bring-your-own-mcp)
 - [Microsoft Learn: Copilot Studio Planned Features (2026 Wave 1)](https://learn.microsoft.com/en-us/power-platform/release-plan/2026wave1/microsoft-copilot-studio/planned-features)
 - [Microsoft Learn: Power Platform DLP Policies](https://learn.microsoft.com/en-us/power-platform/admin/wp-data-loss-prevention)
 - [Microsoft Learn: Azure Key Vault Overview](https://learn.microsoft.com/en-us/azure/key-vault/general/overview)

--- a/docs/playbooks/advanced-implementations/mcp-server-governance/index.md
+++ b/docs/playbooks/advanced-implementations/mcp-server-governance/index.md
@@ -18,6 +18,18 @@ This playbook provides FSI-specific governance guidance for MCP server integrati
 
 ---
 
+## Three flavors of MCP
+
+MCP governance depends on which MCP path is in use. FSI teams should identify the hosting model, administrative surface, and covered controls before approving an agent design because the same protocol can enter through different Microsoft governance surfaces.
+
+**Copilot Studio custom MCP** uses customer- or vendor-hosted MCP servers wired into Copilot Studio agents as custom connectors. The server is hosted outside Microsoft by the customer or vendor, while governance is applied through Power Platform connector governance, DLP and Advanced Connector Policies, environment scope, and Copilot Studio publish review; see Controls 1.4, 1.5, 2.17, and 2.25.
+
+**Microsoft-published MCP servers** are first-party MCP servers shipped and maintained by Microsoft, such as the Microsoft 365 connector MCP. Microsoft hosts and publishes the server, while the tenant governs availability through Microsoft 365 admin center and Agent 365 inventory, app and connector approvals, audit, and reporting surfaces; see Controls 1.2, 1.7, 2.25, 3.13, and 3.14.
+
+**Agent 365 Bring Your Own MCP server (BYO MCP)** covers customer-hosted remote MCP servers registered to Agent 365 through the BYO MCP onboarding surface. The customer hosts and operates the remote MCP server, while Agent 365 registration, Microsoft 365 admin center approval, the Agent 365 Tooling Gateway, Entra permission review, and Defender advanced hunting provide the governance and observability surface; see Controls 1.7, 2.17, 2.25, 2.26, 3.13, and 3.14. Implementation requires verifying current preview capabilities and client-surface support before production use.
+
+---
+
 ## FSI Risk Assessment
 
 MCP server integration introduces governance considerations that require attention in regulated financial services environments:


### PR DESCRIPTION
## Summary

Wave 3a of the 5-wave plan. This PR stacks on Wave 2 (PR #230), which stacks on Wave 1 (PR #224), and branches from `wave-2-license-overlay`.

## Changes

- Updated `docs/playbooks/advanced-implementations/mcp-server-governance/index.md` to introduce **Bring Your Own MCP server (BYO MCP)** terminology.
- Added the new **Three flavors of MCP** subsection:
  > MCP governance depends on which MCP path is in use. FSI teams should identify the hosting model, administrative surface, and covered controls before approving an agent design because the same protocol can enter through different Microsoft governance surfaces.
- Added the verified Microsoft Learn BYO MCP overview link: https://learn.microsoft.com/microsoft-agent-365/bring-your-own-mcp (verified live with `web_fetch`; no substitution required).
- Added see-also cross-links from:
  - Control 2.17 — Multi-Agent Orchestration Limits
  - Control 2.25 — Microsoft Agent 365 Admin Center Governance Console

## Parallel-wave conflict notes

- `docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md` is also expected to receive Wave 3b/3c additive cross-links. This PR only appends one Additional Resources bullet.
- Did not touch Wave 3b/3c/3d-owned files, `mkdocs.yml`, `license-requirements.md`, getting-started files, or Control 1.29.

## Validation

- `mkdocs build --strict` — passed (exit 0; Material for MkDocs advisory printed)
- `python scripts/verify_controls.py` — passed
- `python scripts/check_manifest_doc_drift.py --check` — passed
- `python scripts/generate_coverage_matrix.py --check` — passed
- `python scripts/generate_coverage_matrix.py --type frontier --check` — passed
- `python scripts/verify_language_rules.py` — passed
- `python scripts/verify_excel_templates.py` — passed
- `ruff check assessment scripts` — passed
