### PR TITLE
Wave 3c: Windows 365 for Agents (W365A) reference doc + license row + cross-links

### DIFF
--- a/docs/controls/pillar-1-security/1.20-network-isolation-private-connectivity.md
+++ b/docs/controls/pillar-1-security/1.20-network-isolation-private-connectivity.md
@@ -91,6 +91,7 @@ Together, these mechanisms remove agent traffic from the public internet for the
 | [1.7 - Comprehensive Audit Logging](1.7-comprehensive-audit-logging-and-compliance.md) | NSG flow logs and Private Link diagnostic logs supplement Purview audit for network-layer evidence. |
 | [1.11 - Conditional Access and Phishing-Resistant MFA](1.11-conditional-access-and-phishing-resistant-mfa.md) | IP firewall allowlists should reconcile with Conditional Access named locations to avoid contradictory enforcement. |
 | [1.6 - Microsoft Purview DSPM for AI](1.6-microsoft-purview-dspm-for-ai.md) | Private endpoints constrain *where* DSPM-monitored agent data can flow. |
+| [Windows 365 for Agents reference](../../reference/windows-365-for-agents.md) | Cloud PC agent pools introduce Intune-managed execution endpoints whose network paths should be scoped against private connectivity and diagnostic evidence. |
 
 ---
 

--- a/docs/controls/pillar-1-security/1.29-global-secure-access-network-controls.md
+++ b/docs/controls/pillar-1-security/1.29-global-secure-access-network-controls.md
@@ -142,6 +142,7 @@ When an agent initiates a request to an external resource:
 | **1.8** | Runtime Protection and External Threat Detection | Complementary — 1.8 provides runtime behavioral monitoring; 1.29 provides network-layer prevention. GSA blocked events should feed into 1.8 threat detection workflows. |
 | **3.9** | Microsoft Sentinel Integration | Dependent — Zone 3 requires GSA traffic logs exported to Sentinel. 3.9 defines log schema, alert rules, and retention policy that consume GSA agent traffic log data. |
 | **2.25** | Agent 365 Admin Center Governance Console | Informational — Agent 365 governance templates include Entra Network visibility cards. GSA configuration state should be reflected in the governance console environment health view. |
+| **W365A** | [Windows 365 for Agents reference](../../reference/windows-365-for-agents.md) | Informational — Cloud PC execution for agents can generate outbound web traffic that should be evaluated against GSA egress policy and traffic-log review where enabled. |
 
 ---
 

--- a/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
+++ b/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
@@ -267,6 +267,7 @@ Microsoft Entra admin center
 | [3.2 - Usage Analytics](../pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md) | Activity monitoring |
 | [3.9 - Sentinel Integration](../pillar-3-reporting/3.9-microsoft-sentinel-integration.md) | SIEM integration |
 | [3.14 - Agent 365 Observability SDK](../pillar-3-reporting/3.14-agent-365-observability-sdk.md) | Extends Entra audit logging with custom agent telemetry and session correlation |
+| [Windows 365 for Agents reference](../../reference/windows-365-for-agents.md) | Cloud PC audit evidence for agent execution sessions supplements Purview Audit and Agent 365 audit correlation. |
 
 !!! tip "Automated Validation: Deny Event Correlation Report"
     For daily operational reports correlating deny events across Purview Audit, DLP, and Application Insights with anomaly detection and zone-based alerting, see the **Deny Event Correlation Report** solution.

--- a/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
+++ b/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
@@ -112,6 +112,7 @@ Establish administrative governance over Microsoft 365 AI agents through the Mic
 | 3.13 — Agent 365 Admin Center Analytics and Reporting | Companion reporting control (planned); operationalizes the analytics surfaces (by publisher, by platform, Active Users Over Time) available within the Agent 365 console documented here. Verify availability before relying on it. |
 | 3.6 — Orphaned Agent Detection and Remediation | The Ownerless Agents governance card in the Agent 365 console is the primary detection mechanism for the remediation workflow defined in Control 3.6. Assignments made via the Assign Owner action must be reflected in the Control 3.6 orphaned agent register. |
 | 1.11 — Conditional Access and MFA | Conditional Access policies referenced in the Default Governance Template are configured and maintained per Control 1.11. Governance template application in Agent 365 assumes 1.11 baseline CA policies are in place. |
+| [Windows 365 for Agents reference](../../reference/windows-365-for-agents.md) | Informational — W365A is the Cloud PC execution layer for Agent 365 computer-using agents; governance console review should track agent pools, billing plans, and owner approvals where W365A is enabled. |
 
 ## Implementation Playbooks
 

--- a/docs/reference/agent-365-capabilities-summary.md
+++ b/docs/reference/agent-365-capabilities-summary.md
@@ -28,6 +28,7 @@ Agent 365 is Microsoft's governance control plane for AI agents, announced at Ig
 | **Agent Registry** | Centralized inventory including shadow agent detection | [Control 3.1](../controls/pillar-3-reporting/3.1-agent-inventory-and-metadata-management.md), [Control 3.6](../controls/pillar-3-reporting/3.6-orphaned-agent-detection-and-remediation.md) |
 | **Observability SDK** | OpenTelemetry-based telemetry for agent monitoring | [Agent 365 Observability Playbook](../playbooks/advanced-implementations/agent-365-observability/index.md) |
 | **MCP Server Support** | Cross-platform agent interoperability | [Control 2.17](../controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md) |
+| **Windows 365 for Agents** | Cloud PC execution layer for Agent 365 computer-using agents (public preview) | [Windows 365 for Agents Reference](windows-365-for-agents.md) |
 
 ---
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -47,6 +47,7 @@ This section provides technical reference materials, standards, and supporting d
 | [Agent Audit Event Taxonomy](agent-audit-event-taxonomy.md) | Consolidated audit event reference with KQL queries |
 | [Agent Essentials Control Mapping](agent-essentials-control-mapping.md) | Microsoft Agent Essentials to FSI control mapping |
 | [Agent 365 Capabilities Summary](agent-365-capabilities-summary.md) | Microsoft 365 agent capabilities overview |
+| [Windows 365 for Agents](windows-365-for-agents.md) | Public preview scoping reference for agent Cloud PC execution, Intune policy hooks, audit evidence, and control mappings |
 | [Power Platform SSPM Control Mapping](power-platform-sspm-control-mapping.md) | SaaS Security Posture Management control mapping |
 | [Work IQ Governance Reference](work-iq-governance.md) | Governance considerations for Work IQ MCP tools, business skills, admin consent, data boundaries, and audit evidence |
 

--- a/docs/reference/license-requirements.md
+++ b/docs/reference/license-requirements.md
@@ -20,6 +20,7 @@ License mapping guidance for the current FSI Agent Governance Framework control 
 | **Microsoft 365 Copilot** | 2.24, 3.8 | Copilot experiences and first-party agents |
 | **Microsoft Agent 365** | 1.8, 2.24, 2.25, 2.26, 3.8, 3.13, 3.14 | Agent control plane, registry, analytics, identity, observability |
 | **Microsoft 365 E7** | 2.24, 2.25, 2.26, 3.8, 3.13, 3.14 | Agent 365 entitlement bundle option |
+| **Windows 365 for Agents (Public Preview)** | W365A scope (touchpoints: 1.7, 1.20, 1.29, 2.25) | Agent Cloud PC execution in public preview; Microsoft Learn lists Windows 365 or Agent 365 tenant licensing plus an active W365A billing plan, with Agent ID features licensed through Microsoft Agent 365 or Microsoft 365 E7 |
 | **Microsoft 365 Copilot Business** | N/A | SMB Copilot access |
 
 !!! note "Agent 365 and GSA licensing references"

--- a/docs/reference/windows-365-for-agents.md
+++ b/docs/reference/windows-365-for-agents.md
@@ -1,0 +1,97 @@
+# Windows 365 for Agents (W365A) Reference
+
+**Last Updated:** May 2026
+**Version:** v1.6.2
+
+!!! warning "Public Preview"
+    Microsoft documents Windows 365 for Agents as a [public preview](https://learn.microsoft.com/windows-365/agents/w365a-availability-a365). Preview capabilities can change before general availability and may have regional, licensing, or support limitations. Use this page as informational scoping guidance only; do not treat W365A as a baseline enforcement procedure until Microsoft publishes generally available operational guidance and your organization completes risk acceptance.
+
+---
+
+## Overview
+
+Windows 365 for Agents (W365A) is the Windows 365 execution layer for computer-using agents in Agent 365. Microsoft describes it as a way for Agent 365 agents to obtain Cloud PCs when work requires a full Windows session for desktop applications, browsers, files, or enterprise systems instead of API-only automation ([Windows 365 for Agents in Agent 365](https://learn.microsoft.com/windows-365/agents/w365a-availability-a365)).
+
+Microsoft also describes W365A as a new class of Cloud PCs for agent use, built on the Windows 365 Cloud PC platform. Agents use a check-out/check-in model: an agent checks out a Cloud PC for a task, then checks it back in when the task completes ([What is Windows 365 for Agents?](https://learn.microsoft.com/windows-365/agents/introduction-windows-365-for-agents)). In the current public preview, Microsoft lists United States availability for W365A ([What is Windows 365 for Agents?](https://learn.microsoft.com/windows-365/agents/introduction-windows-365-for-agents#regions-available)).
+
+For FSI governance, W365A should be treated as an agent execution substrate that introduces endpoint, identity, network, audit, and billing evidence streams. It does not replace the framework's existing controls for audit logging, private connectivity, outbound network controls, or Agent 365 administration.
+
+---
+
+## Intune Policy Hooks
+
+Microsoft states that Cloud PCs for Agents are managed through the Microsoft Intune admin center and appear under **Devices** > **All devices** with a `CPCA-` device-name prefix and a **Cloud PC for Agents** device model ([Manage and monitor Cloud PCs for Agents in Microsoft Intune](https://learn.microsoft.com/windows-365/agents/device-management-cloud-pcs-agents)).
+
+Microsoft also states that Intune apps and policies can target Cloud PCs for Agents by using the device name prefix, device model, or enrollment profile in device groups or filters ([Manage and monitor Cloud PCs for Agents in Microsoft Intune](https://learn.microsoft.com/windows-365/agents/device-management-cloud-pcs-agents#assign-apps-and-policies)). A provisioning policy (agents) determines the configuration used to create Cloud PCs for Agents, and Microsoft maps that provisioning policy to a Cloud PC agent pool in Intune ([Create a provisioning policy (agents)](https://learn.microsoft.com/windows-365/agents/create-provisioning-policy-agents)).
+
+| Intune hook | Governance use in this framework | Evidence to retain |
+|-------------|----------------------------------|--------------------|
+| `CPCA-` device-name prefix and **Cloud PC for Agents** model | Build dynamic groups or filters for W365A Cloud PCs without mixing human-user Cloud PCs into agent policy scope | Screenshot/export of the Intune device filter or dynamic group definition |
+| Enrollment profile matching the provisioning policy | Tie a Cloud PC back to the agent pool and business owner recorded in [Control 2.25](../controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md) | Provisioning policy name, assigned agent list, and owner approval record |
+| Intune app and configuration policy targeting | Apply endpoint hardening baselines, browser policy, extension restrictions, and approved tooling only to W365A Cloud PCs | Policy assignment export and last successful device check-in evidence |
+| Compliance policy targeting | Track whether W365A Cloud PCs meet the same endpoint posture expectations as other managed endpoints | Compliance state export with remediation tickets for exceptions |
+
+Implementation caveat: policy targeting depends on accurate naming, model, and enrollment-profile signals. Validate filters in a non-production W365A pool before relying on them for Zone 2 or Zone 3 evidence.
+
+---
+
+## Cloud PC Audit Evidence
+
+W365A introduces two related evidence layers: Windows 365 Cloud PC administrative audit events and agent/session audit context across Agent 365, Microsoft Entra, Microsoft Defender, and Microsoft Purview.
+
+| Evidence layer | Microsoft-documented location | Framework use |
+|----------------|-------------------------------|---------------|
+| Windows 365 Cloud PC audit logs | Microsoft states that Windows 365 audit logs record Cloud PC create, update, delete, assign, and remote actions, are enabled by default, and can be retrieved through Microsoft Graph beta cmdlets or exported through Intune **Reports** > **Diagnostic settings** by selecting `Windows365AuditLogs` ([Get Windows 365 audit logs](https://learn.microsoft.com/windows-365/enterprise/get-cloud-pc-audit-logs-using-powershell)). | Retain as supplemental evidence for [Control 1.7 — Comprehensive Audit Logging](../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md), especially when examiners ask how agent execution infrastructure is administered. |
+| W365A agent session audit trail | Microsoft describes an end-to-end W365A audit view spanning Agent 365 task execution, Microsoft Entra sign-in logs, Microsoft Defender security events, and Microsoft Purview data access/governance activity ([Identity and security: secure by design](https://learn.microsoft.com/windows-365/agents/identity-security-secure-by-design#end-to-end-audit-trail)). | Correlate agent prompts, agent identity sign-ins, Cloud PC session activity, and Purview records under [Control 1.7](../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md). |
+| Network path and private dependency evidence | W365A Cloud PCs are Microsoft Entra-joined and Intune-enrolled in the W365A identity/security model ([Identity and security: secure by design](https://learn.microsoft.com/windows-365/agents/identity-security-secure-by-design)). | Evaluate whether agent Cloud PC traffic to regulated dependencies should follow private connectivity patterns in [Control 1.20 — Network Isolation and Private Connectivity](../controls/pillar-1-security/1.20-network-isolation-private-connectivity.md). |
+| Outbound web access evidence | Microsoft documents network controls for agents as a Microsoft Entra Internet Access / Global Secure Access licensing area for agent identities ([Agent ID prerequisites](https://learn.microsoft.com/entra/agent-id/migrate-copilot-studio-agents-to-agent-id#prerequisites)). | Evaluate W365A-driven browser or web-application activity against [Control 1.29 — Global Secure Access Network Controls](../controls/pillar-1-security/1.29-global-secure-access-network-controls.md) where agent egress should be filtered or logged. |
+
+Recommended evidence package for Zone 2 and Zone 3 W365A pilots:
+
+1. W365A public preview risk acceptance and approved use-case scope.
+2. Intune device filter or dynamic group definition for `CPCA-` / **Cloud PC for Agents** devices.
+3. Provisioning policy export, assigned agents, region, billing plan, and pool capacity.
+4. Windows 365 audit-log export or Azure Monitor diagnostic setting showing `Windows365AuditLogs` routing.
+5. Agent 365 / Entra / Purview correlation sample linking the human requester, agent identity, Cloud PC session, and data-access event.
+6. Network evidence showing whether the Cloud PC path uses private connectivity, GSA egress filtering, or documented compensating controls.
+
+---
+
+## Mappings to Existing Controls
+
+| W365A touchpoint | Existing framework mapping | Why it matters |
+|------------------|----------------------------|----------------|
+| Agent Cloud PC execution layer for UI-level or OS-level tasks | [Control 2.25 — Agent 365 Admin Center Governance Console](../controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md) | Agent approvals, owners, and governance templates should include whether W365A execution is enabled for the agent use case. |
+| Cloud PC provisioning policies and agent pools | [Control 2.25](../controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md) and [License Requirements](license-requirements.md) | Pool configuration, billing plan, and assigned agents are part of the governance evidence for the agent service. |
+| Intune-managed Cloud PCs for Agents | [Control 1.20 — Network Isolation and Private Connectivity](../controls/pillar-1-security/1.20-network-isolation-private-connectivity.md) | W365A Cloud PCs add managed endpoint posture and network-path evidence that should be reviewed alongside private connectivity choices. |
+| Windows 365 Cloud PC audit logs and W365A session audit trail | [Control 1.7 — Comprehensive Audit Logging](../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Cloud PC administrative events and session correlation help support supervisory review and recordkeeping evidence. |
+| Browser/web-application activity from agent Cloud PCs | [Control 1.29 — Global Secure Access Network Controls](../controls/pillar-1-security/1.29-global-secure-access-network-controls.md) | Agent-driven web access may need outbound filtering, traffic logs, and destination review. |
+| Agent ID licensing and identity attribution | [Control 2.26 — Entra Agent ID Identity Governance](../controls/pillar-2-management/2.26-entra-agent-id-identity-governance.md) | Agent identity sponsorship, lifecycle, and Conditional Access should be reviewed before W365A is enabled for regulated tasks. |
+
+---
+
+## License Requirements Summary
+
+For provisioning policies (agents), Microsoft lists these prerequisites: either a Windows 365 or Agent 365 license in the tenant, an active Windows 365 for Agents billing plan, and optional Agent users in Agent 365 that can use W365A ([Create a provisioning policy (agents)](https://learn.microsoft.com/windows-365/agents/create-provisioning-policy-agents#prerequisites)). Microsoft also describes W365A billing as consumption-based pay-as-you-go with an optional monthly always-available Cloud PC charge through an Azure subscription ([Set up billing for Windows 365 for Agents](https://learn.microsoft.com/windows-365/agents/billing-w365a), [Pricing for Windows 365 for Agents](https://learn.microsoft.com/windows-365/agents/pricing-paygo-always-available)).
+
+For Agent ID features, Microsoft states that users need a **Microsoft Agent 365** or **Microsoft 365 E7** license, with additional licensing for Conditional Access, ID Protection, ID Governance, and network controls depending on the feature used ([Agent ID prerequisites](https://learn.microsoft.com/entra/agent-id/migrate-copilot-studio-agents-to-agent-id#prerequisites)).
+
+See the W365A row in [License Requirements](license-requirements.md) for the framework-level interpretation. Validate procurement and availability directly with Microsoft before treating W365A as production-ready in a regulated environment.
+
+---
+
+## Microsoft Learn URLs Verified
+
+- [Windows 365 for Agents in Agent 365](https://learn.microsoft.com/windows-365/agents/w365a-availability-a365)
+- [What is Windows 365 for Agents?](https://learn.microsoft.com/windows-365/agents/introduction-windows-365-for-agents)
+- [Manage and monitor Cloud PCs for Agents in Microsoft Intune](https://learn.microsoft.com/windows-365/agents/device-management-cloud-pcs-agents)
+- [Create a provisioning policy (agents)](https://learn.microsoft.com/windows-365/agents/create-provisioning-policy-agents)
+- [Identity and security: secure by design](https://learn.microsoft.com/windows-365/agents/identity-security-secure-by-design)
+- [Get Windows 365 audit logs](https://learn.microsoft.com/windows-365/enterprise/get-cloud-pc-audit-logs-using-powershell)
+- [Set up billing for Windows 365 for Agents](https://learn.microsoft.com/windows-365/agents/billing-w365a)
+- [Pricing for Windows 365 for Agents](https://learn.microsoft.com/windows-365/agents/pricing-paygo-always-available)
+- [Agent ID prerequisites](https://learn.microsoft.com/entra/agent-id/migrate-copilot-studio-agents-to-agent-id#prerequisites)
+
+---
+
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -765,6 +765,7 @@ nav:
     - Agent Audit Event Taxonomy: reference/agent-audit-event-taxonomy.md
     - Agent Essentials Control Mapping: reference/agent-essentials-control-mapping.md
     - Power Platform SSPM Control Mapping: reference/power-platform-sspm-control-mapping.md
+    - Windows 365 for Agents: reference/windows-365-for-agents.md
     - Glossary: reference/glossary.md
     - FAQ: reference/faq.md
     - Work IQ Governance Reference: reference/work-iq-governance.md


### PR DESCRIPTION
## Summary

- Adds `docs/reference/windows-365-for-agents.md` as an informational Public Preview scoping reference for W365A Cloud PC execution, Intune policy hooks, Cloud PC audit evidence, control mappings, and licensing caveats.
- Wires the new reference into `mkdocs.yml`, `docs/reference/index.md`, and a separate W365A row in `docs/reference/license-requirements.md` without modifying the existing Control 1.29 license row.
- Adds append-only cross-links from Controls 1.7, 1.20, 1.29, 2.25, and `agent-365-capabilities-summary.md`.

## Public preview / Microsoft Learn URLs verified

Verified with `web_fetch`:

- https://learn.microsoft.com/windows-365/agents/w365a-availability-a365
- https://learn.microsoft.com/windows-365/agents/introduction-windows-365-for-agents
- https://learn.microsoft.com/windows-365/agents/device-management-cloud-pcs-agents
- https://learn.microsoft.com/windows-365/agents/create-provisioning-policy-agents
- https://learn.microsoft.com/windows-365/agents/identity-security-secure-by-design
- https://learn.microsoft.com/windows-365/enterprise/get-cloud-pc-audit-logs-using-powershell
- https://learn.microsoft.com/windows-365/agents/billing-w365a
- https://learn.microsoft.com/windows-365/agents/pricing-paygo-always-available
- https://learn.microsoft.com/entra/agent-id/migrate-copilot-studio-agents-to-agent-id#prerequisites
- https://learn.microsoft.com/windows-365/public-preview

## License row

Added a separate **Windows 365 for Agents (Public Preview)** row in the License Summary table with W365A scope touchpoints for Controls 1.7, 1.20, 1.29, and 2.25. This is additive and does not change the existing 1.29 / Global Secure Access row.

## Parallel-wave conflict flags

- Did not touch `docs/playbooks/advanced-implementations/mcp-server-governance/index.md` (Wave 3a).
- Did not touch `docs/reference/work-iq-governance.md` (Wave 3b).
- Did not edit the Secure Web and AI Gateway subsection in Control 1.29 (Wave 3d); only appended a Related Controls row.
- Did not touch Wave 2 quick-start/checklist files or Wave 1 version-string territory.
- Shared-file edits are append-only.

## Validation

All requested gates passed:

- `mkdocs build --strict`
- `python scripts/verify_controls.py`
- `python scripts/check_manifest_doc_drift.py --check`
- `python scripts/generate_coverage_matrix.py --check`
- `python scripts/generate_coverage_matrix.py --type frontier --check`
- `python scripts/verify_language_rules.py`
- `python scripts/verify_excel_templates.py`
- `ruff check assessment scripts`

`docs/version.json` was reverted after validation.
