### PR TITLE
Wave 3d: Control 1.29 Secure Web and AI Gateway subsection

### DIFF
--- a/docs/controls/pillar-1-security/1.29-global-secure-access-network-controls.md
+++ b/docs/controls/pillar-1-security/1.29-global-secure-access-network-controls.md
@@ -49,6 +49,50 @@ Global Secure Access treats agents as security principals — applying the same 
 | **GSA Traffic Logs with Agent Metadata** | All agent traffic passing through GSA generates structured log entries including agent-specific metadata fields. Logs are queryable in Microsoft Entra admin center and exportable to Microsoft Sentinel (see Control 3.9) for SIEM correlation, retention, and examination evidence generation. |
 | **Baseline Profile Policy Linking** | Security policies (web content filtering, threat intelligence, file filtering) are linked to the Global Secure Access baseline profile. The baseline profile applies at the tenant level to all forwarded agent traffic. Note: Conditional Access-linked profiles are not yet supported for agent traffic in the current preview. |
 
+### Secure Web and AI Gateway for Copilot Studio agents
+
+!!! info "Preview scope and current limits"
+    Microsoft documents Secure Web and AI Gateway for Copilot Studio agents as a Global Secure Access (GSA) capability for forwarding Copilot Studio agent traffic from Power Platform environments or environment groups to GSA. In the current preview, agent network controls use the GSA baseline profile; Conditional Access-linked profiles, partner DLP integrations, Copilot Studio Bing search transactions, Dataverse and Azure SQL knowledge-source traffic, Copilot Studio LLM orchestration or result-enhancement requests, and some connectors or custom tools aren't supported. Review the [Power Platform Secure Web and AI Gateway overview](https://learn.microsoft.com/en-us/power-platform/admin/security/secure-web-ai-gateway-agents) and the [Microsoft Entra configuration guide](https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-secure-web-ai-gateway-agents) before relying on this control for regulated workloads.
+
+In plain terms, Secure Web and AI Gateway is the GSA feature that routes supported Copilot Studio agent egress through Microsoft's globally distributed proxy so agent HTTP, connector, and MCP traffic can be evaluated against tenant security policies. It extends the same style of web content filtering, threat intelligence filtering, network file filtering, and traffic logging used for users to supported agent-originated traffic, with implementation caveats for the preview limitations above.
+
+#### MCP connector traffic governance
+
+Microsoft's Copilot Studio documentation states that GSA forwarding applies to HTTP node traffic, tools-generated connectors, custom connectors, custom Model Context Protocol (MCP) servers, custom tools, and supported connectors. For [Control 2.17 — Multi-Agent Orchestration Limits](../pillar-2-management/2.17-multi-agent-orchestration-limits.md), treat Secure Web and AI Gateway as the network-policy layer for MCP and Bring Your Own MCP server (BYO MCP) traffic: approve the MCP server and tool surface under Control 2.17, then use GSA baseline-profile policies to evaluate the outbound MCP requests that leave the agent environment.
+
+This supports governance of MCP traffic in three ways:
+
+- **Destination control:** Web content filtering and explicit URL rules help restrict MCP calls to approved domains and categories, including approved internal APIs and sanctioned vendor MCP endpoints.
+- **Threat-intelligence screening:** Threat intelligence filtering helps mitigate malicious or compromised MCP destinations by evaluating agent requests against Microsoft threat intelligence before the request is forwarded.
+- **File-transfer guardrails and logs:** Network file filtering and GSA traffic logs help identify uploads, downloads, and blocked requests associated with an agent's schema name, supporting SIEM correlation per Control 3.9.
+
+These controls do not replace MCP server approval, server-level authentication review, tool-level DLP/access controls, request/response telemetry, or the MCP monitoring patterns documented in Control 2.17. They provide an additional outbound network layer for supported MCP traffic.
+
+#### Prompt-injection defense
+
+Secure Web and AI Gateway should be positioned as defense-in-depth for prompt-injection scenarios, not as a complete prompt-injection solution. For supported Copilot Studio agent traffic, GSA helps mitigate prompt-injection-driven egress by constraining where induced tool calls can connect, screening destinations with threat intelligence, controlling file uploads and downloads, and logging blocked attempts for investigation. This can attenuate common classes of prompt-injection vectors, including direct instructions that try to force an agent to call an unauthorized HTTP endpoint, indirect instructions embedded in external content that try to exfiltrate data through a connector, and malicious MCP responses that try to redirect the agent to an unapproved destination.
+
+Microsoft also documents [Prompt Injection Protection in Global Secure Access](https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-ai-prompt-injection-protection) for JSON-based generative AI applications routed through Internet Access traffic forwarding, TLS inspection, prompt policies, and security profiles. Use that capability as a complementary control for external GenAI endpoints that are within its supported scope. Do not assume it inspects Copilot Studio's internal LLM orchestration traffic: Microsoft's Secure Web and AI Gateway limitations state that Copilot Studio LLM orchestration and result-enhancement requests aren't supported by agent network controls, and Prompt Injection Protection currently supports text prompts for JSON-based GenAI apps with documented size and file limitations.
+
+#### Tenant restriction policies
+
+Universal tenant restrictions use Global Secure Access signaling to apply tenant restrictions v2 policy information to Microsoft Entra ID and Microsoft Graph traffic. Microsoft documents the configuration path as **Microsoft Entra admin center > Global Secure Access > Settings > Session Management > Universal Tenant Restrictions**, after tenant restrictions v2 policies are defined in cross-tenant access settings. See [Turn on universal tenant restrictions](https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-universal-tenant-restrictions) and [Set up tenant restrictions v2](https://learn.microsoft.com/en-us/azure/active-directory/external-identities/tenant-restrictions-v2).
+
+For agent governance, tenant restrictions are complementary to Secure Web and AI Gateway rather than a substitute for it. Tenant restrictions help reduce cross-tenant authentication and Microsoft Graph data-plane risk for managed devices and remote networks, while the Secure Web and AI Gateway agent forwarding toggle governs supported Copilot Studio agent egress such as HTTP, connector, custom connector, custom MCP server, and custom tool traffic. Document both policy sets in the change record so reviewers can distinguish tenant-boundary restrictions from agent outbound filtering.
+
+#### Configuration pointers
+
+At a high level, configure this capability in two administrative surfaces:
+
+1. In the **Power Platform admin center**, go to **Security > Identity & access > Global Secure Access for Agents**, select an environment or environment group, choose **Set up**, and enable **Global Secure Access for Agents**. Microsoft notes that existing Copilot Studio custom connectors must be edited and saved after enablement so their traffic routes through GSA.
+2. In the **Microsoft Entra admin center**, go to **Global Secure Access > Secure** to create web content filtering, threat intelligence, network file filtering, and—where applicable—prompt policies. For Copilot Studio agent traffic, link the relevant web, threat, and file policies to the **Baseline profile** because Conditional Access-linked security profiles aren't currently supported for agent traffic.
+
+#### Cross-references
+
+- [Control 1.20 — Network Isolation and Private Connectivity](./1.20-network-isolation-private-connectivity.md): inbound network isolation remains the companion control for private endpoint, VNet, and IP-restriction scenarios.
+- [Control 2.17 — Multi-Agent Orchestration Limits](../pillar-2-management/2.17-multi-agent-orchestration-limits.md): MCP approval, BYO MCP governance, and multi-agent orchestration monitoring remain the source controls for tool and delegation risk.
+- [Control 2.25 — Microsoft Agent 365 Admin Center Governance Console](../pillar-2-management/2.25-agent-365-admin-center-governance-console.md): Agent 365 governance console evidence should reflect whether GSA network visibility and related policy posture are configured for governed environments.
+
 ---
 
 ## Key Configuration Points
@@ -142,6 +186,7 @@ When an agent initiates a request to an external resource:
 | **1.8** | Runtime Protection and External Threat Detection | Complementary — 1.8 provides runtime behavioral monitoring; 1.29 provides network-layer prevention. GSA blocked events should feed into 1.8 threat detection workflows. |
 | **3.9** | Microsoft Sentinel Integration | Dependent — Zone 3 requires GSA traffic logs exported to Sentinel. 3.9 defines log schema, alert rules, and retention policy that consume GSA agent traffic log data. |
 | **2.25** | Agent 365 Admin Center Governance Console | Informational — Agent 365 governance templates include Entra Network visibility cards. GSA configuration state should be reflected in the governance console environment health view. |
+| **2.17** | Multi-Agent Orchestration Limits | Complementary — Control 2.17 governs MCP server approval, BYO MCP patterns, and multi-agent delegation controls; the [Secure Web and AI Gateway subsection](#secure-web-and-ai-gateway-for-copilot-studio-agents) describes the outbound network layer for supported MCP connector traffic. |
 | **W365A** | [Windows 365 for Agents reference](../../reference/windows-365-for-agents.md) | Informational — Cloud PC execution for agents can generate outbound web traffic that should be evaluated against GSA egress policy and traffic-log review where enabled. |
 
 ---

--- a/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
+++ b/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
@@ -113,6 +113,7 @@ Establish administrative governance over Microsoft 365 AI agents through the Mic
 | 3.6 — Orphaned Agent Detection and Remediation | The Ownerless Agents governance card in the Agent 365 console is the primary detection mechanism for the remediation workflow defined in Control 3.6. Assignments made via the Assign Owner action must be reflected in the Control 3.6 orphaned agent register. |
 | 1.11 — Conditional Access and MFA | Conditional Access policies referenced in the Default Governance Template are configured and maintained per Control 1.11. Governance template application in Agent 365 assumes 1.11 baseline CA policies are in place. |
 | [Windows 365 for Agents reference](../../reference/windows-365-for-agents.md) | Informational — W365A is the Cloud PC execution layer for Agent 365 computer-using agents; governance console review should track agent pools, billing plans, and owner approvals where W365A is enabled. |
+| [1.29 — Global Secure Access: Network Controls](../pillar-1-security/1.29-global-secure-access-network-controls.md#secure-web-and-ai-gateway-for-copilot-studio-agents) | Network-layer governance companion for Agent 365 governance templates. The Secure Web and AI Gateway subsection explains how GSA forwarding, supported MCP/custom connector traffic controls, prompt-injection defense-in-depth, and tenant restrictions complement Agent 365 console oversight. |
 
 ## Implementation Playbooks
 


### PR DESCRIPTION
## Summary

- Adds a new Control 1.29 subsection, Secure Web and AI Gateway for Copilot Studio agents, covering GSA agent forwarding, supported MCP / BYO MCP traffic governance, prompt-injection defense-in-depth, tenant restrictions, and configuration pointers.
- Adds an append-only Control 2.25 Related Controls cross-link to the new 1.29 subsection.
- Defers the mcp-server-governance playbook cross-link to follow-up issue: 
https://github.com/judeper/FSI-AgentGov/issues/234

## Microsoft Learn URLs verified

- https://learn.microsoft.com/en-us/power-platform/admin/security/secure-web-ai-gateway-agents
- https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-secure-web-ai-gateway-agents
- https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-ai-prompt-injection-protection
- https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-universal-tenant-restrictions
- https://learn.microsoft.com/en-us/azure/active-directory/external-identities/tenant-restrictions-v2

## Prompt-injection scope

Positioned as defense-in-depth only: the subsection states that GSA helps mitigate prompt-injection-driven egress for supported agent traffic and that Prompt Injection Protection is complementary for supported JSON-based GenAI endpoints. It explicitly does not claim coverage for Copilot Studio internal LLM orchestration traffic.

## Conflict flags

- Control 1.29 Related Controls is shared with Wave 3c; this PR uses append-only additions only.
- Control 2.25 Related Controls is shared with Wave 3a/3b/3c; this PR uses an append-only addition only.
- The mcp-server-governance playbook cross-link is deferred to avoid Wave 3a file conflicts.

## Validation

- PASS: mkdocs build --strict
- PASS: python scripts/verify_controls.py
- PASS: python scripts/check_manifest_doc_drift.py --check
- PASS: python scripts/generate_coverage_matrix.py --check
- PASS: python scripts/generate_coverage_matrix.py --type frontier --check
- PASS: python scripts/verify_language_rules.py
- PASS: python scripts/verify_excel_templates.py
- PASS: ruff check assessment scripts