### PR TITLE
test(e2e): align 6 @regression specs with intentional AS8 + AS18b SPA contract changes

### DIFF
--- a/tests/e2e/03-state-restoration-core.spec.mjs
+++ b/tests/e2e/03-state-restoration-core.spec.mjs
@@ -132,8 +132,13 @@ test.describe("state restoration core @regression", () => {
     expect(beforeParsed.responses["1.3"].answer).toBe("no");
     expect(beforeParsed.responses["1.4"].answer).toBe("na");
 
-    // Cold reload.
-    await page.reload({ waitUntil: "domcontentloaded" });
+    // Cold visit — simulate the customer "close tab, return later via fresh URL"
+    // flow. Uses page.goto("/assessment/") instead of page.reload() because AS8's
+    // URL routing (?step= query) preserves the current step across page.reload(),
+    // which would auto-resume to phase1 and bypass the welcome-list resume flow
+    // this test was written to exercise. The localStorage slot survives both
+    // navigation forms — the byte-diff assertion below holds either way.
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
     await page
       .locator("#assessment-app")
       .getByRole("heading", { name: "Governance Readiness Assessment" })

--- a/tests/e2e/06-export-json.spec.mjs
+++ b/tests/e2e/06-export-json.spec.mjs
@@ -18,11 +18,16 @@ import {
  * the export envelope, filename pattern, and `_metadata.exportedAt`
  * determinism via freezeTime.
  *
- * SPA contract (assessment-app.js exportJSON, ~L3790):
- *   filename = sanitize(state.assessmentName || "assessment") + ".json"
+ * SPA contract (assessment-app.js exportJSON, ~L4025):
+ *   filename = _truncateFilename(_sanitizeFilenameStem(state.assessmentName)) + ".json"
  *   where assessmentName = `<org> — <YYYY-MM-DD>` (Begin Assessment).
- *   The sanitize step replaces every char outside [a-zA-Z0-9-_] with "-",
- *   so "Acme Bank — 2026-01-15" becomes "Acme-Bank---2026-01-15".
+ *   AS18b's _sanitizeFilenameStem (closes F-RUNTIME-EXPORT-FILENAME-UNICODE-STRIPPED-01)
+ *   preserves Unicode letters & punctuation (e.g. "Société Générale" → "Société-Générale")
+ *   and only strips Windows-illegal chars + control chars + bidi overrides + path
+ *   separators. Em-dash (U+2014) is punctuation, not whitespace, so it survives the
+ *   strip pass; the surrounding " — " collapses via \s+ → "-" giving "-—-".
+ *   So "Acme Bank — 2026-01-15" becomes "Acme-Bank-—-2026-01-15".
+ *   Cross-reference: tests/spa/filename-sanitizer.test.mjs L144-145.
  *
  * Envelope contract (additive — original state keys remain at top):
  *   _metadata          { exportSchemaVersion:1, schemaType:"full",
@@ -60,8 +65,10 @@ test.describe("export JSON @regression", () => {
 
     // Filename pattern: assessmentName sanitized + ".json".
     // assessmentName = "Acme Bank — 2026-01-15" (em-dash) →
-    //   sanitize → "Acme-Bank---2026-01-15.json".
-    expect(suggestedName).toBe("Acme-Bank---2026-01-15.json");
+    //   AS18b _sanitizeFilenameStem preserves Unicode punctuation →
+    //   "Acme-Bank-—-2026-01-15.json" (em-dash retained between dashes).
+    // See tests/spa/filename-sanitizer.test.mjs L144-145 for the unit-level contract.
+    expect(suggestedName).toBe("Acme-Bank-\u2014-2026-01-15.json");
 
     const rawText = readFileSync(path, "utf8");
     const parsed = JSON.parse(rawText); // throws if invalid JSON

--- a/tests/e2e/11b-cold-start-full-import.spec.mjs
+++ b/tests/e2e/11b-cold-start-full-import.spec.mjs
@@ -93,7 +93,11 @@ test.describe("cold-start full-assessment import @regression", () => {
     expect(slot.responses["1.7"]?.answer).toBe("no");
 
     // -- Phase 2: PERSISTENCE ACROSS RELOAD ----------------------------
-    await page.reload({ waitUntil: "domcontentloaded" });
+    // Use page.goto("/assessment/") instead of page.reload() to simulate the
+    // customer "fresh-URL visit" flow that lands on welcome. AS8's URL routing
+    // would otherwise preserve ?step= across page.reload() and auto-resume into
+    // phase1, bypassing the welcome-list resume probe below.
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
     await page
       .locator("#assessment-app")
       .getByRole("heading", { name: "Governance Readiness Assessment" })

--- a/tests/e2e/14-fetch-failure.spec.mjs
+++ b/tests/e2e/14-fetch-failure.spec.mjs
@@ -155,9 +155,12 @@ test.describe("fetch failure resilience @regression", () => {
     const parsed = JSON.parse(stateOffline);
     expect(parsed.scoping.organizationName).toBe("Offline Bank");
 
-    // Restore network and reload — assessment must be resumable.
+    // Restore network and visit fresh — assessment must be resumable.
+    // page.goto("/assessment/") instead of page.reload() so AS8's URL routing
+    // doesn't auto-resume back into the offline-saved phase1 step (which would
+    // bypass the welcome-list "Previous Assessments" surface this test asserts).
     await context.setOffline(false);
-    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
     await page
       .getByRole("button", { name: "Start New Assessment" })
       .waitFor({ timeout: 15_000 });

--- a/tests/e2e/18-autopop-runs-once.spec.mjs
+++ b/tests/e2e/18-autopop-runs-once.spec.mjs
@@ -83,9 +83,11 @@ test.describe("autofill idempotence @regression", () => {
     });
     expect(afterRoundTrip).toEqual(baseline);
 
-    // Reload — saved state should rehydrate and Phase 1 must show
-    // identical answer set without any re-fire.
-    await page.reload({ waitUntil: "domcontentloaded" });
+    // Fresh visit — saved state should rehydrate and Phase 1 must show
+    // identical answer set without any re-fire. Uses page.goto instead of
+    // page.reload because AS8's URL routing would auto-resume to results
+    // step (the saved state's last step) and bypass the manual resume flow.
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
     await page
       .getByRole("button", { name: "Start New Assessment" })
       .waitFor({ timeout: 15_000 });

--- a/tests/e2e/22-edge-empty-data.spec.mjs
+++ b/tests/e2e/22-edge-empty-data.spec.mjs
@@ -54,8 +54,11 @@ test.describe("edge-empty persona @regression", () => {
     // Force a save so the assessment is on the saved-list when we reload.
     await page.evaluate(() => window.__assessmentApp.saveToStorage());
 
-    // (2) Reload + resume; authored count must still be 0.
-    await page.reload({ waitUntil: "domcontentloaded" });
+    // (2) Fresh visit + manual resume; authored count must still be 0.
+    // Uses page.goto("/assessment/") rather than page.reload() because AS8's
+    // URL routing preserves ?step= across reload and would auto-resume into
+    // phase1, bypassing the welcome-list "Resume" affordance this test exercises.
+    await page.goto("/assessment/", { waitUntil: "domcontentloaded" });
     await page
       .getByRole("button", { name: "Start New Assessment" })
       .waitFor({ timeout: 15_000 });


### PR DESCRIPTION
## Summary

Hotfix for 6 audit-introduced `@regression` failures surfaced by the post-merge `e2e/full` workflow on `main` after PR #255 (`d05b2131`). Smoke gate didn't catch these because they're `@regression`-tagged (full e2e runs only on push-to-main / schedule / `e2e-full` label, not PR checks).

## Root cause

All 6 failures trace to **two intentional behavioral changes** in the audit. The SPA code is correct; the e2e tests were stale.

### 1. AS18b filename sanitizer (1 spec)

Closes [F-RUNTIME-EXPORT-FILENAME-UNICODE-STRIPPED-01]. Replaced legacy ASCII allow-list `/[^a-zA-Z0-9-_]/g → "-"` with `_sanitizeFilenameStem`, a Unicode-preserving block-list. Em-dash (U+2014) is punctuation, not whitespace, and not in the strip set, so the autofill format `<org> — <ISODate>` now produces `Acme-Bank-—-2026-01-15.json` (em-dash retained).

The new contract is asserted at the **unit level** in [`tests/spa/filename-sanitizer.test.mjs:144-145`](https://github.com/judeper/FSI-AgentGov/blob/main/tests/spa/filename-sanitizer.test.mjs#L144-L145); the e2e spec at line 64 was the only site still asserting the legacy contract.

| Spec | Old expectation | New expectation |
|---|---|---|
| `06-export-json.spec.mjs:64` | `Acme-Bank---2026-01-15.json` | `Acme-Bank-—-2026-01-15.json` |

### 2. AS8 SPA URL routing (5 specs)

Closes [F-SPA-BACK-NO-ROUTING-01]. Preserves the current step in `?step=` query param across navigation. After AS8, `page.reload({ waitUntil: "domcontentloaded" })` from `/assessment/?step=phase1` no longer falls back to welcome — it auto-resumes phase1 (the desired UX improvement that fixes the white-screen back-button bug).

5 tests authored pre-AS8 (PR #159, `00b8ebab`) used `page.reload()` to simulate the customer "fresh URL visit" flow that lands on welcome. After AS8, that flow is accurately simulated by `page.goto("/assessment/", ...)` (no step query) instead of `page.reload()`.

| Spec | Failing wait |
|---|---|
| `03-state-restoration-core.spec.mjs:139` | `Governance Readiness Assessment` heading |
| `11b-cold-start-full-import.spec.mjs:99` | `Governance Readiness Assessment` heading |
| `14-fetch-failure.spec.mjs:162` | `Start New Assessment` button |
| `18-autopop-runs-once.spec.mjs:90` | `Start New Assessment` button |
| `22-edge-empty-data.spec.mjs:60` | `Start New Assessment` button |

## Changes

Test logic only. No SPA changes. No new dependencies. No new CI workflows.

- `tests/e2e/06-export-json.spec.mjs` — update header doc + filename assertion + cross-reference unit-level contract for traceability
- `tests/e2e/{03,11b,14,18,22}` — replace `page.reload(...)` with `page.goto("/assessment/", ...)` at each failing call site, with inline comment explaining AS8 routing and why `goto` is the correct simulation of the test's intended customer flow

Net diff: **+40 / -16 across 6 files**.

## Local validation

| Suite | Result |
|---|---|
| 6 originally-failing specs | **6/6 GREEN** |
| 15 sibling regression specs (03-22 family) | **15/15 GREEN** |
| Smoke set (`@smoke`, 12 specs) | **12/12 GREEN** (3 transient `ERR_CONNECTION_REFUSED` resolved with `--workers=1`; Windows http.server flake, not test/code) |
| `tests/spa/filename-sanitizer.test.mjs` (Vitest unit) | **50/50 GREEN** |

## Why test-side fix, not SPA-side fix

Both behavioral changes are intentional improvements:

- **AS18b sanitizer**: per-control [Unicode UX requirement](https://github.com/judeper/FSI-AgentGov/blob/main/tests/spa/filename-sanitizer.test.mjs) (international org names like "Société Générale", العربية, 中文) — reverting would re-mojibake them.
- **AS8 routing**: the back-button white-screen bug it fixes is a real customer-facing defect ([F-SPA-BACK-NO-ROUTING-01](https://github.com/judeper/FSI-AgentGov/blob/main/.planning/.../findings-register-v2.txt)). Reverting would re-introduce the white-screen.

The legacy test mechanisms (`page.reload()` to land on welcome) no longer accurately model the customer flow they were written to test (welcome-list resume from a fresh tab/URL). `page.goto("/assessment/")` is the precise simulation.

## Coverage of the new AS8 reload-auto-resume behavior

Coverage exists implicitly via the 6 failing tests (which proved AS8 preserves URL state across `page.reload`). A dedicated explicit assertion can be added as a follow-up if desired, but is not blocking — the AS8 behavior is now verifiably correct on `main`.

🤖 Generated with [Claude Opus 4.7](https://github.com/copilot/cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
