### PR TITLE
docs(pillar-1): substantive Microsoft Learn drift fixes for controls 1.5/1.6/1.9/1.10 (Wave 6a)

### DIFF
--- a/docs/controls/pillar-1-security/1.10-communication-compliance-monitoring.md
+++ b/docs/controls/pillar-1-security/1.10-communication-compliance-monitoring.md
@@ -52,16 +52,16 @@ Detect and review policy-relevant content in agent-assisted interactions, includ
 
 ### Monitored Channels and AI Locations
 
-Communication Compliance policies operate across the channels and locations Microsoft Learn currently documents. To monitor Microsoft 365 Copilot and Copilot Chat, use the dedicated template **"Detect Microsoft 365 Copilot and Microsoft 365 Copilot Chat interactions"**, which configures **Prompt Shields** and **Protected material** classifiers.
+Communication Compliance policies operate across the channels and locations Microsoft Learn currently documents. To monitor Copilot interactions, use the dedicated template **"Detect Microsoft Copilot interactions"**. Microsoft Learn's policy-template reference documents the Copilot interactions template conditions as **Prompt Shields** and **Protected material** classifiers; verify the displayed conditions during policy creation because template details can vary by tenant rollout.
 
 | Location group | Examples | Notes |
 |----------------|----------|-------|
 | Exchange Online | User mailboxes (internal and outbound) | Reviewers must have Exchange Online mailboxes |
 | Microsoft Teams | Chats, channels (excluding shared with external) | Teams chat matches **may take up to 48 hours** to process per Learn |
 | Viva Engage | Public communities | |
-| Microsoft Copilot experiences | Microsoft 365 Copilot, Copilot Chat | Use the dedicated Copilot template |
-| Enterprise AI apps | Copilot Studio agents, Security Copilot, Fabric Copilot, etc. | **Pay-as-you-go billing required** for non-M365 AI data per Learn |
-| Other AI apps | Approved third-party generative AI (e.g., ChatGPT Enterprise, Gemini for Workspace via connectors) | **Pay-as-you-go billing required** for non-M365 AI data |
+| Microsoft Copilot experiences | Microsoft 365 Copilot, Copilot Chat, Copilot Studio, Security Copilot, Copilot in Fabric | Use the dedicated **Detect Microsoft Copilot interactions** template for Copilot policy creation |
+| Enterprise AI apps | Entra-connected or Purview Data Map-connected generative AI apps, such as ChatGPT Enterprise | **Pay-as-you-go billing required** for non-M365 AI data per Learn |
+| Other AI apps | Browser and network activity for unmanaged AI apps, such as ChatGPT, Google Gemini, and Microsoft Copilot consumer | **Pay-as-you-go billing required** for non-M365 AI data |
 | Third-party sources | Bloomberg, Slack, etc. via supported connectors | Connector availability varies; verify per tenant |
 
 !!! warning "Pay-as-you-go billing required for non-M365 AI"
@@ -77,14 +77,14 @@ Communication Compliance policies operate across the channels and locations Micr
 - **Enable Unified Audit Log first.** Microsoft Learn marks this as a required step; Communication Compliance relies on the audit log for alert generation and reviewer-action logging.
 - **Verify the privacy default.** Pseudonymization of usernames is **on by default** in Communication Compliance. Document the opt-out audit trail (admin, justification, date) before any reviewer is opted in to investigator capability.
 - Assign role groups using the canonical Learn names: **Communication Compliance** (catch-all), **Communication Compliance Admins**, **Communication Compliance Analysts**, **Communication Compliance Investigators**, **Communication Compliance Viewers**. Reviewers must also be assigned at the per-policy level and must have Exchange Online mailboxes.
-- Use the built-in template **"Detect Microsoft 365 Copilot and Microsoft 365 Copilot Chat interactions"** as the starting point for AI monitoring; this template configures **Prompt Shields** and **Protected material** classifiers and is the canonical Copilot scope.
+- Use the built-in template **"Detect Microsoft Copilot interactions"** as the starting point for Copilot monitoring; Microsoft Learn's policy-template reference documents **Prompt Shields** and **Protected material** conditions for the Copilot interactions template, and administrators should verify the displayed conditions before creating the policy.
 - Use **"Detect inappropriate text"** (Exchange + Teams + Viva Engage) for harassment / threats / discrimination scenarios. Note that **"Detect inappropriate content"** is locked to Teams + Viva Engage with Hate / Violence / Sexual / Self-harm classifiers; it does not support Exchange or Copilot locations.
 - Use **"Detect financial regulatory compliance"** (Regulatory compliance template) for FINRA-specific scenarios. *This template defaults to a 10% review percentage; FSI customers supervising registered representatives typically need 100%; tune the review percentage explicitly and document the basis.*
 - Use **Custom policy** when template-locked locations / direction / conditions do not fit the use case.
 - Configure OCR via the policy condition checkbox (it is not a tenant-level toggle). OCR processing typically takes about an hour to take effect per Learn.
 - Document each policy's **Reviewers**, **Locations**, **Conditions**, **Review percentage**, **Direction**, and **Policy Match Preservation** setting as part of the supervisory design record.
 - Plan **administrative units** to scope reviewer/investigator permissions by region or business unit. Per Learn this is the documented mechanism for HR-only vs. Compliance-only vs. Legal-only scoping in multi-affiliate FSI organizations.
-- For non-Microsoft 365 AI / Enterprise AI / Other AI app coverage, **enable pay-as-you-go billing** before scoping a policy to those locations.
+- For Microsoft Copilot experiences beyond Microsoft 365 Copilot data, Enterprise AI apps, or Other AI apps coverage, **enable pay-as-you-go billing** before scoping a policy to those locations where Microsoft Learn requires it.
 
 !!! warning "Records retention vs Policy Match Preservation"
     **Policy Match Preservation** retains a copy of matched content for review while the policy is in place. As of June 1, 2025 the options are 1 month / 6 months / 1 year / 7 years (default 1 year). It is **not** the records retention mechanism for SEC 17a-4(b)(4) / FINRA 4511 — durable books-and-records retention is met via Exchange Online retention, Teams retention, and records management (see Control 1.9). Set Policy Match Preservation per supervisory needs and document records retention separately.
@@ -103,8 +103,8 @@ Verify per tenant before assuming a feature is at parity. Communication Complian
 | Capability | Commercial | GCC | GCC High | DoD |
 |------------|------------|-----|----------|-----|
 | Communication Compliance core (Exchange / Teams / Viva Engage) | GA | GA | GA | GA |
-| Microsoft 365 Copilot / Copilot Chat detection template | GA | Verify staged availability | Verify staged availability | Verify staged availability |
-| Enterprise / Other AI apps coverage (PAYG required) | Verify staged availability | Verify | Verify | Verify |
+| Detect Microsoft Copilot interactions template | GA | Verify staged availability | Verify staged availability | Verify staged availability |
+| Microsoft Copilot experiences / Enterprise AI apps / Other AI apps coverage (PAYG where required) | Verify staged availability | Verify | Verify | Verify |
 | Inappropriate content (Hate / Violence / Sexual / Self-harm) classifiers | GA | GA | Verify model parity | Verify model parity |
 | OCR for images | GA (PAYG) | Verify | Verify | Verify |
 | Administrative Units (preview / GA per Learn) | Per Learn | Per Learn | Per Learn | Per Learn |
@@ -125,7 +125,7 @@ Verify per tenant before assuming a feature is at parity. Communication Complian
 |------|-------------|-----------|
 | **Zone 1** (Personal) | Baseline templates (Inappropriate text + Inappropriate content); weekly sampling at template default | Minimal regulatory exposure |
 | **Zone 2** (Team) | Add Regulatory compliance template; daily review cadence; documented compensating-control plan if any policy is paused | Shared accountability |
-| **Zone 3** (Enterprise) | Add Copilot interactions template; review percentage tuned for FINRA-supervised populations (often 100%); pseudonymization opt-out audited; admin-unit scoping for reviewers | Maximum regulatory protection |
+| **Zone 3** (Enterprise) | Add **Detect Microsoft Copilot interactions** template; review percentage tuned for FINRA-supervised populations (often 100%); pseudonymization opt-out audited; admin-unit scoping for reviewers | Maximum regulatory protection |
 
 ---
 
@@ -181,7 +181,7 @@ Confirm control effectiveness by verifying:
 7. **Audit pipeline** — `Search-UnifiedAuditLog` (paged with `-SessionId` + `-SessionCommand ReturnLargeSet`) returns rows for `SupervisionRuleMatch`, `SupervisionPolicyCreated/Updated/Deleted`, and `SupervisoryReviewTag` operations within the test window
 8. **Policy Match Preservation** — explicit setting per policy is documented (not assumed default); separate records retention is in place per Control 1.9
 9. **Admin units / scoping** — reviewer/investigator permissions are scoped per region or business unit using administrative units where applicable
-10. **PAYG billing enabled** for any policy that includes Enterprise / Other AI apps locations
+10. **PAYG billing enabled** for any policy location where Microsoft Learn requires it, including Enterprise AI apps, Other AI apps, and non-Microsoft 365 AI data in Microsoft Copilot experiences
 11. **Sovereign cloud parity** — for GCC / GCC High / DoD tenants, capability gaps are recorded as compensating-control notes rather than asserted as functioning
 
 ---
@@ -210,6 +210,7 @@ The FINRA 2026 Annual Regulatory Oversight Report emphasizes that firms must con
 - [Microsoft Learn: Communication Compliance Overview](https://learn.microsoft.com/en-us/purview/communication-compliance)
 - [Microsoft Learn: Plan for Communication Compliance](https://learn.microsoft.com/en-us/purview/communication-compliance-plan)
 - [Microsoft Learn: Configure Communication Compliance](https://learn.microsoft.com/en-us/purview/communication-compliance-configure)
+- [Microsoft Learn: Configure Communication Compliance for Microsoft Copilot interactions](https://learn.microsoft.com/en-us/purview/communication-compliance-copilot)
 - [Microsoft Learn: Create Communication Compliance Policies](https://learn.microsoft.com/en-us/purview/communication-compliance-policies)
 - [Microsoft Learn: Communication Compliance Channels](https://learn.microsoft.com/en-us/purview/communication-compliance-channels)
 - [Microsoft Learn: Investigate and Remediate Alerts](https://learn.microsoft.com/en-us/purview/communication-compliance-investigate-remediate)
@@ -226,4 +227,4 @@ The FINRA 2026 Annual Regulatory Oversight Report emphasizes that firms must con
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md
+++ b/docs/controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md
@@ -252,17 +252,17 @@ https://www.federalreserve.gov/*         # Federal Reserve data
 ### DLP for Microsoft 365 Copilot and Copilot Chat
 
 !!! info "Rollout status"
-    The **Microsoft 365 Copilot and Copilot Chat** DLP location is generally available for the **block-by-label** action. The **block-by-SIT-on-prompts** capability is documented by Microsoft Learn as **preview** as of this revision. Verify your tenant's current rollout status against the [Microsoft 365 Roadmap](https://www.microsoft.com/en-us/microsoft-365/roadmap) and Message Center before relying on either as a sole Zone 3 control.
+    The **Microsoft 365 Copilot and Copilot Chat** DLP location is generally available for the **sensitivity-label file and email processing restriction**. Microsoft Learn documents both the **SIT prompt processing restriction** and the **SIT external web-search restriction** as **preview** as of this revision. Verify your tenant's current rollout status against the [Microsoft 365 Roadmap](https://www.microsoft.com/en-us/microsoft-365/roadmap) and Message Center before relying on any single action as a sole Zone 3 control.
 
-A DLP capability allows organizations to (a) block sensitive information types (SITs) from being processed in Microsoft 365 Copilot and Copilot Chat **prompts** (preview), and (b) prevent Copilot from processing **labeled files and emails** as grounding content (GA). This is distinct from DLP for files at rest or email in transit.
+A DLP capability allows organizations to (a) restrict Microsoft 365 Copilot and Copilot Chat from processing **prompts** that contain sensitive information types (SITs) (preview), (b) restrict **external web search** when prompts contain SITs (preview), and (c) prevent Copilot from processing **labeled files and emails** as grounding content (GA). This is distinct from DLP for files at rest or email in transit.
 
-| Aspect | DLP for Copilot prompts (SITs) | Block by sensitivity label | Files / Email DLP |
-|--------|-------------------------------|----------------------------|-------------------|
-| **Status** | Preview | GA | GA |
-| **Scope** | User prompts to M365 Copilot and Copilot Chat | Labeled SharePoint Online and OneDrive files; Exchange emails sent on or after January 1, 2025 | Documents, emails, messages |
-| **License** | Available for tenants with access to Microsoft 365 Copilot and Copilot Chat — verify per-user entitlement against the M365 Service Descriptions | Verify per-user entitlement against the [Purview DLP licensing guidance](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance) | Microsoft Purview DLP entitlements (typically E5 / E5 Compliance / Purview Suite) |
-| **Location in policy** | "Microsoft 365 Copilot and Copilot Chat" — **Custom template only** | "Microsoft 365 Copilot and Copilot Chat" — **Custom template only** | Standard file/email locations |
-| **Action** | Restrict Copilot from processing prompts | Prevent Copilot from processing/summarizing labeled content | Block, notify, or warn |
+| Aspect | DLP for Copilot prompts (SITs) | DLP for Copilot external web search (SITs) | Block by sensitivity label | Files / Email DLP |
+|--------|-------------------------------|--------------------------------------------|----------------------------|-------------------|
+| **Status** | Preview | Preview | GA | GA |
+| **Scope** | User prompts to M365 Copilot and Copilot Chat | External web search as a grounding source for prompts containing SITs | Labeled SharePoint Online and OneDrive files; Exchange emails sent on or after January 1, 2025 | Documents, emails, messages |
+| **License** | Available for tenants with access to Microsoft 365 Copilot and Copilot Chat — verify per-user entitlement against the M365 Service Descriptions | Available for tenants with access to Microsoft 365 Copilot and Copilot Chat — verify per-user entitlement against the M365 Service Descriptions | Verify per-user entitlement against the [Purview DLP licensing guidance](https://learn.microsoft.com/en-us/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance) | Microsoft Purview DLP entitlements (typically E5 / E5 Compliance / Purview Suite) |
+| **Location in policy** | "Microsoft 365 Copilot and Copilot Chat" — **Custom template only** | "Microsoft 365 Copilot and Copilot Chat" — **Custom template only** | "Microsoft 365 Copilot and Copilot Chat" — **Custom template only** | Standard file/email locations |
+| **Action** | Prevent Copilot from processing content > Processing prompts | Prevent Copilot from processing content > Performing Web Searches | Prevent Copilot from processing/summarizing labeled content | Block, notify, or warn |
 
 !!! danger "Same-rule restriction (read before authoring rules)"
     For the **Microsoft 365 Copilot and Copilot Chat** DLP location, you **cannot** combine *Content contains sensitive info types* and *Content contains sensitivity labels* in the **same rule**. Create **separate rules in the same policy** — Rule A with the SIT condition, Rule B with the sensitivity-label condition. Saving a single rule with both conditions will be rejected by the Purview UI. Source: [Learn — DLP for Microsoft 365 Copilot location](https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-learn-about) (Important callout).
@@ -282,14 +282,15 @@ A DLP capability allows organizations to (a) block sensitive information types (
     - The Copilot DLP location does **not support administrative units**. A Restricted Administrative Unit-scoped admin cannot create or edit a policy that includes this location — use a tenant-scoped role.
     - DLP policy changes for the Copilot location can take **up to 4 hours** to fully propagate. Plan validation windows accordingly and treat earlier "no match" results as inconclusive, not as failure.
 
-**FSI use case:** Help prevent users from pasting customer account numbers, SSNs, or other regulated PII directly into Copilot prompts (SIT rule), and help prevent Copilot from processing labeled customer files into responses (label rule), even when the source document allows the user direct access.
+**FSI use case:** Help restrict users from pasting customer account numbers, SSNs, or other regulated PII directly into Copilot prompts (SIT prompt rule), restrict external web search as a grounding source when a prompt contains regulated PII (SIT web-search rule), and help prevent Copilot from processing labeled customer files into responses (label rule), even when the source document allows the user direct access.
 
 ---
 
 ## Key Configuration Points
 
 - Build the **Microsoft 365 Copilot and Copilot Chat** DLP policy from the **Custom** template in Purview (Standard templates do not expose this location)
-- Split conditions into **separate rules in the same policy**: Rule A for SITs, Rule B for sensitivity labels (the same-rule restriction applies to the Copilot location)
+- Split SIT and sensitivity-label conditions into **separate rules in the same policy** (the same-rule restriction applies to the Copilot location)
+- Document whether the SIT prompt-processing restriction and SIT external web-search restriction are configured as separate rules or distinct actions, then validate each behavior independently
 - Configure Power Platform **data policies** in Power Platform Admin Center for Copilot Studio agents and connector classification (this is a separate product from Purview DLP)
 - Create sensitivity label taxonomy (Public, Internal, Confidential, Highly Confidential) and **publish** label policies to the appropriate users and groups (publishing is required — labels do not appear to users until a label policy is published)
 - Implement SITs for financial data (SSN, ABA routing, account numbers) per Control 1.13 and document the confidence threshold and proximity settings used in each rule
@@ -364,8 +365,9 @@ DLP, sensitivity labels, and the connector classification used in this control h
 
 | Capability | Commercial | GCC | GCC High | DoD |
 |------------|------------|-----|----------|-----|
-| Purview DLP for Microsoft 365 Copilot and Copilot Chat (block by label) | GA | Verify Roadmap / MC | Verify — staged | Verify — staged |
-| Purview DLP for Microsoft 365 Copilot prompts (SIT, preview) | Preview | Verify | Verify | Verify |
+| Purview DLP for Microsoft 365 Copilot and Copilot Chat (sensitivity-label processing restriction) | GA | Verify Roadmap / MC | Verify — staged | Verify — staged |
+| Purview DLP for Microsoft 365 Copilot prompts (SIT processing restriction, preview) | Preview | Verify | Verify | Verify |
+| Purview DLP for Microsoft 365 Copilot external web search (SIT restriction, preview) | Preview | Verify | Verify | Verify |
 | Power Platform data policies | GA | GA | GA | GA |
 | Connector endpoint filtering | Preview | Verify | Verify | Verify |
 | Sensitivity labels (file / email) | GA | GA | GA | GA |
@@ -454,11 +456,11 @@ Custom MCP servers in Copilot Studio are subject to Power Platform data policies
 Confirm control effectiveness by verifying:
 
 1. The Microsoft 365 Copilot and Copilot Chat DLP policy was created from the **Custom** template (capture screenshot evidence of the template selection)
-2. The policy contains **separate rules** for SIT-based and sensitivity-label-based conditions (export `Get-DlpComplianceRule` and confirm two distinct rule objects)
+2. The policy documents separate handling for SIT prompt processing, SIT external web-search restriction, and sensitivity-label conditions (export `Get-DlpComplianceRule` and confirm the rule/action mapping; SIT and sensitivity-label conditions are not combined in one rule)
 3. Sensitivity labels exist, and at least one **label policy is published** to the in-scope users or groups (`Get-LabelPolicy` returns the expected policy with `Mode = Enable`)
 4. Auto-labeling policies, where used, are scoped to **SharePoint Online**, **OneDrive for Business**, and **Exchange Online** locations only
 5. SITs referenced by the policy are validated and detecting sensitive content per Control 1.13 (record the confidence threshold and proximity settings used)
-6. A deterministic activation test (named test user, known prompt, UTC-stamped) triggers the expected DLP action **after** the propagation window (≥ 4 hours for the Copilot location) and produces a record in Purview Audit
+6. Deterministic activation tests (named test user, known prompt, UTC-stamped) confirm the prompt-processing restriction, external web-search restriction, and label-based content-processing behavior separately **after** the propagation window (≥ 4 hours for the Copilot location) and produce records in Purview Audit
 7. Power Platform data policies classify all in-scope AI-related connectors and the classification is reflected in `Get-DlpPolicy` output
 8. If custom MCP servers are enabled, server-level and tool-level DLP behavior is validated and documented before production use
 9. If Adaptive Protection is in use, the IRM dependency is documented, baseline window is complete, and behavior is validated in a non-production tenant first; for GCC High / DoD, the parity gap is recorded as a compensating-control note rather than an assertion of behavior
@@ -488,4 +490,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/controls/pillar-1-security/1.6-microsoft-purview-dspm-for-ai.md
+++ b/docs/controls/pillar-1-security/1.6-microsoft-purview-dspm-for-ai.md
@@ -15,7 +15,7 @@
     DSPM for AI is GA in **Commercial** and **GCC** (`https://purview.microsoft.com`) and in **GCC High** and **DoD** (`https://purview.microsoft.us`) as of May 2025. Feature parity is partial: the **new unified DSPM** (GA May 2026, Commercial / GCC) is commercial-first and has not yet been announced for sovereign clouds; partner solutions for non-Microsoft data sources and the Data Security Posture Agent remain in preview. **Insider Risk Management** dependencies (Adaptive Protection, the IRM-backed one-click templates) are not available in US Government clouds at parity — verify against your tenant's cloud before relying on those capabilities.
 
 !!! note "Agent 365 Architecture Update"
-    Agent 365 integrates with Microsoft Purview DSPM to provide security posture visibility across all agent types, extending current DSPM coverage beyond individual platforms. See [Unified Agent Governance](../../framework/agent-identity-architecture.md) for security posture integration details.
+    Current Microsoft Learn directs Agent 365 observability to **Data Security Posture Management > AI observability**. Agent instances are automatically enabled for audit, sensitive-data detection with data classification, and Compliance Manager AI-regulation assessments; for other Purview capabilities, include the agent instance in policies as you would a user where supported. Do not confuse the current DSPM experience with **Data Security Posture Management (classic)**, which Microsoft states doesn't support Agent 365.
 
 ## Objective
 
@@ -222,8 +222,8 @@ The DSPM for AI **Policies** pane surfaces named one-click templates that land i
 
 ## Key Configuration Points
 
-!!! note "DSPM for AI Naming Update (2025)"
-    The original DSPM for AI capability is now labeled **"DSPM for AI (classic)"** in the Microsoft Purview portal. A new unified **Data Security Posture Management** experience is in preview, providing expanded capabilities including AI observability, data security objectives, posture reports, and the Purview Posture Agent. This control currently documents DSPM for AI (classic) capabilities. The framework will incorporate the unified DSPM experience as it reaches general availability.
+!!! note "DSPM for AI Naming Update (2025-2026)"
+    The original DSPM for AI capability is now labeled **"DSPM for AI (classic)"** in the Microsoft Purview portal. The unified **Data Security Posture Management** experience reached general availability for Commercial / GCC in May 2026 per MC1191257, while partner solutions for non-Microsoft data sources and the Data Security Posture Agent remain in preview. This control documents classic DSPM for AI tasks and the current DSPM entry points Microsoft Learn directs administrators to use for Agent 365.
 
 - Complete all 4 Get Started steps in DSPM for AI (classic): Audit, Browser Extension, Device Onboarding, Extended Insights
 - Review and implement high-priority recommendations
@@ -236,6 +236,7 @@ The DSPM for AI **Policies** pane surfaces named one-click templates that land i
 - Run custom assessments for high-priority sites beyond top 100
 - Enable Insider Risk Management for Zone 2-3 agents
 - Export Activity explorer data for compliance evidence
+- For Agent 365 instances, start in current **DSPM > AI observability**, review active agent instances and risk signals, and include agent instances in other Purview policies as user-like principals where supported
 - Plan migration from classic DSPM for AI to the new unified DSPM experience (GA May 2026, Commercial / GCC)
 
 ### e-Discovery and Examination Readiness
@@ -324,6 +325,7 @@ Confirm control effectiveness by verifying (deterministic — generate a known i
 - [Microsoft Learn: DSPM for AI Considerations](https://learn.microsoft.com/en-us/purview/dspm-for-ai-considerations)
 - [Microsoft Learn: DSPM for AI Permissions](https://learn.microsoft.com/en-us/purview/ai-microsoft-purview-permissions)
 - [Microsoft Learn: Unified DSPM Learn About](https://learn.microsoft.com/en-us/purview/data-security-posture-management-learn-about)
+- [Microsoft Learn: Microsoft Purview protections for Agent 365](https://learn.microsoft.com/en-us/purview/ai-agent-365)
 - [Microsoft Learn: DLP for Microsoft 365 Copilot location](https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-learn-about)
 - [Microsoft Learn: Activity Explorer](https://learn.microsoft.com/en-us/purview/data-classification-activity-explorer)
 - [Microsoft Learn: Audit log activities — Copilot](https://learn.microsoft.com/en-us/purview/audit-copilot)
@@ -336,49 +338,34 @@ Confirm control effectiveness by verifying (deterministic — generate a known i
 
 - [Microsoft Learn: Agent Deployment Checklist](https://learn.microsoft.com/en-us/microsoft-365/copilot/agent-essentials/m365-agents-checklist) - Category 7 data security requirements align with DSPM policies
 
-### Agent 365 Blueprint Data Governance (Preview)
+### Agent 365 DSPM Observability
 
-> **Note:** The following guidance applies to Blueprint-registered agents using the Agent 365 SDK.
+> **Microsoft Learn anchor:** [Microsoft Purview data security and compliance protections for Agent 365](https://learn.microsoft.com/en-us/purview/ai-agent-365) identifies current **Data Security Posture Management > AI observability** as the starting point for Agent 365 visibility. Do not confuse this current DSPM experience with **Data Security Posture Management (classic)**, which Microsoft states doesn't support Agent 365.
 
-DSPM for AI provides enhanced visibility into Agent 365 Blueprint-registered agents through integration with the Observability SDK. This enables comprehensive data governance across the agent lifecycle.
+When an Agent 365 agent instance is created, Microsoft Learn states it is automatically enabled for audit, sensitive-data detection with data classification, and Compliance Manager AI-regulation assessments. For other Purview capabilities, include the agent instance in policies as you would a user where the capability supports agent instances.
 
-**Blueprint → DSPM Data Flow:**
-
-```
-Agent 365 SDK → Observability SDK → Application Insights → DSPM Activity Explorer
-     ↓                                      ↓
-Blueprint Metadata              Prompt/Response Telemetry
-(data sources, permissions)     (sensitive data detection)
-```
-
-| DSPM Capability | Agent 365 Integration | FSI Benefit |
-|-----------------|----------------------|-------------|
-| **Activity Explorer** | Ingests Agent 365 telemetry via Observability SDK | Complete audit trail of agent interactions |
-| **Oversharing Assessment** | Evaluates Blueprint-declared data sources | Identifies excessive data access at registration |
-| **Sensitive Data Detection** | Analyzes SDK-captured prompts/responses | Detects NPI exposure in agent conversations |
-| **Policy Recommendations** | Includes Agent 365-specific guidance | Tailored DLP/IRM recommendations for agents |
-
-**Blueprint-Specific Data Classification Requirements:**
-
-1. **Data Source Declaration** - Blueprint registration requires explicit declaration of data sources
-2. **Permission Scope Validation** - DSPM evaluates whether declared permissions match data sensitivity
-3. **Runtime Monitoring** - Observability SDK telemetry feeds DSPM for continuous data access monitoring
+| Purview capability | Current Agent 365 model | FSI benefit |
+|--------------------|-------------------------|-------------|
+| **DSPM > AI observability** | Reviews active agent instances, owner and agent user ID details, risk level from Insider Risk Management, risky activities, and remediation recommendations | Establishes a current agent-risk review queue for supervisory evidence |
+| **Audit** | Agent instances are automatically enabled for audit; search the audit log for Agent 365 activities | Provides evidence for forensic review and examination response |
+| **Data classification** | Sensitive information types and classifiers can detect sensitive data in prompts and responses | Supports NPI and confidential-data monitoring |
+| **Policy targeting** | Include agent instances in DLP, Insider Risk Management, eDiscovery, and other policies as user-like principals where supported | Applies existing Purview controls to agent identities with documented scope |
 
 **Configuration for Agent 365:**
 
-1. Enable DSPM for AI extended insights (Get Started > Extended Insights)
-2. Configure Application Insights integration for Agent 365 SDK agents
-3. Create Activity Explorer filter for `ApplicationId` matching Agent 365 workloads
-4. Run oversharing assessment including Blueprint-registered agent data sources
-5. Review recommendations for Agent 365-specific data protection policies
+1. Open the Microsoft Purview portal and navigate to **DSPM > AI observability**.
+2. Review active agent instances from the last 30 days, including owner, agent user ID, Entra-enabled status, risk level, and risky activities.
+3. For Purview capabilities outside automatic audit, data classification, and Compliance Manager coverage, include agent instances in policies as user-like principals where Microsoft Learn documents support.
+4. Validate audit evidence by searching for Agent 365 activities in the unified audit log.
+5. Document unsupported capabilities, sovereign-cloud gaps, and any policy-targeting exceptions before approving Zone 3 promotion.
 
 **Zone-Specific DSPM Requirements for Agent 365:**
 
 | Zone | Requirement |
 |------|-------------|
-| **Zone 1** | DSPM monitoring optional for personal agents |
-| **Zone 2** | DSPM Activity Explorer review weekly; Blueprint data source validation |
-| **Zone 3** | Daily DSPM review required; Oversharing assessment before Blueprint promotion |
+| **Zone 1** | Confirm whether Agent 365 instances are present; document if no Agent 365 usage exists |
+| **Zone 2** | Review **DSPM > AI observability** weekly and include active agent instances in applicable Purview policies where supported |
+| **Zone 3** | Review **DSPM > AI observability** at the supervisory cadence, verify audit-log evidence, and document policy targeting or exception rationale before promotion |
 
 For DLP policy configuration specific to Agent 365, see [Control 1.5 - DLP and Sensitivity Labels](1.5-data-loss-prevention-dlp-and-sensitivity-labels.md).
 

--- a/docs/controls/pillar-1-security/1.9-data-retention-and-deletion-policies.md
+++ b/docs/controls/pillar-1-security/1.9-data-retention-and-deletion-policies.md
@@ -47,7 +47,7 @@ This control combines four Microsoft Purview surfaces and one Power Platform sur
 | Capability | Microsoft surface | Description |
 |------------|-------------------|-------------|
 | Retention labels | Purview > Solutions > Records Management & Data Lifecycle Management | Item-level retention applied by classification (manual, auto-apply, or default for a SharePoint library). Labels can mark items as **records** (locked retention) or **regulatory records** (immutable — cannot be unmarked, retention cannot be reduced). |
-| Retention policies | Purview > Solutions > Data Lifecycle Management > Policies | Container-level retention scoped by location (Exchange, SharePoint, OneDrive, Microsoft 365 Groups, Teams chats/channels/Copilot, Viva Engage, Microsoft 365 Copilot and AI experiences, Enterprise AI Apps, Other AI Apps). Adaptive scopes are recommended over static for dynamic targeting. |
+| Retention policies | Purview > Solutions > Data Lifecycle Management > Policies | Container-level retention scoped by location (Exchange, SharePoint, OneDrive, Microsoft 365 Groups, Teams chats/channels, Viva Engage, Microsoft Copilot experiences, Enterprise AI apps, Other AI apps). New Copilot / AI-app retention policies are separate from Teams chats; older policies might still show legacy combined naming. Adaptive scopes are recommended over static for dynamic targeting. |
 | Preservation Lock | `Set-RetentionCompliancePolicy -RetentionComplianceLockType Lock` (Security & Compliance PowerShell) | Irreversibly locks a retention policy: no admin (including Global Admin) can disable, delete, or shorten it. Only **adding** locations or **extending** retention is permitted. This is the surface Microsoft positions for SEC 17a-4(f)-aligned immutability. |
 | eDiscovery / Litigation hold | Purview > Solutions > eDiscovery (Standard / Premium); Exchange In-Place Hold (legacy) | Preserves content in scope of a case beyond retention rules. Overrides retention disposition for the duration of the hold. |
 | Disposition review | Purview > Solutions > Records Management > Disposition | Multi-stage reviewer workflow at retention end (supports SharePoint, OneDrive, Exchange items with retention-label-driven retention). Produces an audit trail of disposition decisions. |
@@ -64,11 +64,11 @@ This control combines four Microsoft Purview surfaces and one Power Platform sur
     - Agent transcripts that evidence or generate an 17a-3 record: **6 years**, first 2 readily accessible (17a-4(b)(2)–(3), FINRA 4511)
     - Agent configuration and version history: **6 years** (mirrors books-and-records exposure)
     - Agent audit metadata (sign-ins, action audit, deletion events): **7–10 years** (covers SOX §802 audit-work-paper window and overlapping multi-regulator inquiries)
-- Publish labels to the full set of in-scope locations: **Exchange email**, **SharePoint sites**, **OneDrive accounts**, **Microsoft 365 Groups**, **Teams channel/private/standard messages**, **Teams chats and Copilot interactions**, **Viva Engage communities**, and **Loop workspaces**.
-- Create retention policies for AI interaction surfaces using the three Purview AI-specific locations:
-    - **Microsoft 365 Copilot and AI experiences** — covers M365 Copilot in Word/Excel/Outlook/Teams, Business Chat, and Copilot Studio agent interactions surfaced through M365 Copilot
-    - **Enterprise AI Apps** — covers enterprise-managed AI applications (Microsoft Foundry, Entra-registered AI apps, ChatGPT Enterprise where the connector emits to Microsoft 365)
-    - **Other AI Apps** — covers third-party / unmanaged AI applications captured via the AI App PAYG meter (see Control 1.7)
+- Publish labels to the full set of in-scope locations: **Exchange email**, **SharePoint sites**, **OneDrive accounts**, **Microsoft 365 Groups**, **Teams channel/private/standard messages**, **Viva Engage communities**, and **Loop workspaces**. Use retention policies—not Teams label scopes—to govern Copilot and AI-app interactions in the AI-specific locations below.
+- Create retention policies for AI interaction surfaces using the current Purview AI-specific locations. New Copilot / AI-app retention policies are separate from **Teams chats**; older policies might still display legacy combined naming such as **Teams chats and Copilot interactions**.
+    - **Microsoft Copilot experiences** — covers Microsoft 365 Copilot, Security Copilot, Copilot in Fabric, and Copilot Studio
+    - **Enterprise AI apps** — covers Entra-registered AI apps, ChatGPT Enterprise, and Microsoft Foundry
+    - **Other AI apps** — covers ChatGPT, Google Gemini, Microsoft Copilot consumer, and DeepSeek where captured through supported collection or retention policies
 - Configure **Dataverse long-term retention** in Power Platform Admin Center for Copilot Studio environments to archive agent transcripts beyond the active environment retention window.
 - **Apply Preservation Lock** (`Set-RetentionCompliancePolicy -RetentionComplianceLockType Lock`) on every Zone 3 retention policy after a CAB-approved change window. This is irreversible — see "Locked-policy gotchas" in the PowerShell playbook.
 - Use **adaptive scopes** (driven by Entra group, department, country, or custom attribute) rather than static scopes for any policy that targets a population that changes over time.
@@ -153,8 +153,8 @@ Confirm control effectiveness by verifying:
 
 1. Written retention schedule exists, is signed off by counsel, and maps each record type to a regulatory citation (17a-4(b)(2), 17a-4(b)(4), FINRA 4511, SOX §802, CFTC 1.31, GLBA 501(b), IRS).
 2. All FSI retention labels exist in Purview with the planned duration, action, and (for Zone 3 record-classified content) `IsRecordLabel = True` and/or `Regulatory = True`.
-3. Label policies are published to all required locations (Exchange, SharePoint, OneDrive, Microsoft 365 Groups, Teams chats/channels/Copilot, Viva Engage); distribution status reads **Success** in the portal.
-4. Retention policies for **Microsoft 365 Copilot and AI experiences**, **Enterprise AI Apps**, and **Other AI Apps** exist and are distributed.
+3. Label policies are published to all required locations (Exchange, SharePoint, OneDrive, Microsoft 365 Groups, Teams chats/channels, Viva Engage); distribution status reads **Success** in the portal.
+4. Retention policies for **Microsoft Copilot experiences**, **Enterprise AI apps**, and **Other AI apps** exist and are distributed separately from Teams chat policies; any older legacy combined naming is mapped in the evidence binder.
 5. Preservation Lock is applied to every Zone 3 retention policy (`RetentionComplianceLockType = Lock`) and the lock is verified out-of-band with PowerShell evidence.
 6. Test deletion of labeled / scoped content is **blocked** during the retention period, and the block reason is logged in the unified audit log.
 7. Disposition-review workflow triggers at retention end for label-driven content and produces a reviewer audit trail.
@@ -173,7 +173,7 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Records management — Mark items as records / regulatory records](https://learn.microsoft.com/en-us/purview/records-management)
 - [Microsoft Learn: Use Preservation Lock to restrict changes to retention policies and retention label policies](https://learn.microsoft.com/en-us/purview/retention-preservation-lock)
 - [Microsoft Learn: Disposition of content](https://learn.microsoft.com/en-us/purview/disposition)
-- [Microsoft Learn: Learn about retention for Microsoft 365 Copilot and AI experiences](https://learn.microsoft.com/en-us/purview/retention-policies-copilot)
+- [Microsoft Learn: Learn about retention for Microsoft Copilot and AI apps](https://learn.microsoft.com/en-us/purview/retention-policies-copilot)
 - [Microsoft Learn: Create eDiscovery holds](https://learn.microsoft.com/en-us/purview/ediscovery-create-holds)
 - [Microsoft Learn: Regulatory requirements for information governance (incl. SEC 17a-4)](https://learn.microsoft.com/en-us/purview/retention-regulatory-requirements)
 - [Microsoft Learn: Manage long-term retention for Dataverse](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/data-retention-overview)
@@ -182,4 +182,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/images/1.6/EXPECTED.md
+++ b/docs/images/1.6/EXPECTED.md
@@ -10,10 +10,12 @@
 | `04-purview-dspm-recommendations.png` | Purview | DSPM for AI → Recommendations | Security recommendations |
 | `05-purview-dspm-reports.png` | Purview | DSPM for AI → Reports | AI usage and risk reports |
 | `06-purview-dspm-settings.png` | Purview | DSPM for AI → Settings | Configuration options |
+| `07-purview-dspm-ai-observability.png` | Purview | DSPM → AI observability | Agent 365 active agent instances and risk detail |
 
 ## Verification Focus
 
 - DSPM discovers Copilot Studio agents
+- DSPM → AI observability shows Agent 365 instances where applicable
 - Policies cover AI-specific data risks
 - Recommendations align with FSI requirements
 - Capture from pre-production environment when possible
@@ -31,3 +33,4 @@ Organize screenshots in this directory as:
 - `1.6-04-purview-dspm-recommendations.png` — Security recommendations
 - `1.6-05-purview-dspm-reports.png` — AI usage and risk reports
 - `1.6-06-purview-dspm-settings.png` — Configuration options
+- `1.6-07-purview-dspm-ai-observability.png` — Agent 365 active agent instances and risk detail


### PR DESCRIPTION
## Summary

Wave 6a substantive Microsoft Learn drift fixes for Pillar 1 controls:

- Control 1.5: adds the SIT-based external web-search restriction path to Copilot DLP and separates verification from prompt blocking and label-based processing.
- Control 1.6: refreshes Agent 365 guidance around current DSPM > AI observability, automatic audit/data-classification/Compliance Manager coverage, and user-like policy targeting.
- Control 1.9: updates Copilot retention location terminology to Microsoft Copilot experiences / Enterprise AI apps / Other AI apps and clarifies separation from Teams chats.
- Control 1.10: updates the Communication Compliance template name to Detect Microsoft Copilot interactions and refreshes generative-AI policy location wording.

## Microsoft Learn sources

- https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-learn-about
- https://learn.microsoft.com/en-us/purview/ai-agent-365
- https://learn.microsoft.com/en-us/purview/retention-policies-copilot
- https://learn.microsoft.com/en-us/purview/communication-compliance-copilot
- https://learn.microsoft.com/en-us/purview/communication-compliance-policies

## Notes

- Stacks on Wave 1 (#224) / branch `wave-1-truthfulness-sweep`; PR target remains `main`.
- Updated `docs/images/1.6/EXPECTED.md` because Control 1.6 now cites the current DSPM > AI observability portal path for Agent 365.

## Validation

- `mkdocs build --strict`
- `python scripts/verify_controls.py`
- `python scripts/check_manifest_doc_drift.py --check`
- `python scripts/generate_coverage_matrix.py --check`
- `python scripts/generate_coverage_matrix.py --type frontier --check`
- `python scripts/verify_language_rules.py`
- `python scripts/verify_excel_templates.py`
- `ruff check assessment scripts`

Closes #226 #227 #228 #229