### PR TITLE
docs(pages): fix stale Pages homepage + solutions diagram counts (35->36 solutions, v1.3 pillar baseline->v1.6.2)

### DIFF
--- a/docs/framework/solutions-integration.md
+++ b/docs/framework/solutions-integration.md
@@ -12,13 +12,13 @@ The FSI Agent Governance Framework defines **what** controls organizations shoul
 flowchart TB
     subgraph Framework["FSI-AgentGov (Framework)"]
         direction TB
-        P1[Pillar 1: Security<br/>28 Controls]
-        P2[Pillar 2: Management<br/>24 Controls]
-        P3[Pillar 3: Reporting<br/>12 Controls]
-        P4[Pillar 4: SharePoint<br/>7 Controls]
+        P1[Pillar 1: Security<br/>29 Controls]
+        P2[Pillar 2: Management<br/>26 Controls]
+        P3[Pillar 3: Reporting<br/>14 Controls]
+        P4[Pillar 4: SharePoint<br/>9 Controls]
     end
 
-    subgraph Solutions["FSI-AgentGov-Solutions (19 of 35 Solutions Shown)"]
+    subgraph Solutions["FSI-AgentGov-Solutions (19 of 36 Solutions Shown)"]
         direction TB
         ELM[Environment Lifecycle<br/>Management]
         MCM[Message Center<br/>Monitor]

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hide:
 # AI Agent Governance for **Financial Services**
 
 Govern Microsoft 365 AI agents with confidence — from policy to production.
-78 controls, 35 live companion solutions,
+78 controls, 36 live companion solutions,
 implementation playbooks, and regulatory mappings for Copilot Studio, Agent Builder, and custom
 agent deployments.
 


### PR DESCRIPTION
## Context

During Phase G live-site verification of the GitHub Pages deployment, six instances of stale current-state counts were found in customer-facing pages that escaped Wave 1's truthfulness sweep regex patterns.

## Changes

**`docs/index.md` (1 line)** - hero metrics strip on the Pages homepage:
- L12: `35 live companion solutions` -> `36`  (matches authoritative `docs/reference/solutions-index.md` which lists 36 in three places: L9, L31, L33)

**`docs/framework/solutions-integration.md` (5 lines)** - Mermaid diagram on the framework integration page:
- L15: `28 Controls` -> `29 Controls` (Pillar 1 Security)
- L16: `24 Controls` -> `26 Controls` (Pillar 2 Management)
- L17: `12 Controls` -> `14 Controls` (Pillar 3 Reporting)
- L18: `7 Controls` -> `9 Controls` (Pillar 4 SharePoint)
- L21: `19 of 35 Solutions Shown` -> `19 of 36 Solutions Shown`

Pillar totals were at the v1.3 baseline (28+24+12+7 = 71). Current canonical totals are 29+26+14+9 = 78.

## Why Wave 1 missed these

The pillar counts were embedded in Mermaid HTML-break syntax ``<br/>N Controls`` rather than the conventional `28 controls` prose Wave 1 scanned for. The hero-strip prose string used `live companion solutions` rather than `companion solutions` or just `solutions` plus a count.

## What is NOT changed

**`README.md` L22 `All 35 companion solutions are tagged`** is preserved as-is. Verified via `python scripts/generate_pattern_coverage.py --check` which reports exactly 35 tagged solutions - the 36th solution is in the live inventory but not yet tagged with `applicable_patterns`/`applicable_drivers`/`coe_function` frontmatter. The L22 statement remains factually accurate. Adding the 36th solution's tags is an FSI-AgentGov-Solutions concern, out of scope for this PR.

## Validation

- `mkdocs build --strict` ✅
- `verify_controls.py` ✅
- `verify_language_rules.py` ✅
- `check_manifest_doc_drift.py --check` ✅

## Scope

No version bump, no CHANGELOG entry. v1.6.2 in-scope current-state truthfulness fixes.