### PR TITLE
PR-B: Tier 0B regulatory hotfixes (SR 11-7 path A + N1 link fix + Toolkit verify)

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -9,7 +9,7 @@
 - **3 governance zones** (Personal Productivity, Team Collaboration, Enterprise Managed)
 - **3-layer documentation** (Framework → Controls → Playbooks)
 - **6 advanced implementations** (Platform Change Governance, Environment Lifecycle Management, Agent 365 Observability, etc.)
-- **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC 2011-12, Fed SR 11-7, CFTC 1.31
+- **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly Fed SR 11-7), CFTC 1.31
 - **Documentation:** MkDocs Material-based site published to GitHub Pages
 - **Audience:** M365 administrators in US financial services
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ FSI Agent Governance Framework v1.6.2 - A governance framework for Microsoft 365
 - **78 controls** across 4 pillars (Security, Management, Reporting, SharePoint)
 - **3 governance zones** (Personal Productivity, Team Collaboration, Enterprise Managed)
 - **3-layer documentation** (Framework → Controls → Playbooks)
-- **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC 2011-12, Fed SR 11-7, CFTC 1.31
+- **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly Fed SR 11-7), CFTC 1.31
 - **Documentation site:** Built with MkDocs Material, published to GitHub Pages
 
 ## Design Decisions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This file provides guidance for autonomous AI agents working on this repository.
 - **78 controls** across 4 pillars (Security, Management, Reporting, SharePoint)
 - **3 governance zones** (Personal Productivity, Team Collaboration, Enterprise Managed)
 - **3-layer documentation** (Framework → Controls → Playbooks)
-- **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC 2011-12, Fed SR 11-7, CFTC 1.31
+- **Target regulations:** FINRA 4511/3110/25-07, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly Fed SR 11-7), CFTC 1.31
 - **Audience:** M365 administrators in US financial services
 
 **Full context:** See `.github/copilot-instructions.md` for complete repository structure and design decisions.

--- a/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md
+++ b/docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md
@@ -1,25 +1,36 @@
-# Control 2.6: Model Risk Management (OCC 2011-12/SR 11-7)
+# Control 2.6: Model Risk Management (OCC Bulletin 2026-13 / SR 26-2 — formerly OCC 2011-12 / SR 11-7)
 
 **Control ID:** 2.6<br>
 **Pillar:** Management<br>
-**Regulatory Reference:** OCC Bulletin 2011-12 (Sound Practices for Model Risk Management), Federal Reserve SR 11-7 (Supervisory Guidance on Model Risk Management), FDIC FIL-22-2017 (FDIC adoption of OCC 2011-12), FFIEC IT Examination Handbook (Management; Information Security), FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), FINRA Regulatory Notice 25-07 (AI Tools — RFC, contextual only), SEC Rules 17a-3 / 17a-4 (Recordkeeping for model artifacts and validation evidence), SOX Sections 302 / 404 (Internal Controls over Financial Reporting), GLBA 501(b) (Safeguards Rule), NYDFS 23 NYCRR 500 (where AI agents touch covered customer information)<br>
+**Regulatory Reference:** OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) (Sound Practices for Model Risk Management), Federal Reserve SR 26-2 (formerly SR 11-7) (Supervisory Guidance on Model Risk Management), FDIC FIL-22-2017 (FDIC adoption of OCC Bulletin 2026-13 (formerly OCC 2011-12)), FFIEC IT Examination Handbook (Management; Information Security), FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), FINRA Regulatory Notice 25-07 (AI Tools — RFC, contextual only), SEC Rules 17a-3 / 17a-4 (Recordkeeping for model artifacts and validation evidence), SOX Sections 302 / 404 (Internal Controls over Financial Reporting), GLBA 501(b) (Safeguards Rule), NYDFS 23 NYCRR 500 (where AI agents touch covered customer information)<br>
 **Last UI Verified:** April 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---
 
+!!! warning "Regulatory update — SR 11-7 / OCC 2011-12 superseded April 17, 2026"
+    On **April 17, 2026**, the Federal Reserve, OCC, and FDIC jointly issued [Federal Reserve SR 26-2 — Revised Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) and [OCC Bulletin 2026-13 — Updated Interagency Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-13.html). These instruments **expressly supersede and rescind** SR letter 11-7 (April 4, 2011) and OCC Bulletin 2011-12 ("Sound Practices for Model Risk Management"), respectively, along with related items including SR 21-8 / OCC Bulletin 2021-19 (Interagency Statement on MRM for BSA/AML systems), the OCC's *"Model Risk Management"* booklet of the *Comptroller's Handbook*, and OCC Bulletin 1997-24 (Credit Scoring Models). The original `sr1107.htm` URL no longer resolves on the Federal Reserve site.
+
+    **What carried forward.** SR 26-2 / OCC 2026-13 retains the SR 11-7 conceptual framework — model definition, model inventory, independent validation, effective challenge, ongoing monitoring, outcomes analysis, three-lines-of-defense, vendor-model rigor — and tailors it to a risk-based approach calibrated to the firm's model risk profile and the size and complexity of its operations. Section / paragraph numbering may not match the prior letter; the historical `§V` (validation) and `§VI` (model risk management framework) anchors used throughout this control refer to the predecessor structure and are retained for reader continuity until the firm's MRM policy is re-mapped to the SR 26-2 published text.
+
+    **Generative and agentic AI scope caveat.** SR 26-2 / OCC 2026-13 expressly states that *"generative AI and agentic AI models are novel and rapidly evolving. As such, they are not within the scope of this guidance."* The Federal Reserve, OCC, and FDIC have **not** withdrawn the broader supervisory expectation that AI agents in customer-facing or decision-support roles be governed with model-equivalent rigor — that expectation continues to apply via existing safety-and-soundness, FINRA, SEC, NYDFS, and SOX regimes covered elsewhere in this control. Treat this control as the firm's **model-risk-equivalent** governance for AI agents until the agencies issue AI-specific guidance.
+
+    **File slug.** This control retains its original file slug (`2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md`) and URL path for link stability while citations transition; a slug rename is tracked separately in the v1.7 roadmap. References to "SR 11-7" and "OCC 2011-12" in this document and its playbooks refer to the superseded guidance unless otherwise marked. The operative citations as of the verification date are **SR 26-2** and **OCC Bulletin 2026-13**.
+
+---
+
 ## Objective
 
-Establish governance so that AI agents used in customer-facing or decision-support roles are subject to the same rigorous governance as traditional quantitative models, including model inventory, independent validation, ongoing performance monitoring, bias detection, and documented change control. This control **supports compliance with** OCC Bulletin 2011-12, Federal Reserve SR 11-7, FDIC FIL-22-2017, FFIEC IT Handbook, FINRA Rule 3110, FINRA Rule 4511, SEC Rules 17a-3 / 17a-4, SOX §§ 302 / 404, GLBA 501(b), and NYDFS 23 NYCRR 500 by providing a structured framework for treating AI agents as models within the firm's existing MRM program. **It does not replace, and must not be presented in the firm's MRM policy or WSPs as a substitute for, the firm's Model Risk Management Committee, independent model validation function, effective challenge process, or three-lines-of-defense governance.**
+Establish governance so that AI agents used in customer-facing or decision-support roles are subject to the same rigorous governance as traditional quantitative models, including model inventory, independent validation, ongoing performance monitoring, bias detection, and documented change control. This control **supports compliance with** OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), Federal Reserve SR 26-2 (formerly SR 11-7), FDIC FIL-22-2017, FFIEC IT Handbook, FINRA Rule 3110, FINRA Rule 4511, SEC Rules 17a-3 / 17a-4, SOX §§ 302 / 404, GLBA 501(b), and NYDFS 23 NYCRR 500 by providing a structured framework for treating AI agents as models within the firm's existing MRM program. **It does not replace, and must not be presented in the firm's MRM policy or WSPs as a substitute for, the firm's Model Risk Management Committee, independent model validation function, effective challenge process, or three-lines-of-defense governance.**
 
 ---
 
 !!! warning "Non-Substitution — Tooling Supports MRM, It Does Not Replace It"
     The Microsoft Purview DSPM for AI inventory, Microsoft Foundry (formerly Azure AI Foundry) evaluation harness, Copilot Studio analytics, Agent 365 governance console, and Microsoft Entra Agent ID identity surfaces referenced in this control are **inventory, evaluation, and evidence-collection surfaces**. They do **not** replace, and must not be presented in the firm's MRM policy, WSPs, or examiner submissions as a substitute for:
 
-    - The firm's **Model Risk Management Committee** and the formal model-tiering and approval decisions reserved to it under OCC 2011-12 / SR 11-7.
-    - **Independent model validation** by personnel organizationally and functionally separate from the model owner / developer (SR 11-7 §V). "Independent" is the regulatory test — third-party engagement is one way to achieve it but is not required and is not equivalent.
-    - **Effective challenge** — the critical, objective review by qualified personnel not involved in model development, which is the cornerstone of SR 11-7 and cannot be performed by any platform telemetry on its own.
+    - The firm's **Model Risk Management Committee** and the formal model-tiering and approval decisions reserved to it under OCC Bulletin 2026-13 / SR 26-2 (formerly OCC 2011-12 / SR 11-7).
+    - **Independent model validation** by personnel organizationally and functionally separate from the model owner / developer (SR 26-2 §V (formerly SR 11-7 §V)). "Independent" is the regulatory test — third-party engagement is one way to achieve it but is not required and is not equivalent.
+    - **Effective challenge** — the critical, objective review by qualified personnel not involved in model development, which is the cornerstone of SR 26-2 (formerly SR 11-7) and cannot be performed by any platform telemetry on its own.
     - **Three-lines-of-defense governance** — first line (model owner / developer), second line (independent MRM / validation / compliance), third line (Internal Audit). The Microsoft surfaces produce evidence; lines-of-defense judgments are made by people.
     - **Registered-principal supervisory review** under FINRA Rule 3110 of any AI-agent business activity (see Control 2.12).
     - **Books-and-records retention** of model artifacts under SEC 17a-4 / FINRA 4511 — Copilot Studio analytics and Foundry evaluation runs are not WORM-compliant for 17a-4(f) purposes; long-term model documentation and validation evidence must land in Purview retention or an approved 17a-4(f) vendor (see Controls 1.7 and 1.9).
@@ -39,11 +50,11 @@ Establish governance so that AI agents used in customer-facing or decision-suppo
 
 ## Why This Matters for FSI
 
-- **OCC 2011-12:** Establishes model risk management framework requirements for banks
-- **Fed SR 11-7:** Requires model development, validation, and ongoing monitoring (identical to OCC 2011-12; jointly issued)
+- **OCC Bulletin 2026-13 (formerly OCC 2011-12):** Establishes model risk management framework requirements for banks
+- **Fed SR 26-2 (formerly Fed SR 11-7):** Requires model development, validation, and ongoing monitoring (identical to OCC Bulletin 2026-13 (formerly OCC 2011-12); jointly issued)
 - **FINRA Rule 3110:** AI supervision and oversight requirements for broker-dealers
 - **SOX Sections 302/404:** Internal controls must include documented model controls (see SOX AI Governance below)
-- **Interagency RFI on AI (2021):** Confirmed OCC 2011-12 applies to AI/ML systems
+- **Interagency RFI on AI (2021):** Confirmed OCC Bulletin 2026-13 (formerly OCC 2011-12) applies to AI/ML systems
 
 !!! info "SOX AI Governance and PCAOB Standards"
     SOX applies to AI systems implicitly through Internal Control over Financial Reporting (ICFR). AI agents that affect financial data, reporting, or controls must be documented and tested as IT general controls.
@@ -79,9 +90,9 @@ While Copilot Studio agents may not be "models" in the traditional sense, their 
     For MRM purposes the firm must:
 
     - Record the **specific underlying model and version** in use for each agent in the model inventory and Agent Card (do not record only "Copilot Studio default").
-    - Treat any change in underlying model — including a Microsoft-driven default-model migration — as a **model change** under SR 11-7 §VI, requiring documented impact assessment and re-validation per the agent's risk tier.
+    - Treat any change in underlying model — including a Microsoft-driven default-model migration — as a **model change** under SR 26-2 §VI (formerly SR 11-7 §VI), requiring documented impact assessment and re-validation per the agent's risk tier.
     - Subscribe to the Microsoft 365 Message Center and Power Platform release plans so that vendor-driven model changes are detected before they take effect (cross-reference Control 2.3 — Change Management).
-    - Treat third-party model providers (e.g., Anthropic Claude when available) as **vendor models** under SR 11-7 §V — see the Vendor Model Governance section below.
+    - Treat third-party model providers (e.g., Anthropic Claude when available) as **vendor models** under SR 26-2 §V (formerly SR 11-7 §V) — see the Vendor Model Governance section below.
 
 !!! info "Infrastructure vs MRM Framework"
     Microsoft provides **infrastructure platforms** (Dataverse, SharePoint, Power Platform, Application Insights) that can support MRM processes, but organizations must **design and implement their own MRM frameworks**. There is no built-in "MRM solution" that automatically classifies agents, schedules validations, or generates compliance reports. The capabilities below describe governance processes that leverage Microsoft infrastructure.
@@ -90,7 +101,7 @@ While Copilot Studio agents may not be "models" in the traditional sense, their 
 |------------|-------------|----------------|-----------------|
 | **Model Classification** | Determine if agent qualifies as "model" | Organization-defined process using Dataverse/SharePoint | Tier-based governance |
 | **Model Inventory** | Catalog agents that function as models | Custom SharePoint list or Dataverse table | Regulatory examination readiness |
-| **Independent Validation** | Third-party review of agent behavior | Organization-managed process | Compliance with SR 11-7 |
+| **Independent Validation** | Third-party review of agent behavior | Organization-managed process | Compliance with SR 26-2 (formerly SR 11-7) |
 | **Performance Monitoring** | Track output quality over time | Copilot Studio Analytics (built-in) + custom RAI metrics | Early issue detection |
 | **Agent Cards** | Standardized documentation of capabilities/limitations | Custom template in SharePoint/Dataverse | Model transparency |
 
@@ -109,17 +120,17 @@ While Copilot Studio agents may not be "models" in the traditional sense, their 
 
 ### Organization-Designed MRM Framework
 
-- Classify all agents using OCC 2011-12 model definition criteria (organization-defined process)
+- Classify all agents using OCC Bulletin 2026-13 (formerly OCC 2011-12) model definition criteria (organization-defined process)
 - Maintain model inventory with tier assignments, owners, and validation status (custom Dataverse table or SharePoint list)
 - Create Agent Cards documenting capabilities, limitations, and performance benchmarks (custom template)
-- Establish an **independent** validation program. SR 11-7 §V defines independence functionally — validation must be performed by personnel organizationally and functionally separate from the model owner / developer, with the authority and competence to challenge the model. Internal second-line MRM staff can satisfy this; third-party engagement is one way to demonstrate independence (often used for Tier 1 / customer-facing / decision-support agents) but is **not required by SR 11-7** and is **not a substitute** for the firm's own validation judgment.
+- Establish an **independent** validation program. SR 26-2 §V (formerly SR 11-7 §V) defines independence functionally — validation must be performed by personnel organizationally and functionally separate from the model owner / developer, with the authority and competence to challenge the model. Internal second-line MRM staff can satisfy this; third-party engagement is one way to demonstrate independence (often used for Tier 1 / customer-facing / decision-support agents) but is **not required by SR 26-2 (formerly SR 11-7)** and is **not a substitute** for the firm's own validation judgment.
 - Define validation schedule and tracking mechanism (custom workflow or calendar integration)
 
-### Platform-Enabled Monitoring (mapped to SR 11-7 pillars)
+### Platform-Enabled Monitoring (mapped to SR 26-2 (formerly SR 11-7) pillars)
 
-SR 11-7 sets three validation pillars: **conceptual soundness**, **ongoing monitoring**, and **outcomes analysis**. Each maps to a specific Microsoft surface that produces evidence the firm's validators consume — the surface does not perform the validation.
+SR 26-2 (formerly SR 11-7) sets three validation pillars: **conceptual soundness**, **ongoing monitoring**, and **outcomes analysis**. Each maps to a specific Microsoft surface that produces evidence the firm's validators consume — the surface does not perform the validation.
 
-| SR 11-7 Pillar | Primary Microsoft Surface | What It Produces | Where Validators Use It |
+| SR 26-2 (formerly SR 11-7) Pillar | Primary Microsoft Surface | What It Produces | Where Validators Use It |
 |----------------|---------------------------|------------------|-------------------------|
 | Conceptual soundness | **Microsoft Purview DSPM for AI** (inventory of agents, models, knowledge sources, prompts, and interactions) + **Agent 365 Admin Center** (publication approvals, governance template applied) + Agent Card | Documented model purpose, design, data, intended use, limitations | Pre-deployment validation memo and Model Risk Committee review |
 | Ongoing monitoring | **Copilot Studio Analytics** (conversational and autonomous-agent metrics) + **Azure AI Foundry monitoring** (when underlying model is on Foundry) + **Application Insights / Azure Monitor** + DSPM for AI interaction reports | KPI drift, exception rate, sensitive-prompt rate, sentiment, customer-comment summaries | Quarterly monitoring report to MRM Committee; threshold breaches feed Control 3.4 incident workflow |
@@ -156,15 +167,15 @@ In addition:
 |------|-----------------|----------------|
 | Agent Owner / Copilot Studio Agent Author | 1st line | Model classification submission, Agent Card authorship, day-to-day monitoring of agent performance, response to MRM findings |
 | AI Governance Lead | 1st / 2nd line bridge | Model-tiering recommendation to the MRM Committee, governance-template application at publish/activate time, coordination with Compliance |
-| Model Risk Manager (independent validation function) | 2nd line | Independent validation per SR 11-7 (conceptual soundness, ongoing monitoring, outcomes analysis); effective challenge; validation report to MRM Committee |
+| Model Risk Manager (independent validation function) | 2nd line | Independent validation per SR 26-2 (formerly SR 11-7) (conceptual soundness, ongoing monitoring, outcomes analysis); effective challenge; validation report to MRM Committee |
 | Compliance Officer | 2nd line | Regulatory mapping, FINRA / SEC / OCC / NYDFS examination readiness, WSP integration |
 | AI Administrator | Operational | Agent 365 Admin Center publication and activation approvals, governance template enforcement, Researcher / Computer Use configuration |
 | Power Platform Admin | Operational | Environment governance, solution / manifest version control, Application Insights and Copilot Studio analytics configuration |
 | Internal Audit | 3rd line | Periodic independent audit of the MRM program for AI agents; assurance to the audit committee on operating effectiveness |
 | Model Risk Committee (governance body) | Governance | Final tiering decisions for Tier 1 / customer-facing agents; acceptance of validation reports; approval of model retirement |
 
-!!! note "Read-only Analytics Access for Independent Validation (SR 11-7)"
-    SR 11-7's "ongoing monitoring" pillar requires the Model Risk Manager and Internal Audit to inspect production performance signals without owning the model under review. The Copilot Studio **Analytics Viewer** sharing role helps meet this independence expectation by granting read-only access to an agent's Analytics page (success rate, sessions, escalations, CSAT) without conferring edit rights on agent topics, knowledge, or actions. Pair with the **Bot Transcript Viewer** role to expose conversation transcripts used as outcomes-analysis evidence. The role is shared by the agent owner via the agent's three-dots menu → **Share** → **Analytics viewer** and **must be assigned to individual users — Microsoft Entra security groups are not supported**, so maintain a named-individual attestation log linked to the validation work-paper to support OCC 2011-12 / SR 11-7 audit traceability. See [Share an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-share-bots).
+!!! note "Read-only Analytics Access for Independent Validation (SR 26-2 (formerly SR 11-7))"
+    SR 26-2 (formerly SR 11-7)'s "ongoing monitoring" pillar requires the Model Risk Manager and Internal Audit to inspect production performance signals without owning the model under review. The Copilot Studio **Analytics Viewer** sharing role helps meet this independence expectation by granting read-only access to an agent's Analytics page (success rate, sessions, escalations, CSAT) without conferring edit rights on agent topics, knowledge, or actions. Pair with the **Bot Transcript Viewer** role to expose conversation transcripts used as outcomes-analysis evidence. The role is shared by the agent owner via the agent's three-dots menu → **Share** → **Analytics viewer** and **must be assigned to individual users — Microsoft Entra security groups are not supported**, so maintain a named-individual attestation log linked to the validation work-paper to support OCC Bulletin 2026-13 / SR 26-2 (formerly OCC 2011-12 / SR 11-7) audit traceability. See [Share an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-share-bots).
 
 ---
 
@@ -179,7 +190,7 @@ In addition:
 | [2.1 - Managed Environments](2.1-managed-environments.md) | Platform substrate that hosts governed agents in scope for MRM |
 | [2.3 - Change Management](2.3-change-management-and-release-planning.md) | Captures vendor-driven model changes (e.g., Microsoft default-model migration) and prompt / knowledge-source changes as MRM-relevant model changes |
 | [2.5 - Testing and Validation](2.5-testing-validation-and-quality-assurance.md) | Pre-deployment validation evidence |
-| [2.7 - Vendor and Third-Party Risk Management](2.7-vendor-and-third-party-risk-management.md) | Vendor-model governance under SR 11-7 §V (Azure OpenAI, Anthropic Claude, partner models) |
+| [2.7 - Vendor and Third-Party Risk Management](2.7-vendor-and-third-party-risk-management.md) | Vendor-model governance under SR 26-2 §V (formerly SR 11-7 §V) (Azure OpenAI, Anthropic Claude, partner models) |
 | [2.8 - Access Control and Segregation of Duties](2.8-access-control-and-segregation-of-duties.md) | Independence of validation function from model owner / developer |
 | [2.11 - Bias Testing](2.11-bias-testing-and-fairness-assessment.md) | Fairness component of outcomes analysis |
 | [2.12 - Supervision (FINRA Rule 3110)](2.12-supervision-and-oversight-finra-rule-3110.md) | Registered-principal supervisory layer over AI-enabled business activity |
@@ -191,7 +202,7 @@ In addition:
 | [3.2 - Usage Analytics and Activity Monitoring](../pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md) | Usage data feeding ongoing-monitoring pillar |
 | [3.3 - Compliance and Regulatory Reporting](../pillar-3-reporting/3.3-compliance-and-regulatory-reporting.md) | MRM reporting to regulators and the audit committee |
 | [3.4 - Incident Reporting and Root Cause Analysis](../pillar-3-reporting/3.4-incident-reporting-and-root-cause-analysis.md) | Threshold breaches and outcomes-analysis failures escalate into the IR / RCA workflow; RCA feedback returns to MRM |
-| [3.6 - Orphaned Agent Detection](../pillar-3-reporting/3.6-orphaned-agent-detection-and-remediation.md) | Ownerless / orphaned agents are MRM-actionable; an unowned model has no accountable owner under SR 11-7 |
+| [3.6 - Orphaned Agent Detection](../pillar-3-reporting/3.6-orphaned-agent-detection-and-remediation.md) | Ownerless / orphaned agents are MRM-actionable; an unowned model has no accountable owner under SR 26-2 (formerly SR 11-7) |
 | [3.9 - Microsoft Sentinel Integration](../pillar-3-reporting/3.9-microsoft-sentinel-integration.md) | Cross-source telemetry for ongoing monitoring and incident correlation |
 
 ---
@@ -209,17 +220,17 @@ In addition:
 
 ---
 
-## Vendor Model Governance (SR 11-7 Section V)
+## Vendor Model Governance (SR 26-2 Section V (formerly SR 11-7 Section V))
 
 !!! warning "Vendor Models Require Equal Rigor"
-    Federal Reserve SR 11-7 Section V explicitly requires that **vendor-provided models be validated with the same rigor as internally-developed models**. For AI agents using Microsoft Azure OpenAI, OpenAI APIs, or other third-party model providers, organizations must:
+    Federal Reserve SR 26-2 Section V (formerly SR 11-7 Section V) explicitly requires that **vendor-provided models be validated with the same rigor as internally-developed models**. For AI agents using Microsoft Azure OpenAI, OpenAI APIs, or other third-party model providers, organizations must:
 
     1. **Obtain sufficient documentation** from the vendor to understand model behavior and limitations
     2. **Conduct independent validation** appropriate to the model's risk tier
     3. **Monitor ongoing model performance** including tracking vendor model updates
     4. **Assess vendor model changes** before deployment to production
 
-| Vendor Model Governance Requirement | SR 11-7 Reference | FSI-AgentGov Implementation |
+| Vendor Model Governance Requirement | SR 26-2 (formerly SR 11-7) Reference | FSI-AgentGov Implementation |
 |-------------------------------------|-------------------|----------------------------|
 | Documentation from vendor | Section V | Request Azure OpenAI model cards, benchmark data |
 | Validation despite vendor source | Section V | Independent validation per tier (see Agent-as-Model Classification) |
@@ -245,10 +256,10 @@ Confirm control effectiveness by verifying:
 1. Every agent in the firm's authoritative inventory (Control 3.1 / DSPM for AI) has a documented model-classification decision with rationale, classifier identity, and decision date.
 2. Model inventory records, for each in-scope agent: tier, owner, sponsor, underlying model and version, knowledge sources, validation status, last validation date, and next scheduled validation.
 3. Agent Cards exist for every Tier 1 and Tier 2 agent and document intended use, data, limitations, performance benchmarks, and known failure modes.
-4. Independent validation (conceptual soundness, ongoing monitoring, outcomes analysis) has been completed for each in-scope agent at a frequency commensurate with risk, model complexity, and change activity (SR 11-7 §V) — not on a fixed annual basis. Validation cadence is documented in the model risk policy and approved by the MRM Committee.
+4. Independent validation (conceptual soundness, ongoing monitoring, outcomes analysis) has been completed for each in-scope agent at a frequency commensurate with risk, model complexity, and change activity (SR 26-2 §V (formerly SR 11-7 §V)) — not on a fixed annual basis. Validation cadence is documented in the model risk policy and approved by the MRM Committee.
 5. Effective challenge of each Tier 1 validation is evidenced by MRM Committee minutes referencing the specific challenge questions raised and their disposition.
 6. Ongoing-monitoring thresholds are defined per agent, alerts route to a named owner, and threshold breaches are escalated to the IR workflow per [Control 3.4](../pillar-3-reporting/3.4-incident-reporting-and-root-cause-analysis.md).
-7. Vendor-model change notifications (Microsoft Message Center, Power Platform release plan, Foundry model deprecations) are reviewed and dispositioned as model changes per SR 11-7 §V before they take effect in production.
+7. Vendor-model change notifications (Microsoft Message Center, Power Platform release plan, Foundry model deprecations) are reviewed and dispositioned as model changes per SR 26-2 §V (formerly SR 11-7 §V) before they take effect in production.
 8. Solution / manifest version control enables point-in-time reconstruction of agent configuration for any date in the retention window.
 9. Validation evidence, MRM Committee minutes, model retirement decisions, and vendor-model assessments are retained on 17a-4(f)-compliant media for six years (with the first two easily accessible).
 10. A documented model-retirement / sunset workflow exists and has been exercised at least once, with retirement evidence retained alongside development and validation evidence.
@@ -257,13 +268,18 @@ Confirm control effectiveness by verifying:
 
 ## Additional Resources
 
-**Regulatory sources**
+**Regulatory sources — current (April 2026)**
 
-- [OCC Bulletin 2011-12 — Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
-- [Federal Reserve SR 11-7 — Supervisory Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm)
-- [FDIC FIL-22-2017 — Adoption of Supervisory Guidance on Model Risk Management](https://www.fdic.gov/news/financial-institution-letters/2017/fil17022.html)
+- [OCC Bulletin 2026-13 — Updated Interagency Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-13.html) — supersedes and rescinds OCC Bulletin 2011-12 (April 17, 2026)
+- [Federal Reserve SR 26-2 — Revised Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) — supersedes and replaces SR letter 11-7 and SR letter 21-8 (April 17, 2026)
+- [FDIC FIL-22-2017 — Adoption of Supervisory Guidance on Model Risk Management](https://www.fdic.gov/news/financial-institution-letters/2017/fil17022.html) — historical FDIC adoption of the 2011 guidance; refer to FDIC supervisory communications for adoption status of the 2026 revised guidance
 - [FFIEC IT Examination Handbook](https://ithandbook.ffiec.gov/)
 - [FINRA Regulatory Notice 25-07 — Use of Artificial Intelligence (RFC)](https://www.finra.org/rules-guidance/notices/25-07)
+
+**Regulatory sources — historical (rescinded April 2026, retained for audit-trail context)**
+
+- [OCC Bulletin 2011-12 — Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html) — *rescinded by OCC Bulletin 2026-13*
+- Federal Reserve SR 11-7 — Supervisory Guidance on Model Risk Management — *superseded by SR 26-2; the predecessor URL `sr1107.htm` no longer resolves on the Federal Reserve site*
 
 **Microsoft Learn — surfaces this control depends on (verified May 2026)**
 

--- a/docs/images/2.6/EXPECTED.md
+++ b/docs/images/2.6/EXPECTED.md
@@ -1,4 +1,4 @@
-# Control 2.6: Model Risk Management (OCC 2011-12/SR 11-7)
+# Control 2.6: Model Risk Management (OCC Bulletin 2026-13 / SR 26-2 — formerly OCC 2011-12 / SR 11-7)
 
 ## Expected Screenshots
 

--- a/docs/playbooks/control-implementations/1.13/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.13/powershell-setup.md
@@ -1066,7 +1066,7 @@ Stop-Transcript
 - **Control 1.5 — Identity baseline for agent makers and admins.** SIT authoring requires the privileged-role and Conditional Access posture defined there. `docs/controls/pillar-1-security/1.5-identity-baseline-for-agent-makers-and-admins.md`
 - **Control 1.6 — Sensitivity labels and label policies.** SIT detection drives auto-labelling; labels in turn drive Copilot grounding eligibility. `docs/controls/pillar-1-security/1.6-sensitivity-labels-for-ai-content.md`
 - **Control 1.7 — DLP policy framework.** This playbook publishes SITs; Control 1.7 is the parent for the DLP policy engine that consumes them. `docs/controls/pillar-1-security/1.7-data-loss-prevention-for-ai-interactions.md`
-- **Control 1.10 — Customer Lockbox / data-residency boundary.** EDM hash stores and trainable classifier inference inherit the residency posture from Control 1.10. `docs/controls/pillar-1-security/1.10-customer-lockbox-and-data-residency.md`
+- **Control 1.10 — Customer Lockbox / data-residency boundary.** Customer Lockbox and data-residency posture are currently covered in Control 2.1 Managed Environments; a dedicated Lockbox/Data Residency control decision is tracked in the v1.7 roadmap.
 - **Control 4.6 — SharePoint grounding scope governance.** SIT-based DLP rules complement scope governance for what an agent can ground on. `docs/controls/pillar-4-sharepoint/4.6-grounding-scope-governance.md`
 - **AI Incident Response Playbook.** Standing on-call runbook for SIT/DLP alerts that fire against agent traffic. `docs/playbooks/incident-and-risk/ai-incident-response-playbook.md`
 - **Shared PowerShell baseline.** Module pinning, sovereign endpoints, transcript and evidence helpers. `docs/playbooks/_shared/powershell-baseline.md`

--- a/docs/playbooks/control-implementations/2.6/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/2.6/portal-walkthrough.md
@@ -1,14 +1,14 @@
-# Portal Walkthrough — Control 2.6: Model Risk Management (OCC 2011-12 / Fed SR 11-7)
+# Portal Walkthrough — Control 2.6: Model Risk Management (OCC Bulletin 2026-13 / Fed SR 26-2 — formerly OCC 2011-12 / Fed SR 11-7)
 
 !!! danger "READ FIRST — What This Playbook Configures, and What It Does Not"
     This playbook walks a US FSI Microsoft 365 administrator through the **portal configuration of the Microsoft surfaces that produce model-risk-management evidence** for AI agents — Microsoft Purview Data Security Posture Management (DSPM) for AI, the Agent 365 Admin Center, the Agent Card SharePoint inventory, Microsoft Copilot Studio Analytics, Azure AI Foundry monitoring and evaluators, and Microsoft Entra Agent ID. It is the operational companion to [Control 2.6 — Model Risk Management](../../../controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md).
 
-    **These surfaces support compliance with OCC Bulletin 2011-12 and Federal Reserve SR 11-7. They do not replace, and must not be presented in the firm's MRM policy, Written Supervisory Procedures (WSPs), or examiner submissions as a substitute for:**
+    **These surfaces support compliance with OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) and Federal Reserve SR 26-2 (formerly SR 11-7). They do not replace, and must not be presented in the firm's MRM policy, Written Supervisory Procedures (WSPs), or examiner submissions as a substitute for:**
 
     | What the firm must do (people, not platforms) | Where it lives |
     |---|---|
     | **Model Risk Management Committee** — formal model definition, tiering, approval, retirement decisions | Firm's MRM charter and minutes |
-    | **Independent model validation function** — SR 11-7 §V *independence* test (organizationally and functionally separate from model owner / developer) | Firm's second-line MRM staff (internal is sufficient; third-party is one way, not the only way, to demonstrate independence) |
+    | **Independent model validation function** — SR 26-2 §V (formerly SR 11-7 §V) *independence* test (organizationally and functionally separate from model owner / developer) | Firm's second-line MRM staff (internal is sufficient; third-party is one way, not the only way, to demonstrate independence) |
     | **Effective challenge** — critical, objective review by qualified personnel not involved in model development | MRM Committee or independent reviewer working papers |
     | **Three-lines-of-defense governance** — first line (model owner/developer), second line (MRM/validation/compliance), third line (Internal Audit) | Firm's risk taxonomy and reporting lines |
     | **Registered-principal supervisory review** under FINRA Rule 3110 for any AI-agent business activity | WSPs and supervisory log (see Control 2.12) |
@@ -17,7 +17,7 @@
     Microsoft surfaces produce telemetry, inventory, and evaluation runs. **Lines-of-defense judgments are made by people.**
 
 !!! warning "Hedged-Language Reminder"
-    Configuring the surfaces in this walkthrough **supports compliance with** OCC Bulletin 2011-12, Federal Reserve SR 11-7, FDIC FIL-22-2017, FFIEC IT Handbook (Management; Information Security), FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), SEC Rules 17a-3 / 17a-4, SOX §§ 302 / 404, GLBA 501(b), and NYDFS 23 NYCRR 500. It does not by itself guarantee any regulatory outcome. **FINRA Regulatory Notice 25-07 (AI Tools) is cited only as RFC / contextual material; it is not binding AI guidance.** Implementation requires the firm's existing MRM program, validated change control, and independent testing by the firm's compliance and audit functions. Organizations should verify all configurations against their own examination workpapers and legal counsel before treating these procedures as adequate evidence.
+    Configuring the surfaces in this walkthrough **supports compliance with** OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), Federal Reserve SR 26-2 (formerly SR 11-7), FDIC FIL-22-2017, FFIEC IT Handbook (Management; Information Security), FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), SEC Rules 17a-3 / 17a-4, SOX §§ 302 / 404, GLBA 501(b), and NYDFS 23 NYCRR 500. It does not by itself guarantee any regulatory outcome. **FINRA Regulatory Notice 25-07 (AI Tools) is cited only as RFC / contextual material; it is not binding AI guidance.** Implementation requires the firm's existing MRM program, validated change control, and independent testing by the firm's compliance and audit functions. Organizations should verify all configurations against their own examination workpapers and legal counsel before treating these procedures as adequate evidence.
 
 !!! warning "Sovereign Cloud Availability — GCC, GCC High, DoD, China"
     Several Microsoft surfaces this playbook depends on have parity gaps in sovereign clouds as of the verification date. **If your tenant authenticates against `login.microsoftonline.us` (GCC, GCC High, DoD) or operates in 21Vianet China**, stop and read [§1 — Sovereign Cloud Variant](#1-sovereign-cloud-variant-and-compensating-controls) before continuing. Re-verify status against the [Microsoft 365 Government roadmap](https://aka.ms/m365gov-roadmap) and the [Power Platform release plan](https://learn.microsoft.com/en-us/power-platform/release-plan/) at least quarterly.
@@ -36,14 +36,14 @@
 
 ## Document Map
 
-| § | Section | SR 11-7 pillar | Verification Criterion |
+| § | Section | SR 26-2 (formerly SR 11-7) pillar | Verification Criterion |
 |---|---|---|---|
 | 0 | [Pre-flight Prerequisites](#0-pre-flight-prerequisites) | All | VC-1, VC-2 |
 | 1 | [Sovereign Cloud Variant and Compensating Controls](#1-sovereign-cloud-variant-and-compensating-controls) | All (substitute path) | VC-1 |
 | 2 | [Conceptual Soundness Evidence Surfaces](#2-conceptual-soundness-evidence-surfaces) | Conceptual soundness | VC-3, VC-4 |
 | 3 | [Ongoing Monitoring Evidence Surfaces](#3-ongoing-monitoring-evidence-surfaces) | Ongoing monitoring | VC-5, VC-6 |
 | 4 | [Outcomes Analysis Evidence Surfaces](#4-outcomes-analysis-evidence-surfaces) | Outcomes analysis | VC-7 |
-| 5 | [Vendor Model Governance (SR 11-7 §V)](#5-vendor-model-governance-sr-11-7-v) | Vendor models | VC-8 |
+| 5 | [Vendor Model Governance (SR 26-2 §V (formerly SR 11-7 §V))](#5-vendor-model-governance-sr-11-7-v) | Vendor models | VC-8 |
 | 6 | [Validation Evidence Retention Path](#6-validation-evidence-retention-path) | Books and records | VC-9 |
 | 7 | [Verification Checklist](#7-verification-checklist) | All | VC-1 → VC-10 |
 | 8 | [Common Pitfalls](#8-common-pitfalls) | All | Operational |
@@ -60,9 +60,9 @@ Skipping a pre-flight gate is itself an auditable finding. Log every gate result
 Before configuring any portal:
 
 1. Confirm the firm's **Model Risk Management Committee charter** exists, names a Model Risk Manager, and defines model-tiering criteria (Tier 1 / Tier 2 / Tier 3) and validation cadence.
-2. Confirm the firm's **MRM policy** explicitly addresses AI agents — that is, it states whether and when an AI agent meets the firm's definition of a "model" under OCC 2011-12 / SR 11-7, and assigns first-line, second-line, and third-line responsibilities.
+2. Confirm the firm's **MRM policy** explicitly addresses AI agents — that is, it states whether and when an AI agent meets the firm's definition of a "model" under OCC Bulletin 2026-13 / SR 26-2 (formerly OCC 2011-12 / SR 11-7), and assigns first-line, second-line, and third-line responsibilities.
 3. Confirm the **WSPs** (broker-dealers) or equivalent supervisory procedures (banks, IAs, NYDFS-covered firms) name the registered principal or supervisor responsible for AI-agent supervision under **FINRA Rule 3110**. This designation must exist in writing **before** any in-scope agent is published.
-4. Confirm the **independent validation function** under SR 11-7 §V is identified by name and reporting line. Internal second-line MRM staff who are organizationally and functionally separate from the model owner / developer satisfy the *independence* test. Third-party engagement is one way to demonstrate independence; it is not required and is not equivalent.
+4. Confirm the **independent validation function** under SR 26-2 §V (formerly SR 11-7 §V) is identified by name and reporting line. Internal second-line MRM staff who are organizationally and functionally separate from the model owner / developer satisfy the *independence* test. Third-party engagement is one way to demonstrate independence; it is not required and is not equivalent.
 
 If any of these are missing, **stop**. The Microsoft surfaces below have nothing to evidence until the firm's MRM governance exists.
 
@@ -131,7 +131,7 @@ If your tenant is in GCC, GCC High, DoD, or China, treat this section as the pri
 
 ## 2. Conceptual Soundness Evidence Surfaces
 
-SR 11-7 conceptual soundness asks whether the model is appropriately designed for its intended use, with reasonable assumptions and clearly documented limitations. The surfaces below produce **inventory and design evidence** the MRM Committee uses to evaluate conceptual soundness. They do not perform the evaluation.
+SR 26-2 (formerly SR 11-7) conceptual soundness asks whether the model is appropriately designed for its intended use, with reasonable assumptions and clearly documented limitations. The surfaces below produce **inventory and design evidence** the MRM Committee uses to evaluate conceptual soundness. They do not perform the evaluation.
 
 ### 2.1 Microsoft Purview DSPM for AI inventory
 
@@ -204,7 +204,7 @@ The Agent Card is the firm's **authoritative model inventory record** for each i
 
 ## 3. Ongoing Monitoring Evidence Surfaces
 
-SR 11-7 ongoing monitoring asks whether the model continues to perform as intended after deployment. The surfaces below produce **operational telemetry** the MRM Committee uses to detect drift, degradation, and abnormal behavior.
+SR 26-2 (formerly SR 11-7) ongoing monitoring asks whether the model continues to perform as intended after deployment. The surfaces below produce **operational telemetry** the MRM Committee uses to detect drift, degradation, and abnormal behavior.
 
 ### 3.1 Copilot Studio Analytics — summary and event-trigger reports
 
@@ -229,11 +229,11 @@ SR 11-7 ongoing monitoring asks whether the model continues to perform as intend
     Analytics data is available for up to **180 days**; session details and transcript information is available for the last **28 days** (per Microsoft Learn — analytics overview). Ongoing-monitoring evidence required beyond these windows — session transcripts, KPI trend snapshots, threshold-breach records — must be exported to Log Analytics or the retention path described in [§6](#6-validation-evidence-retention-path) before the applicable window closes. Validation memos and MRM Committee minutes are not stored in Copilot Studio Analytics and must be routed to the §6 retention path directly.
 
 !!! warning "Analytics is the evidence — not the validation"
-    Copilot Studio Analytics produces operational telemetry. It is one input the MRM Committee uses to perform ongoing monitoring under SR 11-7. The committee's review, judgment, and effective challenge are the validation — Analytics dashboards are not.
+    Copilot Studio Analytics produces operational telemetry. It is one input the MRM Committee uses to perform ongoing monitoring under SR 26-2 (formerly SR 11-7). The committee's review, judgment, and effective challenge are the validation — Analytics dashboards are not.
 
 #### 3.1.1 Granting read-only Analytics access to independent validators (Analytics Viewer sharing role)
 
-The Model Risk Manager, Internal Audit, and the MRM Committee secretariat typically need read-only visibility into the Copilot Studio Analytics page **without** being granted Co-owner or edit rights on the agent. Granting edit rights to the independent validation function violates the SR 11-7 effective-challenge principle (a validator must not also hold operational change rights on the model under review).
+The Model Risk Manager, Internal Audit, and the MRM Committee secretariat typically need read-only visibility into the Copilot Studio Analytics page **without** being granted Co-owner or edit rights on the agent. Granting edit rights to the independent validation function violates the SR 26-2 (formerly SR 11-7) effective-challenge principle (a validator must not also hold operational change rights on the model under review).
 
 **Portal path:** [Copilot Studio](https://copilotstudio.microsoft.com) → select agent → **three-dots (...)** menu (top-right of the agent header) → **Share**.
 
@@ -244,7 +244,7 @@ The Model Risk Manager, Internal Audit, and the MRM Committee secretariat typica
 5. Save and capture a screenshot of the Share dialog as evidence in the validation work-paper.
 
 !!! warning "Individual users only — security groups are not supported"
-    The Analytics Viewer role **can only be assigned to individual users**. Microsoft Entra security groups, distribution lists, and Microsoft 365 groups are **not** valid assignment targets. Maintain a named-individual attestation list (suggested location: the Agent Card, §2.3) and review at the agent's quarterly governance cycle. The list supports examiner traceability of who held read-only Analytics access during any supervisory or validation period and helps meet OCC 2011-12 / SR 11-7 documentation expectations for the model-validation function.
+    The Analytics Viewer role **can only be assigned to individual users**. Microsoft Entra security groups, distribution lists, and Microsoft 365 groups are **not** valid assignment targets. Maintain a named-individual attestation list (suggested location: the Agent Card, §2.3) and review at the agent's quarterly governance cycle. The list supports examiner traceability of who held read-only Analytics access during any supervisory or validation period and helps meet OCC Bulletin 2026-13 / SR 26-2 (formerly OCC 2011-12 / SR 11-7) documentation expectations for the model-validation function.
 
 Reference: [Microsoft Learn — Share an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/admin-share-bots).
 
@@ -273,7 +273,7 @@ Reference: [Microsoft Learn — Azure AI Foundry monitoring](https://learn.micro
 
 ## 4. Outcomes Analysis Evidence Surfaces
 
-SR 11-7 outcomes analysis compares model output to actual outcomes (or to a reference standard) to assess accuracy. The surfaces below produce **evaluator runs** the MRM Committee uses to assess outcome quality.
+SR 26-2 (formerly SR 11-7) outcomes analysis compares model output to actual outcomes (or to a reference standard) to assess accuracy. The surfaces below produce **evaluator runs** the MRM Committee uses to assess outcome quality.
 
 ### 4.1 Foundry built-in evaluators
 
@@ -327,9 +327,9 @@ Capture each re-validation as a discrete validation memo retained under §6.
 
 ---
 
-## 5. Vendor Model Governance (SR 11-7 §V)
+## 5. Vendor Model Governance (SR 26-2 §V (formerly SR 11-7 §V)) {#5-vendor-model-governance-sr-11-7-v}
 
-SR 11-7 §V applies to vendor and externally developed models with the same rigor as internal models. The validation function must assess the vendor model and document independence.
+SR 26-2 §V (formerly SR 11-7 §V) applies to vendor and externally developed models with the same rigor as internal models. The validation function must assess the vendor model and document independence.
 
 ### 5.1 Capture vendor-model selection and provider evidence
 
@@ -347,7 +347,7 @@ SR 11-7 §V applies to vendor and externally developed models with the same rigo
 
 ### 5.2 Detect Microsoft default-model migrations as model changes
 
-A Microsoft-driven default-model migration (for example, a tenant's default Copilot Studio model moving from one foundation model to a successor) is a **model change** for SR 11-7 purposes and triggers re-validation.
+A Microsoft-driven default-model migration (for example, a tenant's default Copilot Studio model moving from one foundation model to a successor) is a **model change** for SR 26-2 (formerly SR 11-7) purposes and triggers re-validation.
 
 1. Subscribe the AI Governance Lead and Model Risk Manager to the **Microsoft 365 Message Center** and the **Power Platform release plan** ([https://learn.microsoft.com/en-us/power-platform/release-plan/](https://learn.microsoft.com/en-us/power-platform/release-plan/)).
 2. Configure Message Center email digest delivery; Message Center posts are the authoritative tenant-targeted notice for Copilot and Copilot Studio model changes.
@@ -412,12 +412,12 @@ The MRM Committee, on demand, can produce each of the following. The verificatio
 | Pitfall | Why it fails | What to do instead |
 |---|---|---|
 | **Treating Copilot Studio Analytics as the validation.** Pointing examiners at a dashboard and saying "monitoring is in place." | Analytics is operational telemetry — it is **the evidence**, not the validation. The validation is the MRM Committee's review and effective challenge using that evidence. | Produce the validation memo that **references** the Analytics export, authored by the independent validation function. |
-| **Calling third-party engagement "independent validation" without substantiating independence.** Engaging an external firm and inferring SR 11-7 §V independence from the engagement alone. | SR 11-7 independence is a **functional and organizational** test, not a contractual one. An internal second-line MRM team that is functionally separate from the model owner / developer satisfies independence. A third party that is not appropriately scoped or qualified does not. | Document the validator's reporting line, scope of work, qualifications, and absence of conflicts. Independence is the test; third-party is one way to demonstrate it, not the test itself. |
-| **Not capturing vendor-model changes as model changes.** Treating a Microsoft default-model migration as a routine platform update. | A foundation-model change alters the model under SR 11-7 and triggers re-validation. Missing this is a recordkeeping and validation gap. | Subscribe to Microsoft 365 Message Center and the Power Platform release plan; activate the §5.2 runbook on every announced default-model migration. |
+| **Calling third-party engagement "independent validation" without substantiating independence.** Engaging an external firm and inferring SR 26-2 §V (formerly SR 11-7 §V) independence from the engagement alone. | SR 26-2 (formerly SR 11-7) independence is a **functional and organizational** test, not a contractual one. An internal second-line MRM team that is functionally separate from the model owner / developer satisfies independence. A third party that is not appropriately scoped or qualified does not. | Document the validator's reporting line, scope of work, qualifications, and absence of conflicts. Independence is the test; third-party is one way to demonstrate it, not the test itself. |
+| **Not capturing vendor-model changes as model changes.** Treating a Microsoft default-model migration as a routine platform update. | A foundation-model change alters the model under SR 26-2 (formerly SR 11-7) and triggers re-validation. Missing this is a recordkeeping and validation gap. | Subscribe to Microsoft 365 Message Center and the Power Platform release plan; activate the §5.2 runbook on every announced default-model migration. |
 | **Relying on M365 Audit Premium retention as 17a-4(f) WORM.** Storing validation memos in audit logs and assuming they meet broker-dealer recordkeeping. | M365 Audit Premium is **operational telemetry**, not WORM. It does not meet 17a-4(f) attestation requirements. | Retain validation memos under Purview retention with a locked Regulatory Record label, or in an approved 17a-4(f) vendor (Smarsh, Global Relay, Proofpoint, Mimecast). See [Control 1.9](../../../controls/pillar-1-security/1.9-data-retention-and-deletion-policies.md). |
 | **Treating DSPM for AI inventory as the model inventory.** Using DSPM for AI as the firm's authoritative Agent Card record. | DSPM for AI captures activity; it does not capture tier, owner-of-record, validation memo URI, or registered-principal designee. | Maintain the Agent Card SharePoint list as the authoritative inventory and reconcile against DSPM for AI monthly. |
 | **Assuming sovereign-cloud parity.** Configuring the platform path in GCC, GCC High, or DoD without verifying availability. | Several surfaces in this playbook have not been announced for sovereign clouds. Configurations that fail silently produce no evidence. | Run §0.4 verification, jump to §1 if sovereign, and re-verify quarterly against the Microsoft 365 Government roadmap. |
-| **Confusing FINRA Notice 25-07 with binding AI rules.** Citing Notice 25-07 as a regulatory requirement. | Notice 25-07 is RFC / contextual material, not binding AI guidance. | Cite the binding regulations (OCC 2011-12, SR 11-7, FINRA 3110, FINRA 4511, SEC 17a-3 / 17a-4, SOX, GLBA, NYDFS 23 NYCRR 500) and reference Notice 25-07 only as contextual background. |
+| **Confusing FINRA Notice 25-07 with binding AI rules.** Citing Notice 25-07 as a regulatory requirement. | Notice 25-07 is RFC / contextual material, not binding AI guidance. | Cite the binding regulations (OCC Bulletin 2026-13 (formerly OCC 2011-12), SR 26-2 (formerly SR 11-7), FINRA 3110, FINRA 4511, SEC 17a-3 / 17a-4, SOX, GLBA, NYDFS 23 NYCRR 500) and reference Notice 25-07 only as contextual background. |
 
 ---
 

--- a/docs/playbooks/control-implementations/2.6/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.6/powershell-setup.md
@@ -1,10 +1,10 @@
-# Control 2.6 — PowerShell Setup: MRM Evidence Inventories and Reports (OCC 2011-12 / SR 11-7)
+# Control 2.6 — PowerShell Setup: MRM Evidence Inventories and Reports (OCC Bulletin 2026-13 / SR 26-2 — formerly OCC 2011-12 / SR 11-7)
 
 !!! danger "Non-Substitution — This PowerShell Produces Evidence; Validation Judgments Remain with People"
-    The helpers in this playbook are **inventory, change-detection, and evidence-export** utilities. They do **not** perform model validation, **do not** assign model tiers, **do not** issue effective challenge, and **do not** approve, reject, or retire any AI agent. Those judgments are reserved — under OCC Bulletin 2011-12 and Federal Reserve SR 11-7 §V — to:
+    The helpers in this playbook are **inventory, change-detection, and evidence-export** utilities. They do **not** perform model validation, **do not** assign model tiers, **do not** issue effective challenge, and **do not** approve, reject, or retire any AI agent. Those judgments are reserved — under OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) and Federal Reserve SR 26-2 §V (formerly SR 11-7 §V) — to:
 
     - The firm's **Model Risk Management Committee** (model-tiering, validation acceptance, model retirement).
-    - The firm's **independent model validation function** — personnel **organizationally and functionally separate** from model owners and developers. "Independent" is the SR 11-7 §V test; third-party engagement is one way to achieve it but is not required and is not equivalent.
+    - The firm's **independent model validation function** — personnel **organizationally and functionally separate** from model owners and developers. "Independent" is the SR 26-2 §V (formerly SR 11-7 §V) test; third-party engagement is one way to achieve it but is not required and is not equivalent.
     - The firm's **effective challenge** process — qualified personnel not involved in model development conducting critical, objective review.
     - **Three lines of defense** — first line (model owner / developer), second line (independent MRM / validation / compliance), third line (Internal Audit).
     - **Registered-principal supervisory review** under FINRA Rule 3110 (see [Control 2.12](../../../controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md)).
@@ -14,11 +14,11 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety, Dataverse compatibility, and SHA-256 evidence emission. Sovereign-cloud endpoints are documented in [§3 — Sovereign Cloud Endpoints (GCC, GCC High, DoD)](../../_shared/powershell-baseline.md#3-sovereign-cloud-endpoints-gcc-gcc-high-dod).
 
-> **Scope.** This playbook automates **read-only evidence inventories** for [Control 2.6 — Model Risk Management (OCC 2011-12 / SR 11-7)](../../../controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md). Outputs feed your existing MRM program; they do not replace it.
+> **Scope.** This playbook automates **read-only evidence inventories** for [Control 2.6 — Model Risk Management (OCC Bulletin 2026-13 / SR 26-2 — formerly OCC 2011-12 / SR 11-7)](../../../controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md). Outputs feed your existing MRM program; they do not replace it.
 >
 > **Namespace.** All functions use the `FsiMRM` prefix to prevent collision with peer-control automation (`Agt36`, `Agt225`, `Agt226`).
 >
-> **Hedged-language reminder.** The artifacts produced here **support compliance with** OCC 2011-12, SR 11-7, FDIC FIL-22-2017, FFIEC IT Handbook, FINRA 3110/4511, SEC 17a-3/17a-4, SOX §§302/404, GLBA 501(b), and NYDFS 23 NYCRR 500. They do not — and cannot — *ensure*, *guarantee*, *prevent*, or *eliminate* anything on their own.
+> **Hedged-language reminder.** The artifacts produced here **support compliance with** OCC Bulletin 2026-13 (formerly OCC 2011-12), SR 26-2 (formerly SR 11-7), FDIC FIL-22-2017, FFIEC IT Handbook, FINRA 3110/4511, SEC 17a-3/17a-4, SOX §§302/404, GLBA 501(b), and NYDFS 23 NYCRR 500. They do not — and cannot — *ensure*, *guarantee*, *prevent*, or *eliminate* anything on their own.
 
 ---
 
@@ -479,7 +479,7 @@ function Resolve-FsiMRMRowStatus {
 
 ### 3.2 — `Get-FsiAgentModelChangeFeed`
 
-Per **SR 11-7 §V (vendor-model governance)**, the firm must monitor and disposition vendor-driven changes to underlying models — including default-model migrations in Copilot Studio and model deprecations in Azure AI Foundry. This helper aggregates two signal sources into a disposition-ready feed.
+Per **SR 26-2 §V (formerly SR 11-7 §V) (vendor-model governance)**, the firm must monitor and disposition vendor-driven changes to underlying models — including default-model migrations in Copilot Studio and model deprecations in Azure AI Foundry. This helper aggregates two signal sources into a disposition-ready feed.
 
 ```powershell
 function Get-FsiAgentModelChangeFeed {
@@ -487,7 +487,7 @@ function Get-FsiAgentModelChangeFeed {
 .SYNOPSIS
     Surfaces vendor-driven model-change signals (Power Platform release plan
     items + M365 Message Center notices) the MRM Committee must disposition
-    under SR 11-7 §V vendor-model governance.
+    under SR 26-2 §V (formerly SR 11-7 §V) vendor-model governance.
 
 .DESCRIPTION
     Read-only. Pulls candidate change events from:
@@ -768,7 +768,7 @@ function Export-FsiMRMEvidencePackage {
 
 This package is **input to** an MRM Committee or independent validation review.
 It is not a validation, a tier assignment, or an effective-challenge record. All
-MRM judgments under OCC 2011-12 / SR 11-7 §V remain with the firm's MRM
+MRM judgments under OCC Bulletin 2026-13 / SR 26-2 (formerly OCC 2011-12 / SR 11-7) §V remain with the firm's MRM
 Committee and independent validators.
 
 ## Contents
@@ -848,7 +848,7 @@ $dispositionLog | Export-Csv -Path '.\sr11-7-vendor-model-disposition.csv' -NoTy
 
 ### 4.4 — Outcomes-analysis evidence index
 
-Outcomes analysis (SR 11-7 §V) requires that model output be compared against actual outcomes on an ongoing basis. This recipe indexes the evidence inputs the MRM analyst will join — it does not perform the analysis.
+Outcomes analysis (SR 26-2 §V (formerly SR 11-7 §V)) requires that model output be compared against actual outcomes on an ongoing basis. This recipe indexes the evidence inputs the MRM analyst will join — it does not perform the analysis.
 
 ```powershell
 $pkg = Export-FsiMRMEvidencePackage -Cloud Commercial `
@@ -862,7 +862,7 @@ $index = [pscustomobject]@{
     EvaluatorArtifact = 'foundry-evaluator-runs.json'
     ChangeFeedArtifact= 'change-feed.json'
     Status            = $pkg.Status
-    AnalystAction     = 'Join evaluator run output to production telemetry from the firm''s downstream business systems; perform outcomes analysis per SR 11-7 §V; record conclusion in MRM Committee minutes.'
+    AnalystAction     = 'Join evaluator run output to production telemetry from the firm''s downstream business systems; perform outcomes analysis per SR 26-2 §V (formerly SR 11-7 §V); record conclusion in MRM Committee minutes.'
 }
 $index | ConvertTo-Json -Depth 5 |
     Set-Content -Path (Join-Path $pkg.PackagePath 'outcomes-analysis-index.json')

--- a/docs/playbooks/control-implementations/2.6/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.6/troubleshooting.md
@@ -1,8 +1,8 @@
-# Control 2.6 — Troubleshooting: Model Risk Management (OCC 2011-12 / SR 11-7) Evidence Pipeline and Examination Readiness
+# Control 2.6 — Troubleshooting: Model Risk Management (OCC Bulletin 2026-13 / SR 26-2 — formerly OCC 2011-12 / SR 11-7) Evidence Pipeline and Examination Readiness
 
-> **Scope.** This playbook is the diagnostic companion to [Control 2.6 — Model Risk Management (OCC 2011-12 / SR 11-7)](../../../controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md). It addresses operational failure modes in the **evidence pipeline** the firm relies on to satisfy SR 11-7 — the model inventory (DSPM for AI), the underlying-model change-detection path (Copilot Studio + Message Center), the validation evidence chain (Foundry evaluators, Committee minutes, validation memos), the 17a-4(f)-compliant retention path, the publication-approval workflow in Agent 365, sovereign-cloud parity gaps, the PowerShell helpers used to produce examiner-ready inventories, and examination-readiness rehearsal.
+> **Scope.** This playbook is the diagnostic companion to [Control 2.6 — Model Risk Management (OCC Bulletin 2026-13 / SR 26-2 — formerly OCC 2011-12 / SR 11-7)](../../../controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md). It addresses operational failure modes in the **evidence pipeline** the firm relies on to satisfy SR 26-2 (formerly SR 11-7) — the model inventory (DSPM for AI), the underlying-model change-detection path (Copilot Studio + Message Center), the validation evidence chain (Foundry evaluators, Committee minutes, validation memos), the 17a-4(f)-compliant retention path, the publication-approval workflow in Agent 365, sovereign-cloud parity gaps, the PowerShell helpers used to produce examiner-ready inventories, and examination-readiness rehearsal.
 >
-> **Regulatory framing.** Reliable evidence produced by the surfaces in this control *supports compliance with* OCC Bulletin 2011-12, Federal Reserve SR 11-7, FDIC FIL-22-2017, FFIEC IT Handbook, FINRA Rule 3110 (Supervision), FINRA Rule 4511 and SEC 17a-3 / 17a-4 (Books and Records — including 17a-4(f) WORM retention of validation evidence and Committee minutes), SOX §§ 302 / 404 (ICFR documentation of AI controls), GLBA 501(b), and NYDFS 23 NYCRR 500 where AI agents touch covered customer information. FINRA Regulatory Notice 25-07 (AI Tools) is referenced **as RFC / contextual only** and is not cited as an enforceable rule. The Microsoft surfaces described here **support** the firm's MRM program; they **do not replace** the firm's Model Risk Management Committee, the independent validation function, the effective-challenge process, three-lines-of-defense governance, or registered-principal supervisory review under FINRA Rule 3110.
+> **Regulatory framing.** Reliable evidence produced by the surfaces in this control *supports compliance with* OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), Federal Reserve SR 26-2 (formerly SR 11-7), FDIC FIL-22-2017, FFIEC IT Handbook, FINRA Rule 3110 (Supervision), FINRA Rule 4511 and SEC 17a-3 / 17a-4 (Books and Records — including 17a-4(f) WORM retention of validation evidence and Committee minutes), SOX §§ 302 / 404 (ICFR documentation of AI controls), GLBA 501(b), and NYDFS 23 NYCRR 500 where AI agents touch covered customer information. FINRA Regulatory Notice 25-07 (AI Tools) is referenced **as RFC / contextual only** and is not cited as an enforceable rule. The Microsoft surfaces described here **support** the firm's MRM program; they **do not replace** the firm's Model Risk Management Committee, the independent validation function, the effective-challenge process, three-lines-of-defense governance, or registered-principal supervisory review under FINRA Rule 3110.
 >
 > **Audience.** Power Platform Admin, Purview Compliance Admin, AI Administrator, Compliance Officer, AI Governance Lead, Model Risk Manager, and second-line MRM staff supporting the firm's response to internal audit, examiner pulls, and Committee inquiries.
 >
@@ -11,7 +11,7 @@
 ---
 
 !!! warning "Non-Substitution — Tooling Supports MRM, It Does Not Replace It"
-    Every diagnostic, helper, and remediation step in this playbook produces or repairs **evidence**. None of them performs validation, exercises effective challenge, or makes a model-tiering or approval decision. Those judgments are reserved to the firm's Model Risk Management Committee, the independent validation function (organizationally separate from the model owner per SR 11-7 §V), and registered-principal supervision under FINRA Rule 3110. Any examiner-facing communication arising from an incident in this playbook must be coordinated through Compliance and Legal — **not** by individual administrators acting on their own.
+    Every diagnostic, helper, and remediation step in this playbook produces or repairs **evidence**. None of them performs validation, exercises effective challenge, or makes a model-tiering or approval decision. Those judgments are reserved to the firm's Model Risk Management Committee, the independent validation function (organizationally separate from the model owner per SR 26-2 §V (formerly SR 11-7 §V)), and registered-principal supervision under FINRA Rule 3110. Any examiner-facing communication arising from an incident in this playbook must be coordinated through Compliance and Legal — **not** by individual administrators acting on their own.
 
 ---
 
@@ -111,13 +111,13 @@ Before taking any remediation action recorded in this playbook:
 
 - **No subscription to vendor change signals.** The Microsoft 365 Message Center, the Power Platform release plan, and the Copilot Studio "What's new" feed are not routed to a monitored mailbox / Teams channel staffed by the AI Administrator and the Model Risk Manager.
 - **Agent Card records "Copilot Studio default" rather than the specific model and version.** When the default rolls forward, the Agent Card silently changes meaning.
-- **No change-management gate** treating an underlying-model change as a model change under SR 11-7 §VI.
+- **No change-management gate** treating an underlying-model change as a model change under SR 26-2 §VI (formerly SR 11-7 §VI).
 
 **Resolution.**
 
 1. **Subscribe vendor change signals to a monitored mailbox.** Route the Microsoft 365 Message Center, Power Platform release plan, and Copilot Studio release notes to a shared mailbox / Teams channel with the AI Administrator, AI Governance Lead, Model Risk Manager, and second-line MRM as members. Document the subscription owners and the SLA for triage of model-impacting messages (recommended: 1 business day).
 2. **Update Agent Card schema.** Require the Agent Card to record **specific underlying model and version** (e.g., `gpt-5-2026-03`, not `Copilot Studio default`). Re-issue Agent Cards for every in-scope agent in the inventory.
-3. **Treat the migration as a model change.** Under SR 11-7 §VI, a vendor-driven default-model migration is a model change. Open a change ticket per agent, perform impact assessment proportionate to tier (Tier 1: full re-validation; Tier 2: abbreviated re-validation; Tier 3: documented review), and obtain MRM Committee disposition.
+3. **Treat the migration as a model change.** Under SR 26-2 §VI (formerly SR 11-7 §VI), a vendor-driven default-model migration is a model change. Open a change ticket per agent, perform impact assessment proportionate to tier (Tier 1: full re-validation; Tier 2: abbreviated re-validation; Tier 3: documented review), and obtain MRM Committee disposition.
 4. **Backfill evidence.** For the migration that took effect without prior assessment, document the gap in the Committee minutes, the date the firm became aware, the post-fact impact assessment, and any compensating monitoring (e.g., enhanced Foundry evaluator cadence for the next monitoring period).
 
 **Verification.**
@@ -132,7 +132,7 @@ Before taking any remediation action recorded in this playbook:
 
 ## §3 Issue 3 — Independent Validation Challenged Because Validator Reports to Model Owner
 
-**Symptom.** During an examination, internal audit, or Committee review, a finding is raised that the validator who signed the validation memo for one or more agents reports — directly or via dotted line — to the model owner / model developer. SR 11-7 §V independence test failed.
+**Symptom.** During an examination, internal audit, or Committee review, a finding is raised that the validator who signed the validation memo for one or more agents reports — directly or via dotted line — to the model owner / model developer. SR 26-2 §V (formerly SR 11-7 §V) independence test failed.
 
 **Root causes (typical).**
 
@@ -142,7 +142,7 @@ Before taking any remediation action recorded in this playbook:
 
 **Resolution.**
 
-1. **Re-route validators to second-line MRM.** Reassign the validation function to personnel organizationally and functionally separate from the model owner / developer (SR 11-7 §V). Internal second-line MRM staff can satisfy independence; third-party engagement is one way to demonstrate it but is **not required** and is **not equivalent** to the regulatory independence test.
+1. **Re-route validators to second-line MRM.** Reassign the validation function to personnel organizationally and functionally separate from the model owner / developer (SR 26-2 §V (formerly SR 11-7 §V)). Internal second-line MRM staff can satisfy independence; third-party engagement is one way to demonstrate it but is **not required** and is **not equivalent** to the regulatory independence test.
 2. **Document organizational independence in the MRM charter.** Update the firm's Model Risk Management policy / charter to explicitly state: (a) the reporting line of the validation function, (b) that validators have authority and competence to challenge the model, and (c) the prohibition on validators sitting in the same reporting chain as the model owner. Obtain MRM Committee approval and Compliance sign-off.
 3. **Re-validate affected agents.** For every agent whose validation is challenged, perform a new validation by an organizationally independent validator. Retain both memos: the original (with the noted independence finding) and the re-validation, with a cover memo explaining the remediation. Do not delete the original.
 4. **Retain remediation evidence.** Route the original memo, the independence finding, the charter update, the re-validation memo, and the Committee disposition to the 17a-4(f)-compliant retention path (see [§7](#7-issue-7-validation-evidence-retention-not-17a-4f-compliant)).
@@ -159,7 +159,7 @@ Before taking any remediation action recorded in this playbook:
 
 ## §4 Issue 4 — Anthropic Claude (or Other Vendor Model) Selected Without Vendor-Model Assessment
 
-**Symptom.** Review of an Agent Card or Copilot Studio model-selection screen shows an agent configured to use a third-party / vendor model (for example, Anthropic Claude where available in the firm's tenant) without a documented vendor-model assessment. SR 11-7 §V vendor-model governance gap.
+**Symptom.** Review of an Agent Card or Copilot Studio model-selection screen shows an agent configured to use a third-party / vendor model (for example, Anthropic Claude where available in the firm's tenant) without a documented vendor-model assessment. SR 26-2 §V (formerly SR 11-7 §V) vendor-model governance gap.
 
 **Root causes (typical).**
 
@@ -170,7 +170,7 @@ Before taking any remediation action recorded in this playbook:
 **Resolution.**
 
 1. **Quarantine or dispose.** Pending assessment, the MRM Committee may direct the agent owner to either (a) revert to a pre-approved model on the firm's approved-model list, or (b) restrict the agent to Zone 1 / non-production use until assessment completes. Record the disposition.
-2. **Perform post-hoc vendor-model assessment.** Apply the firm's vendor-model assessment under SR 11-7 §V — covering the vendor's model documentation, training-data disclosures, evaluation results, sovereign-cloud availability, terms-of-service review, data-handling commitments, and the vendor's incident-disclosure history. Coordinate with Vendor Risk Management (Control 2.7).
+2. **Perform post-hoc vendor-model assessment.** Apply the firm's vendor-model assessment under SR 26-2 §V (formerly SR 11-7 §V) — covering the vendor's model documentation, training-data disclosures, evaluation results, sovereign-cloud availability, terms-of-service review, data-handling commitments, and the vendor's incident-disclosure history. Coordinate with Vendor Risk Management (Control 2.7).
 3. **MRM Committee disposition.** The Committee renders an explicit disposition: approved / approved-with-conditions / not approved. Disposition, conditions, and effective dates are recorded in Committee minutes and routed to retention.
 4. **Update Agent Card and approved-model list.** Update the Agent Card to record the specific vendor model and version, the assessment reference, and the Committee disposition. Update the firm's approved-model list and re-publish to model owners.
 5. **Add a technical guardrail (forward-looking).** Where supported, configure Power Platform DLP and / or the Agent 365 governance template so that selection of a non-approved vendor model in Zone 2 / 3 either blocks publish or routes through an approval workflow (see [Issue 8](#8-issue-8-agent-365-publication-approval-workflow-not-blocking-publish)).
@@ -187,7 +187,7 @@ Before taking any remediation action recorded in this playbook:
 
 ## §5 Issue 5 — Foundry Evaluator Runs Missing for Tier 1 Agent
 
-**Symptom.** A Tier 1 agent has no Azure AI Foundry evaluator runs in the current monitoring period, or the most recent evaluator run is older than the cadence specified in the firm's MRM policy. The outcomes-analysis pillar of SR 11-7 has an evidence gap.
+**Symptom.** A Tier 1 agent has no Azure AI Foundry evaluator runs in the current monitoring period, or the most recent evaluator run is older than the cadence specified in the firm's MRM policy. The outcomes-analysis pillar of SR 26-2 (formerly SR 11-7) has an evidence gap.
 
 **Root causes (typical).**
 
@@ -219,7 +219,7 @@ Before taking any remediation action recorded in this playbook:
 
 ## §6 Issue 6 — Effective-Challenge Evidence Weak: Committee Minutes Generic
 
-**Symptom.** Internal audit or examiner review finds Committee minutes that record approvals in generic terms ("the Committee reviewed and approved") without capturing the specific challenge questions raised, validator responses, disposition rationale, dissenting views, or follow-up actions. Effective-challenge evidence under SR 11-7 is weak.
+**Symptom.** Internal audit or examiner review finds Committee minutes that record approvals in generic terms ("the Committee reviewed and approved") without capturing the specific challenge questions raised, validator responses, disposition rationale, dissenting views, or follow-up actions. Effective-challenge evidence under SR 26-2 (formerly SR 11-7) is weak.
 
 **Root causes (typical).**
 
@@ -237,7 +237,7 @@ Before taking any remediation action recorded in this playbook:
     - **Follow-up actions** with owner, due date, and the agenda item where closure will be reported.
 2. **Pre-meeting challenge package.** Require the secretary to circulate a challenge package in advance of the meeting (validation memo, Foundry evaluator results, prior findings, open follow-ups). Capture in the minutes which materials were reviewed.
 3. **Re-issue prior minutes only on Legal direction.** Do not retroactively edit historical minutes. If a historical minute is materially incomplete, file a **supplemental memo** with the dated correction, signed by the Committee Chair, and route both the original and the supplement to retention.
-4. **Train the secretary.** Brief the Committee secretary on the new template and the SR 11-7 effective-challenge standard. Record the training as evidence of remediation.
+4. **Train the secretary.** Brief the Committee secretary on the new template and the SR 26-2 (formerly SR 11-7) effective-challenge standard. Record the training as evidence of remediation.
 
 **Verification.**
 
@@ -408,7 +408,7 @@ Before taking any remediation action recorded in this playbook:
 
 ## §12 Issue 12 — Examiner Asks for Inventory of In-Scope Agents and Firm Cannot Produce in Real Time
 
-**Symptom.** A regulator (OCC, Federal Reserve, SEC, FINRA, FDIC, NYDFS) requests, during an examination, an inventory of AI agents the firm treats as models under SR 11-7. The firm cannot produce the inventory within the requested window (typically same-day or next business day for routine pulls). Process and tooling gap.
+**Symptom.** A regulator (OCC, Federal Reserve, SEC, FINRA, FDIC, NYDFS) requests, during an examination, an inventory of AI agents the firm treats as models under SR 26-2 (formerly SR 11-7). The firm cannot produce the inventory within the requested window (typically same-day or next business day for routine pulls). Process and tooling gap.
 
 **Root causes (typical).**
 
@@ -441,7 +441,7 @@ The matrix below describes **when** to escalate and to **whom**. Substantive MRM
 | Trigger | Escalate To | Purpose |
 |---|---|---|
 | Tier 1 agent in production with missing or stale validation evidence | **MRM Committee** (Chair + Model Risk Manager) | Validation disposition; quarantine or compensating-control direction |
-| Validator-independence finding (SR 11-7 §V) | **MRM Committee** + **Compliance Officer** | Charter remediation; re-validation direction |
+| Validator-independence finding (SR 26-2 §V (formerly SR 11-7 §V)) | **MRM Committee** + **Compliance Officer** | Charter remediation; re-validation direction |
 | Vendor model in production without assessment | **MRM Committee** + **Vendor Risk Management** (Control 2.7) | Vendor-model assessment; disposition |
 | Material model change (vendor-driven default migration) detected post-fact for Tier 1 | **MRM Committee** + **Compliance Officer** | Impact assessment; disclosure decision |
 | 17a-4(f) retention gap on validation evidence or Committee minutes | **Compliance Officer** + **Records Management** | Books-and-records remediation; potential self-disclosure decision |
@@ -477,9 +477,9 @@ The matrix below describes **when** to escalate and to **whom**. Substantive MRM
 
 **External references.**
 
-- OCC Bulletin 2011-12 — Sound Practices for Model Risk Management
-- Federal Reserve SR 11-7 — Supervisory Guidance on Model Risk Management
-- FDIC FIL-22-2017 — FDIC adoption of OCC 2011-12
+- OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) — Sound Practices for Model Risk Management
+- Federal Reserve SR 26-2 (formerly SR 11-7) — Supervisory Guidance on Model Risk Management
+- FDIC FIL-22-2017 — FDIC adoption of OCC Bulletin 2026-13 (formerly OCC 2011-12)
 - FFIEC IT Examination Handbook — Management; Information Security
 - FINRA Rule 3110 (Supervision); FINRA Rule 4511 (Books and Records)
 - SEC Rule 17a-3 / 17a-4 (Recordkeeping; 17a-4(f) WORM retention)

--- a/docs/playbooks/control-implementations/2.6/verification-testing.md
+++ b/docs/playbooks/control-implementations/2.6/verification-testing.md
@@ -1,6 +1,6 @@
-# Verification & Testing — Control 2.6: Model Risk Management (OCC 2011-12 / SR 11-7)
+# Verification & Testing — Control 2.6: Model Risk Management (OCC Bulletin 2026-13 / SR 26-2 — formerly OCC 2011-12 / SR 11-7)
 
-> **Examiner-defensible verification package** for [Control 2.6 — Model Risk Management Alignment with OCC 2011-12 / SR 11-7](../../../controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md). This playbook produces, signs, and retains the artifacts required to demonstrate to the OCC, Federal Reserve, FDIC, NYDFS, FINRA, SEC, and Internal Audit that the firm's **Model Risk Management program** is operating with respect to the AI agents in scope — not that Microsoft tooling is configured.
+> **Examiner-defensible verification package** for [Control 2.6 — Model Risk Management Alignment with OCC Bulletin 2026-13 / SR 26-2 (formerly OCC 2011-12 / SR 11-7)](../../../controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md). This playbook produces, signs, and retains the artifacts required to demonstrate to the OCC, Federal Reserve, FDIC, NYDFS, FINRA, SEC, and Internal Audit that the firm's **Model Risk Management program** is operating with respect to the AI agents in scope — not that Microsoft tooling is configured.
 >
 > **Audience:** Compliance Officer, Internal Audit, MRM Committee secretariat, Model Risk Manager (independent validation function), AI Governance Lead. The detailed portal navigation and PowerShell automation that *produce* the evidence consumed here are in the sister [Portal Walkthrough](./portal-walkthrough.md) and [PowerShell Setup](./powershell-setup.md) playbooks; this playbook focuses on the audit and examination question: **is the firm's MRM program actually operating with these agents in it, and is the MRM Committee accepting the validation?**
 >
@@ -12,7 +12,7 @@
 
 | Convention | Value |
 |---|---|
-| Hedged regulatory language | This playbook **supports compliance with**, but does not by itself ensure compliance with, OCC Bulletin 2011-12, Federal Reserve SR 11-7, FDIC FIL-22-2017, FFIEC IT Examination Handbook, FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), FINRA Regulatory Notice 25-07 (AI Tools — RFC, contextual only), SEC Rules 17a-3 / 17a-4 (Recordkeeping), SOX §§ 302 / 404, GLBA § 501(b), CFTC Regulation 1.31, and NYDFS 23 NYCRR Part 500. A clean execution of every test in this playbook **does not guarantee** regulatory compliance, **does not replace** the firm's Model Risk Management Committee, **does not replace** independent model validation by qualified personnel, **does not replace** the effective-challenge process required by SR 11-7, and **does not replace** the registered-principal supervisory review required by FINRA Rule 3110. |
+| Hedged regulatory language | This playbook **supports compliance with**, but does not by itself ensure compliance with, OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), Federal Reserve SR 26-2 (formerly SR 11-7), FDIC FIL-22-2017, FFIEC IT Examination Handbook, FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), FINRA Regulatory Notice 25-07 (AI Tools — RFC, contextual only), SEC Rules 17a-3 / 17a-4 (Recordkeeping), SOX §§ 302 / 404, GLBA § 501(b), CFTC Regulation 1.31, and NYDFS 23 NYCRR Part 500. A clean execution of every test in this playbook **does not guarantee** regulatory compliance, **does not replace** the firm's Model Risk Management Committee, **does not replace** independent model validation by qualified personnel, **does not replace** the effective-challenge process required by SR 26-2 (formerly SR 11-7), and **does not replace** the registered-principal supervisory review required by FINRA Rule 3110. |
 | Canonical role names | Per [`docs/reference/role-catalog.md`](../../../reference/role-catalog.md). The roles relevant to this playbook are: **Model Risk Manager** (independent validation function — second line), **MRM Committee** (governance body), **AI Governance Lead**, **Compliance Officer**, **Internal Audit** (third line), **AI Administrator**, **Power Platform Admin**, **Purview Compliance Admin**, **Entra Global Reader** (read-only witness). |
 | Run identifier | Each verification cycle is tagged `MRM26-yyyyMMdd-HHmmss-<8charGuid>` and embedded in every evidence record and artifact filename. |
 | Cycle cadence | Pre-deployment (§2), quarterly ongoing-monitoring (§3), risk-commensurate outcomes-analysis (§4 — *not* fixed annual), per-vendor-event vendor-model (§5), per-MRM-Committee-meeting effective-challenge (§6), continuous retention (§7), quarterly sovereign parity (§8), per-retirement event (§9), on-demand examination rehearsal (§10). |
@@ -106,7 +106,7 @@ For **every agent classified Tier 1 or Tier 2** in §1.3, confirm the following 
 
 | Item | Expectation | Source |
 |---|---|---|
-| Classification (Tier 1 / 2 / 3 / Non-model) | Recorded with a written rationale ≥ 200 words referencing the OCC 2011-12 model definition | Model inventory record (Dataverse / SharePoint per [Portal Walkthrough §3](./portal-walkthrough.md)) |
+| Classification (Tier 1 / 2 / 3 / Non-model) | Recorded with a written rationale ≥ 200 words referencing the OCC Bulletin 2026-13 (formerly OCC 2011-12) model definition | Model inventory record (Dataverse / SharePoint per [Portal Walkthrough §3](./portal-walkthrough.md)) |
 | Classifier identity | Named individual, role, employee ID | Inventory record |
 | Classifier independence statement | "The classifier is not the model owner / developer for this agent" or, where the same person plays both roles, an explicit second-line counter-signature | Inventory record + e-signature |
 | Classification date | UTC timestamp; not back-dated more than 5 business days from approval | Inventory record version history |
@@ -133,7 +133,7 @@ Required sections (verifier checks each is present and non-empty):
 
 ### 2.3 Evidence artifact 3 — Pre-deployment validation memo
 
-The validation memo is authored by **personnel functionally independent of the model owner / developer**, per SR 11-7 § V. Internal second-line MRM staff satisfy the independence test; external assessment is one way to demonstrate independence (often used for Tier 1) but is not required and is not equivalent.
+The validation memo is authored by **personnel functionally independent of the model owner / developer**, per SR 26-2 (formerly SR 11-7) § V. Internal second-line MRM staff satisfy the independence test; external assessment is one way to demonstrate independence (often used for Tier 1) but is not required and is not equivalent.
 
 | Section | Expectation |
 |---|---|
@@ -225,7 +225,7 @@ The validator (second line, not the model owner) signs a one-page summary statin
 
 ### 4.1 Risk-commensurate cadence — not fixed annual
 
-SR 11-7 § V requires outcomes analysis at a frequency commensurate with **risk, model complexity, and change activity** — not on a fixed annual basis. The firm's model risk policy must define how cadence is set per agent. The verifier confirms the cadence is documented and being followed; the verifier does **not** opine on whether the cadence is correct.
+SR 26-2 (formerly SR 11-7) § V requires outcomes analysis at a frequency commensurate with **risk, model complexity, and change activity** — not on a fixed annual basis. The firm's model risk policy must define how cadence is set per agent. The verifier confirms the cadence is documented and being followed; the verifier does **not** opine on whether the cadence is correct.
 
 | Driver | Effect on cadence |
 |---|---|
@@ -277,9 +277,9 @@ Each Foundry evaluator run produces a record retained alongside the validation m
 
 ---
 
-## §5 Vendor-Model Governance Test (VENDOR namespace, SR 11-7 § V)
+## §5 Vendor-Model Governance Test (VENDOR namespace, SR 26-2 (formerly SR 11-7) § V)
 
-**Criterion mapping:** Control 2.6 Verification Criterion 7. SR 11-7 § V requires vendor-supplied models be validated with the same rigour as internally-developed models.
+**Criterion mapping:** Control 2.6 Verification Criterion 7. SR 26-2 (formerly SR 11-7) § V requires vendor-supplied models be validated with the same rigour as internally-developed models.
 
 ### 5.1 Vendor-event watchlist
 
@@ -327,9 +327,9 @@ For each vendor event affecting an in-scope agent, the firm produces a **vendor-
 
 ## §6 Effective-Challenge Test (CHALLENGE namespace)
 
-**Criterion mapping:** Control 2.6 Verification Criterion 5; SR 11-7 § III ("effective challenge").
+**Criterion mapping:** Control 2.6 Verification Criterion 5; SR 26-2 (formerly SR 11-7) § III ("effective challenge").
 
-> **Effective challenge is the cornerstone of SR 11-7.** Microsoft tooling cannot perform it. This test confirms that the firm's MRM Committee minutes evidence challenge questions raised by personnel **not involved in model development** for each in-scope Tier 1 agent, and that those questions were dispositioned.
+> **Effective challenge is the cornerstone of SR 26-2 (formerly SR 11-7).** Microsoft tooling cannot perform it. This test confirms that the firm's MRM Committee minutes evidence challenge questions raised by personnel **not involved in model development** for each in-scope Tier 1 agent, and that those questions were dispositioned.
 
 ### 6.1 Per-Tier-1-agent assertions
 
@@ -588,7 +588,7 @@ The cycle attestation rolls up every assertion into a single MRM cycle status:
 - [Control 1.9 — Data Retention and Deletion](../../../controls/pillar-1-security/1.9-data-retention-and-deletion-policies.md) — Retention schedule for validation evidence
 - [Control 1.10 — Communication Compliance](../../../controls/pillar-1-security/1.10-communication-compliance-monitoring.md) — Supervisory review feeding §6.2
 - [Control 2.3 — Change Management](../../../controls/pillar-2-management/2.3-change-management-and-release-planning.md) — Vendor-driven change capture for §5
-- [Control 2.7 — Vendor and Third-Party Risk Management](../../../controls/pillar-2-management/2.7-vendor-and-third-party-risk-management.md) — Vendor-model governance under SR 11-7 § V
+- [Control 2.7 — Vendor and Third-Party Risk Management](../../../controls/pillar-2-management/2.7-vendor-and-third-party-risk-management.md) — Vendor-model governance under SR 26-2 (formerly SR 11-7) § V
 - [Control 2.12 — FINRA Rule 3110 Supervision](../../../controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) — Registered-principal linkage in §6.2
 - [Control 2.16 — RAG Source Integrity Validation](../../../controls/pillar-2-management/2.16-rag-source-integrity-validation.md) — Knowledge-source integrity feeding §2.2 and §9.2
 - [Control 2.25 — Agent 365 Admin Center Governance Console](../../../controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md) — Publication / activation approval surface


### PR DESCRIPTION
# PR-B: Tier 0B regulatory hotfixes (SR 11-7 path **A** + N1 link fix + Toolkit verify)

This PR executes Tier 0B of the v3 triage plan in parallel with PR-A (which owns root surfaces / version stamps). It contains six logical commits across the chosen sweep path, the broken-link fix, and the AI tooling files. **Do not merge** until human reviewer signs off on F1 verdict + sweep direction.

---

## T0B.1 — F1 verification gate (CONFIRMED rescission)

Three authoritative sources fetched **on the day this PR was opened**:

### 1. Federal Reserve SR 26-2 (the new letter)

URL: https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm
Title: **"SR 26-2: Revised Guidance on Model Risk Management"**
Date: **April 17, 2026**

Quoted from the letter:

> The Board of Governors of the Federal Reserve System, Office of the Comptroller of the Currency (OCC), and Federal Deposit Insurance Corporation (FDIC) (the "agencies") are issuing the attached *Revised Guidance on Model Risk Management*, which **supersedes and replaces SR letter 11-7**, *Guidance on Model Risk Management* (issued April 4, 2011) and SR letter 21-8, *Interagency Statement on Model Risk Management for Bank Systems Supporting Bank Secrecy Act/Anti-Money Laundering Compliance* (issued April 9, 2021).

Footer: *Supersedes: SR letter 11-7, "Guidance on Model Risk Management" (April 4, 2011) ... SR letter 21-8, ... (April 9, 2021).*
Last Update: April 17, 2026.

### 2. Federal Reserve SR 11-7 (the old letter)

URL: https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm
**Returns HTTP 404.** The Federal Reserve has removed the predecessor URL from its site.

### 3. OCC Bulletin 2026-13 (the new bulletin)

URL: https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-13.html
Title: **"OCC Bulletin 2026-13"**
Date: **April 17, 2026**

Quoted from the bulletin:

> The Office of the Comptroller of the Currency (OCC), the Board of Governors of the Federal Reserve System (Federal Reserve Board), and the Federal Deposit Insurance Corporation (FDIC) (collectively, the agencies) are issuing updated interagency guidance and this bulletin to clarify model risk management principles, to set forth a risk-based approach to model risk management, and to **rescind prior model risk management guidance and other issuances**.
>
> ## Rescissions
> This bulletin rescinds
> - "Model Risk Management" booklet of the *Comptroller's Handbook*
> - OCC Bulletin 1997-24, "Credit Scoring Models: Examination Guidance," ...
> - **OCC Bulletin 2011-12, "Sound Practices for Model Risk Management: Supervisory Guidance on Model Risk Management"**
> - OCC Bulletin 2021-19, "Bank Secrecy Act/Anti-Money Laundering: Interagency Statement on Model Risk Management for Bank Systems Supporting BSA/AML Compliance and Request for Information"

Important new caveat in the rescission bulletin:

> **Generative AI and agentic AI models are novel and rapidly evolving. As such, they are not within the scope of this guidance.**

### Verdict

**CONFIRMED rescission/renumbering.** Both the Fed and the OCC issued superseding instruments on the same day (April 17, 2026), each explicitly displacing its predecessor. The original `sr1107.htm` URL is now a 404. **Path A (T0B.2) executed.**

The "generative AI / agentic AI out of scope" caveat is reflected in the new warning callout on the 2.6 control page; the FSI framework continues to treat AI agents as model-risk-equivalent via the broader supervisory regime (FINRA, SEC, SOX, NYDFS, GLBA, safety-and-soundness) until AI-specific agency guidance lands.

---

## T0B.2 — Path A SR-naming sweep (commit fc3387ed)

**Scope (per plan, exactly the 6 files realist counted, 82 hits):**
- `docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md`
- `docs/playbooks/control-implementations/2.6/portal-walkthrough.md`
- `docs/playbooks/control-implementations/2.6/troubleshooting.md`
- `docs/playbooks/control-implementations/2.6/verification-testing.md`
- `docs/playbooks/control-implementations/2.6/powershell-setup.md`
- `docs/images/2.6/EXPECTED.md`

**Replacement pattern** (per-occurrence parenthetical so the historical mapping is unambiguous to future readers and AI agents):
- `SR 11-7` → `SR 26-2 (formerly SR 11-7)`
- `OCC 2011-12` → `OCC Bulletin 2026-13 (formerly OCC 2011-12)`
- `OCC Bulletin 2011-12` → `OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12)`
- Section refs (`§V`, `§VI`, `Section V`) preserved with parenthetical
- `Federal Reserve` and `Fed` prefix variants handled before bare `SR 11-7` to avoid double-substitution

**Other 2.6 control changes:**
1. New `!!! warning` callout at the top of the body (after the existing warnings) following the FINRA Notice 25-07 callout pattern from `regulatory-framework.md` and `cco-quick-reference.md`. The callout cites both new sources, lists what was rescinded, calls out the **generative-AI / agentic-AI scope caveat**, and explains why the file slug stays put (link stability; rename is PR-C scope).
2. **Additional Resources** section restructured into "current (April 2026)" with a corrected OCC URL (`/bulletins/2026/bulletin-2026-13.html`) and "historical (rescinded April 2026, retained for audit-trail context)" with the 2011 OCC URL marked rescinded and a note that the predecessor `sr1107.htm` no longer resolves.
3. Explicit MkDocs anchor `{#5-vendor-model-governance-sr-11-7-v}` added to portal-walkthrough Section 5 heading so the existing TOC link `[Vendor Model Governance ...](#5-vendor-model-governance-sr-11-7-v)` continues to resolve after the heading text changed.

**File slug NOT renamed in this PR** (deferred to PR-C, conditional, per plan). The slug rename has cascade effects (manifest, CONTROL-INDEX, mkdocs nav, every cross-reference) that warrant their own PR with the dedicated acceptance gates listed in the triage plan (Skeptic R2 review item).

**Out of scope — broader SR 11-7 sweep.** A full repo grep shows 762 SR 11-7 hits across 229 files (and 965 OCC 2011-12 hits across 251 files) — the realist's count of "82 hits across 6 files" was correct *for the 2.6 control + playbooks* but the rest of the repo also still references the predecessor letter. That broader sweep is **not in T0B.2 scope**; the 2.6 hotfix gets the framework's regulatory anchor right, and the cross-cutting sweep belongs to PR-α (Examiner Regulatory Accuracy, Tier 1A) per the triage plan. The new warning callout on 2.6 explains the supersession authoritatively for readers who land on related documents in the meantime.

---

## T0B.5 — N1 broken cross-link fix (commit 0c79b128)

**File:** `docs/playbooks/control-implementations/1.13/powershell-setup.md` (line 1069 in the original)

The bullet referenced `docs/controls/pillar-1-security/1.10-customer-lockbox-and-data-residency.md`, which **does not exist** (only `1.10-communication-compliance-monitoring.md` exists at the 1.10 slot).

Replaced with the **exact interim wording specified in the triage plan**:

> Customer Lockbox and data-residency posture are currently covered in Control 2.1 Managed Environments; a dedicated Lockbox/Data Residency control decision is tracked in the v1.7 roadmap.

This wording is interim and is expected to be replaced by **PR-γ** when the Customer Lockbox sub-control lands (Tier 1A). No fake link to 2.1 was inserted (per plan instruction).

---

## T0B.6 — N9-light broken-link audit

`mkdocs build --strict` was run after each substantive change set; a single anchor breakage was introduced and immediately fixed (the `#5-vendor-model-governance-sr-11-7-v` anchor in 2.6/portal-walkthrough.md after the Section 5 heading text changed — fixed by adding an explicit `{#5-vendor-model-governance-sr-11-7-v}` MkDocs attribute in the same commit).

After all PR-B changes, **mkdocs --strict reports zero WARNING / ERROR lines.** All other "INFO" lines (unrecognized relative links, link-to-excluded-file) are pre-existing and out of scope for PR-B.

A repo-wide search for `#sr-11-7` / `#vendor-model-governance-sr-11-7` anchor references in `docs/` returned no other hits, so no additional anchors were broken by this PR's heading changes.

**No defects backlogged** specifically by T0B.6. The broader v1.6.2 link-health work remains scheduled for PR-A (root surfaces) and PR-α (regulatory accuracy bundle).

---

## T0B.7 — F2 Microsoft Agent Governance Toolkit verify-or-drop

**Reviewer claim:** A 7-package "Microsoft Agent Governance Toolkit" (Agent OS, Agent Mesh, Agent Runtime, Agent SRE, Agent Compliance, Agent Marketplace, Agent Lightning) was supposedly released April 2026.

**Sources checked:**
- `learn.microsoft.com` search for "Microsoft Agent Governance Toolkit" → no relevant hits
- `microsoft.com/security/blog` search → no hits for "Agent Governance Toolkit", "Agent Mesh", "Agent SRE", or any composite of the named packages
- `github.com/microsoft` search for "agent governance toolkit" → no matching repo
- `github.com/search?q=org:microsoft "Agent Lightning" OR "Agent Mesh" OR "Agent SRE"` → **one** match: `microsoft/agent-lightning` (~17.2k stars, Python), self-described as *"The absolute trainer to light up AI agents."* — i.e., a **training framework**, not a governance toolkit.

**Verdict:** Likely hallucinated by the reviewer; one real adjacent repo (`microsoft/agent-lightning`) exists and may be the source of name confusion, but it is not a governance toolkit and there is no evidence of a 7-package "Microsoft Agent Governance Toolkit" release. **Dropped from plan; no further action.**

This task does not gate PR-B merge regardless.

---

## T0B.8 — AI tooling files SR-naming update (commit 94766487)

Three AI tooling files each had exactly one `Target regulations:` bullet referencing `OCC 2011-12, Fed SR 11-7`:
- `.claude/claude.md`
- `.github/copilot-instructions.md`
- `AGENTS.md`

Each was updated to:

```
- **Target regulations:** ..., OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly Fed SR 11-7), ...
```

Goal: AI agents (Copilot CLI, Claude Code, Codex CLI) ingesting these context files in future sessions don't re-introduce stale SR framing when generating new control content.

**Coordination with PR-A:** PR-B's edit to `.claude/claude.md` is on **line 12** (the `Target regulations` bullet). PR-A's T0A.8 version-stamp change to the same file will land on the framework-version line elsewhere in the file. These should not conflict mechanically, but call this out in PR-A's merge so reviewers expect a clean rebase. Same situation likely for `.github/copilot-instructions.md` and `AGENTS.md` if PR-A touches their version-stamp lines.

---

## Validation status (all gates green locally)

| Gate | Result |
|---|---|
| `mkdocs build --strict` | ✅ no WARNING / ERROR |
| `python scripts/verify_controls.py` | ✅ all 78 controls present |
| `python scripts/check_manifest_doc_drift.py --check` | ✅ manifest=78, CONTROL-INDEX=78, mkdocs nav=78 |
| `python scripts/verify_language_rules.py` | ✅ no prohibited language |
| `python scripts/verify_version_stamps.py --check` | ✅ no non-allowlisted drift |
| `ruff check assessment scripts` | ✅ all checks passed |
| `pytest assessment/tests/` | ✅ 114 passed |

---

## Files changed

| Task | File |
|---|---|
| T0B.2 | `docs/controls/pillar-2-management/2.6-model-risk-management-alignment-with-occ-2011-12-sr-11-7.md` |
| T0B.2 | `docs/playbooks/control-implementations/2.6/portal-walkthrough.md` |
| T0B.2 | `docs/playbooks/control-implementations/2.6/troubleshooting.md` |
| T0B.2 | `docs/playbooks/control-implementations/2.6/verification-testing.md` |
| T0B.2 | `docs/playbooks/control-implementations/2.6/powershell-setup.md` |
| T0B.2 | `docs/images/2.6/EXPECTED.md` |
| T0B.5 | `docs/playbooks/control-implementations/1.13/powershell-setup.md` |
| T0B.8 | `.claude/claude.md` |
| T0B.8 | `.github/copilot-instructions.md` |
| T0B.8 | `AGENTS.md` |

**No edits to PR-A's scope files** (root README.md, DISCLAIMER.md, framework footer stamps, changelog/, mkdocs.yml, prod-smoke.yml).

---

## Follow-ups

- **PR-α (Tier 1A)** owns the broader 762-hit / 229-file SR 11-7 → SR 26-2 sweep across non-2.6 surfaces.
- **PR-C (conditional)** owns the 2.6 file slug rename + cascade once this PR lands and reviewers approve the SR-naming approach.
- **PR-γ (Tier 1A)** will replace the T0B.5 interim wording when the Customer Lockbox sub-control lands.

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
