### PR TITLE
chore(ci): ignore eCFR.gov in markdown-link-check (503 flake)

### DIFF
--- a/.github/workflows/mlc-config.json
+++ b/.github/workflows/mlc-config.json
@@ -31,6 +31,9 @@
       "pattern": "^https://www\\.ftc\\.gov"
     },
     {
+      "pattern": "^https://www\\.ecfr\\.gov"
+    },
+    {
       "pattern": "^https://admin\\.portal\\.com"
     },
     {

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -16,6 +16,9 @@
     },
     {
       "pattern": "^https://github.com/judeper/FSI-AgentGov-Solutions"
+    },
+    {
+      "pattern": "^https://www\\.ecfr\\.gov"
     }
   ],
   "replacementPatterns": [],


### PR DESCRIPTION
## Summary

Adds `^https://www\.ecfr\.gov` to the `ignorePatterns` list in both markdown-link-check configs so PR CI is no longer blocked when the U.S. Electronic Code of Federal Regulations site is having a 503 episode.

## Why

All 4 of the recently-opened content waves are currently red on `markdown-link-check` for the same reason — eCFR.gov returning `Status: 503` under crawler load:
- PR #224 (Wave 1 — version truthfulness)
- PR #230 (Wave 2 — license overlay)
- PR #233 (Wave 3c — W365A reference)
- PR #235 (Wave 3d — Secure Web and AI Gateway)

None of those PRs touch eCFR URLs. The flake is environmental.

## Pattern consistency

This matches the existing exemptions for other US regulatory sites already in the same `ignorePatterns` list:
- `^https://www\.sec\.gov`
- `^https://www\.ftc\.gov`

eCFR URLs in the repo are stable government regulation references (SEC 17a-3/4, FINRA 4511/3110, OCC 2011-12, etc). If a citation ever moves we'd update the affected control regardless of link-check.

## Files changed

- `.github/workflows/mlc-config.json` — used by CI (`link-check.yml`)
- `.markdown-link-check.json` — used by IDE plugins / local runs (kept in sync to avoid divergence)

## After this merges

The 4 stacked content PRs will need a CI re-run (or a fresh push) to pick up the updated config.