### PR TITLE
chore(engine): P3 hygiene — collector -WhatIf support + driver-rollup signal (Phase 4c)

### DIFF
--- a/assessment/collectors/Collect-Frontier.ps1
+++ b/assessment/collectors/Collect-Frontier.ps1
@@ -49,7 +49,7 @@
 
 #Requires -Version 7.0
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]
     [string] $OutputFile,

--- a/assessment/collectors/Collect-Graph.ps1
+++ b/assessment/collectors/Collect-Graph.ps1
@@ -43,7 +43,7 @@
 
 #Requires -Version 7.0
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
@@ -75,6 +75,21 @@ if (-not (Test-Path $collectedDir)) {
 }
 $outputFile = Join-Path $collectedDir 'graph.json'
 
+function Invoke-CollectorOperation {
+    param(
+        [Parameter(Mandatory)][string]$Target,
+        [Parameter(Mandatory)][string]$Action,
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Target, $Action)) {
+        Write-Verbose "Skipping $Action on $Target because -WhatIf was specified."
+        return $null
+    }
+
+    & $ScriptBlock
+}
+
 # ─── Module Imports ──────────────────────────────────────────────────
 Import-Module Microsoft.Graph.Authentication    -ErrorAction Stop
 Import-Module Microsoft.Graph.Identity.SignIns  -ErrorAction Stop
@@ -88,7 +103,9 @@ $requiredScopes = @('Policy.Read.All', 'Group.Read.All', 'Directory.Read.All', '
 Write-Verbose "Authenticating to Microsoft Graph in $AuthMode mode..."
 
 if ($AuthMode -eq 'Interactive') {
-    Connect-MgGraph -TenantId $TenantId -Scopes $requiredScopes -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'Connect to Microsoft Graph (interactive)' -ScriptBlock {
+        Connect-MgGraph -TenantId $TenantId -Scopes $requiredScopes -ErrorAction Stop
+    } | Out-Null
 }
 else {
     if (-not $ClientId -or -not $ClientSecret) {
@@ -102,10 +119,12 @@ else {
         grant_type    = 'client_credentials'
     }
     # Use Connect-MgGraph with client secret credential
-    Connect-MgGraph -TenantId $TenantId -ClientSecretCredential $credential -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'Connect to Microsoft Graph (service principal)' -ScriptBlock {
+        Connect-MgGraph -TenantId $TenantId -ClientSecretCredential $credential -ErrorAction Stop
+    } | Out-Null
 }
 
-Write-Verbose "Microsoft Graph authentication successful."
+Write-Verbose "Microsoft Graph authentication stage complete."
 
 # ═══════════════════════════════════════════════════════════════════════
 # Section 1: Conditional Access Policies
@@ -115,7 +134,9 @@ Write-Verbose "Microsoft Graph authentication successful."
 $conditionalAccessPolicies = $null
 try {
     Write-Verbose "Section 1: Collecting Conditional Access policies..."
-    $rawPolicies = Get-MgIdentityConditionalAccessPolicy -All -ErrorAction Stop
+    $rawPolicies = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'List conditional access policies' -ScriptBlock {
+        Get-MgIdentityConditionalAccessPolicy -All -ErrorAction Stop
+    }
     $conditionalAccessPolicies = $rawPolicies | ForEach-Object {
         [PSCustomObject]@{
             Id                    = $_.Id
@@ -148,14 +169,18 @@ catch {
 $fsiSecurityGroups = $null
 try {
     Write-Verbose "Section 2: Collecting FSI-Agent-* security groups..."
-    $rawGroups = Get-MgGroup -Filter "startsWith(displayName,'FSI-Agent-')" -All `
-        -Property Id, DisplayName, SecurityEnabled, GroupTypes, MembershipRule -ErrorAction Stop
+    $rawGroups = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'List FSI-Agent security groups' -ScriptBlock {
+        Get-MgGroup -Filter "startsWith(displayName,'FSI-Agent-')" -All `
+            -Property Id, DisplayName, SecurityEnabled, GroupTypes, MembershipRule -ErrorAction Stop
+    }
 
     $fsiSecurityGroups = foreach ($grp in $rawGroups) {
         # Get member count via a separate call
         $memberCount = 0
         try {
-            $members = Get-MgGroupMember -GroupId $grp.Id -All -ErrorAction Stop
+            $members = Invoke-CollectorOperation -Target $grp.Id -Action 'List group members' -ScriptBlock {
+                Get-MgGroupMember -GroupId $grp.Id -All -ErrorAction Stop
+            }
             $memberCount = @($members).Count
         }
         catch {
@@ -190,7 +215,9 @@ try {
     $ibModule = Get-Module -ListAvailable -Name ExchangeOnlineManagement -ErrorAction SilentlyContinue
     if ($ibModule) {
         Import-Module ExchangeOnlineManagement -ErrorAction Stop
-        $rawIb = Get-InformationBarrierPolicy -ErrorAction Stop
+        $rawIb = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'List information barrier policies' -ScriptBlock {
+            Get-InformationBarrierPolicy -ErrorAction Stop
+        }
         $informationBarriers = $rawIb | ForEach-Object {
             [PSCustomObject]@{
                 Identity     = $_.Identity
@@ -224,11 +251,15 @@ try {
     $targetRoleNames = @('Power Platform Administrator', 'Dynamics 365 Administrator')
 
     # Get all role definitions to map IDs to names
-    $roleDefinitions = Get-MgRoleManagementDirectoryRoleDefinition -All -ErrorAction Stop
+    $roleDefinitions = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'List privileged role definitions' -ScriptBlock {
+        Get-MgRoleManagementDirectoryRoleDefinition -All -ErrorAction Stop
+    }
     $targetRoles = $roleDefinitions | Where-Object { $targetRoleNames -contains $_.DisplayName }
 
     $privilegedRoleAssignments = foreach ($role in $targetRoles) {
-        $assignments = Get-MgRoleManagementDirectoryRoleAssignment -Filter "roleDefinitionId eq '$($role.Id)'" -All -ErrorAction Stop
+        $assignments = Invoke-CollectorOperation -Target $role.Id -Action 'List privileged role assignments' -ScriptBlock {
+            Get-MgRoleManagementDirectoryRoleAssignment -Filter "roleDefinitionId eq '$($role.Id)'" -All -ErrorAction Stop
+        }
         foreach ($assignment in $assignments) {
             [PSCustomObject]@{
                 RoleDefinitionId   = $role.Id
@@ -262,7 +293,9 @@ try {
 
     $copilotServicePrincipals = foreach ($filterExpr in $filterConditions) {
         try {
-            $sps = Get-MgServicePrincipal -Filter $filterExpr -All -ErrorAction Stop
+            $sps = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action "List service principals matching filter $filterExpr" -ScriptBlock {
+                Get-MgServicePrincipal -Filter $filterExpr -All -ErrorAction Stop
+            }
             foreach ($sp in $sps) {
                 [PSCustomObject]@{
                     AppId          = $sp.AppId
@@ -294,27 +327,34 @@ catch {
 $tenantSecuritySettings = $null
 try {
     Write-Verbose "Section 6: Collecting tenant security settings via Get-MgOrganization..."
-    $org = Get-MgOrganization -ErrorAction Stop | Select-Object -First 1
-
-    $tenantSecuritySettings = [PSCustomObject]@{
-        DisplayName               = $org.DisplayName
-        TenantId                  = $org.Id
-        TenantType                = $org.TenantType
-        SecurityComplianceNotificationMails = $org.SecurityComplianceNotificationMails
-        SecurityComplianceNotificationPhones = $org.SecurityComplianceNotificationPhones
-        TechnicalNotificationMails = $org.TechnicalNotificationMails
-        VerifiedDomains           = $org.VerifiedDomains | ForEach-Object {
-            [PSCustomObject]@{
-                Name       = $_.Name
-                IsDefault  = $_.IsDefault
-                IsInitial  = $_.IsInitial
-                Type       = $_.Type
-            }
-        }
-        CreatedDateTime           = $org.CreatedDateTime
-        OnPremisesSyncEnabled     = $org.OnPremisesSyncEnabled
+    $org = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'Get organization settings' -ScriptBlock {
+        Get-MgOrganization -ErrorAction Stop | Select-Object -First 1
     }
-    Write-Verbose "  Tenant security settings collected."
+
+    if ($org) {
+        $tenantSecuritySettings = [PSCustomObject]@{
+            DisplayName               = $org.DisplayName
+            TenantId                  = $org.Id
+            TenantType                = $org.TenantType
+            SecurityComplianceNotificationMails = $org.SecurityComplianceNotificationMails
+            SecurityComplianceNotificationPhones = $org.SecurityComplianceNotificationPhones
+            TechnicalNotificationMails = $org.TechnicalNotificationMails
+            VerifiedDomains           = $org.VerifiedDomains | ForEach-Object {
+                [PSCustomObject]@{
+                    Name       = $_.Name
+                    IsDefault  = $_.IsDefault
+                    IsInitial  = $_.IsInitial
+                    Type       = $_.Type
+                }
+            }
+            CreatedDateTime           = $org.CreatedDateTime
+            OnPremisesSyncEnabled     = $org.OnPremisesSyncEnabled
+        }
+        Write-Verbose "  Tenant security settings collected."
+    }
+    else {
+        Write-Verbose "  Tenant security settings collection skipped."
+    }
 }
 catch {
     $warnings.Add("Section 6 (Tenant Security Settings) failed: $($_.Exception.Message)")
@@ -345,16 +385,26 @@ try {
     # Two narrow server-side filters to limit API response volume
     $rawUsers = @()
     try {
-        $rawUsers += @(Get-MgUser -Filter "startswith(jobTitle,'Chief')" `
-            -Property $selectProps -All -ErrorAction Stop)
+        $chiefUsers = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action "List users matching job title prefix 'Chief'" -ScriptBlock {
+            Get-MgUser -Filter "startswith(jobTitle,'Chief')" `
+                -Property $selectProps -All -ErrorAction Stop
+        }
+        if ($chiefUsers) {
+            $rawUsers += @($chiefUsers)
+        }
     }
     catch {
         $warnings.Add("Section 7 filter 'Chief' failed: $($_.Exception.Message)")
         Write-Warning $warnings[-1]
     }
     try {
-        $rawUsers += @(Get-MgUser -Filter "startswith(jobTitle,'Head of') or startswith(jobTitle,'VP of') or startswith(jobTitle,'Director of') or startswith(jobTitle,'AI ')" `
-            -Property $selectProps -All -ErrorAction Stop)
+        $leadershipUsers = Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action "List users matching AI leadership job title filters" -ScriptBlock {
+            Get-MgUser -Filter "startswith(jobTitle,'Head of') or startswith(jobTitle,'VP of') or startswith(jobTitle,'Director of') or startswith(jobTitle,'AI ')" `
+                -Property $selectProps -All -ErrorAction Stop
+        }
+        if ($leadershipUsers) {
+            $rawUsers += @($leadershipUsers)
+        }
     }
     catch {
         $warnings.Add("Section 7 filter 'Head/VP/Director/AI' failed: $($_.Exception.Message)")

--- a/assessment/collectors/Collect-PPAC.ps1
+++ b/assessment/collectors/Collect-PPAC.ps1
@@ -44,7 +44,7 @@
 
 #Requires -Version 7.0
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
@@ -76,6 +76,21 @@ if (-not (Test-Path $collectedDir)) {
 }
 $outputFile = Join-Path $collectedDir 'ppac.json'
 
+function Invoke-CollectorOperation {
+    param(
+        [Parameter(Mandatory)][string]$Target,
+        [Parameter(Mandatory)][string]$Action,
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Target, $Action)) {
+        Write-Verbose "Skipping $Action on $Target because -WhatIf was specified."
+        return $null
+    }
+
+    & $ScriptBlock
+}
+
 # ─── Module Import ───────────────────────────────────────────────────
 Import-Module Microsoft.PowerApps.Administration.PowerShell -ErrorAction Stop
 Write-Verbose "Loaded Microsoft.PowerApps.Administration.PowerShell module."
@@ -86,19 +101,23 @@ Write-Verbose "Loaded Microsoft.PowerApps.Administration.PowerShell module."
 Write-Verbose "Authenticating in $AuthMode mode..."
 
 if ($AuthMode -eq 'Interactive') {
-    Add-PowerAppsAccount -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Power Platform tenant $TenantId" -Action 'Connect to Power Platform Admin Center (interactive)' -ScriptBlock {
+        Add-PowerAppsAccount -ErrorAction Stop
+    } | Out-Null
 }
 else {
     if (-not $ClientId -or -not $ClientSecret) {
         throw "ServicePrincipal auth requires -ClientId and -ClientSecret parameters."
     }
     $credential = [System.Management.Automation.PSCredential]::new($ClientId, $ClientSecret)
-    Add-PowerAppsAccount -Endpoint prod -TenantID $TenantId `
-        -ApplicationId $ClientId -ClientSecret (ConvertFrom-SecureString $ClientSecret -AsPlainText) `
-        -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Power Platform tenant $TenantId" -Action 'Connect to Power Platform Admin Center (service principal)' -ScriptBlock {
+        Add-PowerAppsAccount -Endpoint prod -TenantID $TenantId `
+            -ApplicationId $ClientId -ClientSecret (ConvertFrom-SecureString $ClientSecret -AsPlainText) `
+            -ErrorAction Stop
+    } | Out-Null
 }
 
-Write-Verbose "Authentication successful."
+Write-Verbose "Authentication stage complete."
 
 # ─── BAP API Helper ──────────────────────────────────────────────────
 # Adapted from Set-InactivityTimeout.ps1 Get-BapApiToken / Invoke-BapApi pattern.
@@ -107,7 +126,12 @@ function Get-BapApiToken {
     [CmdletBinding()]
     param()
     try {
-        $tokenResult = Get-AzAccessToken -ResourceUrl "https://api.bap.microsoft.com" -ErrorAction Stop
+        $tokenResult = Invoke-CollectorOperation -Target "BAP API tenant $TenantId" -Action 'Acquire access token' -ScriptBlock {
+            Get-AzAccessToken -ResourceUrl "https://api.bap.microsoft.com" -ErrorAction Stop
+        }
+        if ($null -eq $tokenResult) {
+            return $null
+        }
         if ($tokenResult.Token -is [securestring]) {
             return $tokenResult.Token | ConvertFrom-SecureString -AsPlainText
         }
@@ -130,7 +154,9 @@ function Invoke-BapApi {
         'Content-Type' = 'application/json'
     }
     try {
-        $response = Invoke-RestMethod -Uri $Uri -Method $Method -Headers $headers -ErrorAction Stop
+        $response = Invoke-CollectorOperation -Target $Uri -Action "Invoke BAP API ($Method)" -ScriptBlock {
+            Invoke-RestMethod -Uri $Uri -Method $Method -Headers $headers -ErrorAction Stop
+        }
         return $response
     }
     catch {
@@ -158,7 +184,9 @@ catch {
 $environments = $null
 try {
     Write-Verbose "Section 1: Collecting Power Platform environments..."
-    $rawEnvs = Get-AdminPowerAppEnvironment
+    $rawEnvs = Invoke-CollectorOperation -Target "Power Platform tenant $TenantId" -Action 'List Power Platform environments' -ScriptBlock {
+        Get-AdminPowerAppEnvironment
+    }
     $environments = $rawEnvs | ForEach-Object {
         [PSCustomObject]@{
             DisplayName              = $_.DisplayName
@@ -186,7 +214,9 @@ $dlpPolicies = $null
 $dlpSpBypassWarning = $false
 try {
     Write-Verbose "Section 2: Collecting DLP policies..."
-    $rawDlp = Get-DlpPolicy
+    $rawDlp = Invoke-CollectorOperation -Target "Power Platform tenant $TenantId" -Action 'List DLP policies' -ScriptBlock {
+        Get-DlpPolicy
+    }
     $dlpPolicies = $rawDlp | ForEach-Object {
         [PSCustomObject]@{
             DisplayName             = $_.displayName
@@ -238,7 +268,9 @@ try {
     if ($environments) {
         $roleAssignments = foreach ($env in $rawEnvs) {
             try {
-                $roles = Get-AdminPowerAppEnvironmentRoleAssignment -EnvironmentName $env.EnvironmentName -ErrorAction Stop
+                $roles = Invoke-CollectorOperation -Target $env.EnvironmentName -Action 'List environment role assignments' -ScriptBlock {
+                    Get-AdminPowerAppEnvironmentRoleAssignment -EnvironmentName $env.EnvironmentName -ErrorAction Stop
+                }
                 [PSCustomObject]@{
                     EnvironmentName    = $env.EnvironmentName
                     DisplayName        = $env.DisplayName

--- a/assessment/collectors/Collect-Purview.ps1
+++ b/assessment/collectors/Collect-Purview.ps1
@@ -43,7 +43,7 @@
 
 #Requires -Version 7.0
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
@@ -75,6 +75,21 @@ if (-not (Test-Path $collectedDir)) {
 }
 $outputFile = Join-Path $collectedDir 'purview.json'
 
+function Invoke-CollectorOperation {
+    param(
+        [Parameter(Mandatory)][string]$Target,
+        [Parameter(Mandatory)][string]$Action,
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Target, $Action)) {
+        Write-Verbose "Skipping $Action on $Target because -WhatIf was specified."
+        return $null
+    }
+
+    & $ScriptBlock
+}
+
 # ─── Module Import ───────────────────────────────────────────────────
 Import-Module ExchangeOnlineManagement -ErrorAction Stop
 Write-Verbose "Loaded ExchangeOnlineManagement module."
@@ -85,7 +100,9 @@ Write-Verbose "Loaded ExchangeOnlineManagement module."
 Write-Verbose "Authenticating to Security & Compliance Center in $AuthMode mode..."
 
 if ($AuthMode -eq 'Interactive') {
-    Connect-IPPSSession -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'Connect to Security & Compliance PowerShell (interactive)' -ScriptBlock {
+        Connect-IPPSSession -ErrorAction Stop
+    } | Out-Null
 }
 else {
     if (-not $ClientId) {
@@ -94,10 +111,12 @@ else {
     # Service principal with certificate auth for IPPS
     # Note: Connect-IPPSSession -AppId / -CertificateThumbprint is the supported SP path.
     # The caller should have the certificate installed in the current user's certificate store.
-    Connect-IPPSSession -AppId $ClientId -Organization "$TenantId" -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'Connect to Security & Compliance PowerShell (service principal)' -ScriptBlock {
+        Connect-IPPSSession -AppId $ClientId -Organization "$TenantId" -ErrorAction Stop
+    } | Out-Null
 }
 
-Write-Verbose "Security & Compliance authentication successful."
+Write-Verbose "Security & Compliance authentication stage complete."
 
 # ═══════════════════════════════════════════════════════════════════════
 # Section 1: Audit Log Configuration
@@ -108,31 +127,41 @@ $auditConfig = $null
 try {
     Write-Verbose "Section 1: Collecting audit log configuration..."
 
-    $adminAuditConfig = Get-AdminAuditLogConfig -ErrorAction Stop
-    $unifiedAuditEnabled = $adminAuditConfig.UnifiedAuditLogIngestionEnabled
+    $adminAuditConfig = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'Get audit log configuration' -ScriptBlock {
+        Get-AdminAuditLogConfig -ErrorAction Stop
+    }
 
-    # Audit configuration policies (audit plan tier)
-    $auditPolicies = $null
-    try {
-        $auditPolicies = Get-AuditConfigurationPolicy -ErrorAction Stop | ForEach-Object {
-            [PSCustomObject]@{
-                Identity    = $_.Identity
-                Priority    = $_.Priority
-                Workload    = $_.Workload
+    if ($adminAuditConfig) {
+        $unifiedAuditEnabled = $adminAuditConfig.UnifiedAuditLogIngestionEnabled
+
+        # Audit configuration policies (audit plan tier)
+        $auditPolicies = $null
+        try {
+            $auditPolicies = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List audit configuration policies' -ScriptBlock {
+                Get-AuditConfigurationPolicy -ErrorAction Stop
+            } | ForEach-Object {
+                [PSCustomObject]@{
+                    Identity    = $_.Identity
+                    Priority    = $_.Priority
+                    Workload    = $_.Workload
+                }
             }
         }
-    }
-    catch {
-        $warnings.Add("Audit configuration policies not available: $($_.Exception.Message)")
-        Write-Warning $warnings[-1]
-    }
+        catch {
+            $warnings.Add("Audit configuration policies not available: $($_.Exception.Message)")
+            Write-Warning $warnings[-1]
+        }
 
-    $auditConfig = [PSCustomObject]@{
-        UnifiedAuditLogIngestionEnabled = $unifiedAuditEnabled
-        AdminAuditLogAgeLimit           = $adminAuditConfig.AdminAuditLogAgeLimit
-        AuditConfigurationPolicies      = $auditPolicies
+        $auditConfig = [PSCustomObject]@{
+            UnifiedAuditLogIngestionEnabled = $unifiedAuditEnabled
+            AdminAuditLogAgeLimit           = $adminAuditConfig.AdminAuditLogAgeLimit
+            AuditConfigurationPolicies      = $auditPolicies
+        }
+        Write-Verbose "  Audit config collected. Unified audit enabled: $unifiedAuditEnabled"
     }
-    Write-Verbose "  Audit config collected. Unified audit enabled: $unifiedAuditEnabled"
+    else {
+        Write-Verbose "  Audit log configuration collection skipped."
+    }
 }
 catch {
     $warnings.Add("Section 1 (Audit Config) failed: $($_.Exception.Message)")
@@ -147,12 +176,16 @@ catch {
 $dlpCompliancePolicies = $null
 try {
     Write-Verbose "Section 2: Collecting DLP compliance policies..."
-    $rawDlp = Get-DlpCompliancePolicy -ErrorAction Stop
+    $rawDlp = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List DLP compliance policies' -ScriptBlock {
+        Get-DlpCompliancePolicy -ErrorAction Stop
+    }
     $dlpCompliancePolicies = foreach ($policy in $rawDlp) {
         # Retrieve associated rules with SIT references
         $rules = $null
         try {
-            $rules = Get-DlpComplianceRule -Policy $policy.Name -ErrorAction Stop | ForEach-Object {
+            $rules = Invoke-CollectorOperation -Target $policy.Name -Action 'List DLP compliance rules' -ScriptBlock {
+                Get-DlpComplianceRule -Policy $policy.Name -ErrorAction Stop
+            } | ForEach-Object {
                 [PSCustomObject]@{
                     Name                       = $_.Name
                     Disabled                   = $_.Disabled
@@ -189,7 +222,9 @@ catch {
 $retentionPolicies = $null
 try {
     Write-Verbose "Section 3: Collecting retention compliance policies..."
-    $rawRetention = Get-RetentionCompliancePolicy -ErrorAction Stop
+    $rawRetention = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List retention compliance policies' -ScriptBlock {
+        Get-RetentionCompliancePolicy -ErrorAction Stop
+    }
     $retentionPolicies = $rawRetention | ForEach-Object {
         $hasCopilotWorkload = $false
         if ($_.Workload) {
@@ -220,7 +255,9 @@ catch {
 $communicationCompliance = $null
 try {
     Write-Verbose "Section 4: Collecting communication compliance policies..."
-    $rawComm = Get-SupervisoryReviewPolicyV2 -ErrorAction Stop
+    $rawComm = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List communication compliance policies' -ScriptBlock {
+        Get-SupervisoryReviewPolicyV2 -ErrorAction Stop
+    }
     $communicationCompliance = $rawComm | ForEach-Object {
         [PSCustomObject]@{
             Name    = $_.Name
@@ -243,7 +280,9 @@ catch {
 $eDiscoveryCases = $null
 try {
     Write-Verbose "Section 5: Collecting eDiscovery cases..."
-    $rawCases = Get-ComplianceCase -ErrorAction Stop
+    $rawCases = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List eDiscovery cases' -ScriptBlock {
+        Get-ComplianceCase -ErrorAction Stop
+    }
     $eDiscoveryCases = $rawCases | ForEach-Object {
         $agentScoped = $false
         if ($_.Name -match 'agent|copilot|bot' -or $_.Description -match 'agent|copilot|bot') {
@@ -271,7 +310,9 @@ catch {
 $insiderRiskPolicies = $null
 try {
     Write-Verbose "Section 6: Collecting insider risk policies..."
-    $rawInsider = Get-InsiderRiskPolicy -ErrorAction Stop
+    $rawInsider = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List insider risk policies' -ScriptBlock {
+        Get-InsiderRiskPolicy -ErrorAction Stop
+    }
     $insiderRiskPolicies = $rawInsider | ForEach-Object {
         $copilotIndicators = $false
         if ($_.InsightTypes -match 'Copilot' -or $_.Name -match 'copilot|agent') {
@@ -342,7 +383,9 @@ catch {
 $sensitivityLabelPolicies = $null
 try {
     Write-Verbose "Section 8: Collecting sensitivity label policies..."
-    $rawLabels = Get-LabelPolicy -ErrorAction Stop
+    $rawLabels = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List sensitivity label policies' -ScriptBlock {
+        Get-LabelPolicy -ErrorAction Stop
+    }
     $sensitivityLabelPolicies = $rawLabels | ForEach-Object {
         [PSCustomObject]@{
             Name             = $_.Name
@@ -380,7 +423,9 @@ try {
     }
     else {
         # If DLP collection failed earlier, attempt a direct query
-        $rawEndpoint = Get-DlpCompliancePolicy -ErrorAction Stop | Where-Object {
+        $rawEndpoint = Invoke-CollectorOperation -Target "Purview tenant $TenantId" -Action 'List endpoint DLP policies' -ScriptBlock {
+            Get-DlpCompliancePolicy -ErrorAction Stop
+        } | Where-Object {
             $_.Workload -match 'Endpoint' -or $_.Workload -match 'EndpointDevices'
         }
         $endpointDlp = $rawEndpoint | ForEach-Object {

--- a/assessment/collectors/Collect-Sentinel.ps1
+++ b/assessment/collectors/Collect-Sentinel.ps1
@@ -50,7 +50,7 @@
 
 #Requires -Version 7.0
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
@@ -94,6 +94,21 @@ if (-not (Test-Path $collectedDir)) {
 }
 $outputFile = Join-Path $collectedDir 'sentinel.json'
 
+function Invoke-CollectorOperation {
+    param(
+        [Parameter(Mandatory)][string]$Target,
+        [Parameter(Mandatory)][string]$Action,
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Target, $Action)) {
+        Write-Verbose "Skipping $Action on $Target because -WhatIf was specified."
+        return $null
+    }
+
+    & $ScriptBlock
+}
+
 # ─── Module Import ───────────────────────────────────────────────────
 Import-Module Az.OperationalInsights -ErrorAction Stop
 Write-Verbose "Loaded Az.OperationalInsights module."
@@ -103,20 +118,26 @@ Write-Verbose "Loaded Az.OperationalInsights module."
 Write-Verbose "Authenticating to Azure in $AuthMode mode..."
 
 if ($AuthMode -eq 'Interactive') {
-    Connect-AzAccount -TenantId $TenantId -SubscriptionId $SubscriptionId -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Azure subscription $SubscriptionId" -Action 'Connect to Azure (interactive)' -ScriptBlock {
+        Connect-AzAccount -TenantId $TenantId -SubscriptionId $SubscriptionId -ErrorAction Stop
+    } | Out-Null
 }
 else {
     if (-not $ClientId -or -not $ClientSecret) {
         throw "ServicePrincipal auth requires -ClientId and -ClientSecret parameters."
     }
     $credential = [System.Management.Automation.PSCredential]::new($ClientId, $ClientSecret)
-    Connect-AzAccount -TenantId $TenantId -SubscriptionId $SubscriptionId `
-        -ServicePrincipal -Credential $credential -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Azure subscription $SubscriptionId" -Action 'Connect to Azure (service principal)' -ScriptBlock {
+        Connect-AzAccount -TenantId $TenantId -SubscriptionId $SubscriptionId `
+            -ServicePrincipal -Credential $credential -ErrorAction Stop
+    } | Out-Null
 }
 
 # Set active subscription context
-Set-AzContext -SubscriptionId $SubscriptionId -ErrorAction Stop | Out-Null
-Write-Verbose "Azure authentication successful. Subscription: $SubscriptionId"
+Invoke-CollectorOperation -Target "Azure subscription $SubscriptionId" -Action 'Set active Azure context' -ScriptBlock {
+    Set-AzContext -SubscriptionId $SubscriptionId -ErrorAction Stop | Out-Null
+} | Out-Null
+Write-Verbose "Azure authentication stage complete. Subscription: $SubscriptionId"
 
 # ═══════════════════════════════════════════════════════════════════════
 # Section 1: Workspace Existence and Configuration
@@ -125,22 +146,29 @@ Write-Verbose "Azure authentication successful. Subscription: $SubscriptionId"
 $workspaceInfo = $null
 try {
     Write-Verbose "Section 1: Validating Sentinel workspace existence..."
-    $workspace = Get-AzOperationalInsightsWorkspace `
-        -ResourceGroupName $ResourceGroup `
-        -Name $WorkspaceName `
-        -ErrorAction Stop
-
-    $workspaceInfo = [PSCustomObject]@{
-        WorkspaceId       = $workspace.CustomerId
-        ResourceId        = $workspace.ResourceId
-        Name              = $workspace.Name
-        Location          = $workspace.Location
-        ProvisioningState = $workspace.ProvisioningState
-        Sku               = $workspace.Sku
-        RetentionInDays   = $workspace.RetentionInDays
-        WorkspaceCapping  = $workspace.WorkspaceCapping
+    $workspace = Invoke-CollectorOperation -Target $WorkspaceName -Action 'Get Sentinel workspace configuration' -ScriptBlock {
+        Get-AzOperationalInsightsWorkspace `
+            -ResourceGroupName $ResourceGroup `
+            -Name $WorkspaceName `
+            -ErrorAction Stop
     }
-    Write-Verbose "  Workspace '$WorkspaceName' found. State: $($workspace.ProvisioningState), SKU: $($workspace.Sku)"
+
+    if ($workspace) {
+        $workspaceInfo = [PSCustomObject]@{
+            WorkspaceId       = $workspace.CustomerId
+            ResourceId        = $workspace.ResourceId
+            Name              = $workspace.Name
+            Location          = $workspace.Location
+            ProvisioningState = $workspace.ProvisioningState
+            Sku               = $workspace.Sku
+            RetentionInDays   = $workspace.RetentionInDays
+            WorkspaceCapping  = $workspace.WorkspaceCapping
+        }
+        Write-Verbose "  Workspace '$WorkspaceName' found. State: $($workspace.ProvisioningState), SKU: $($workspace.Sku)"
+    }
+    else {
+        Write-Verbose "  Workspace collection skipped."
+    }
 }
 catch {
     $warnings.Add("Section 1 (Workspace) failed: $($_.Exception.Message)")
@@ -167,12 +195,16 @@ try {
     # Pattern: Set-InactivityTimeout.ps1 — Get-AzAccessToken for resource-specific tokens
     $armToken = $null
     try {
-        $armTokenResult = Get-AzAccessToken -ResourceUrl "https://management.azure.com" -ErrorAction Stop
-        if ($armTokenResult.Token -is [securestring]) {
-            $armToken = $armTokenResult.Token | ConvertFrom-SecureString -AsPlainText
+        $armTokenResult = Invoke-CollectorOperation -Target "Azure Resource Manager subscription $SubscriptionId" -Action 'Acquire ARM access token' -ScriptBlock {
+            Get-AzAccessToken -ResourceUrl "https://management.azure.com" -ErrorAction Stop
         }
-        else {
-            $armToken = $armTokenResult.Token
+        if ($armTokenResult) {
+            if ($armTokenResult.Token -is [securestring]) {
+                $armToken = $armTokenResult.Token | ConvertFrom-SecureString -AsPlainText
+            }
+            else {
+                $armToken = $armTokenResult.Token
+            }
         }
     }
     catch {
@@ -183,42 +215,48 @@ try {
         Authorization  = "Bearer $armToken"
         'Content-Type' = 'application/json'
     }
-    $connectorResponse = Invoke-RestMethod -Uri $connectorApiUri -Method GET -Headers $headers -ErrorAction Stop
+    $connectorResponse = Invoke-CollectorOperation -Target $connectorApiUri -Action 'Enumerate Sentinel data connectors' -ScriptBlock {
+        Invoke-RestMethod -Uri $connectorApiUri -Method GET -Headers $headers -ErrorAction Stop
+    }
 
     # Extract connectors of interest
-    $targetKinds = @('Office365', 'MicrosoftCloudAppSecurity', 'AzureActiveDirectory', 'MicrosoftThreatProtection')
-
-    $dataConnectors = [PSCustomObject]@{
-        TotalConnectors     = if ($connectorResponse.value) { $connectorResponse.value.Count } else { 0 }
-        ConnectorSummary    = if ($connectorResponse.value) {
-            $connectorResponse.value | ForEach-Object {
-                [PSCustomObject]@{
-                    Id        = $_.id
-                    Name      = $_.name
-                    Kind      = $_.kind
-                    Etag      = $_.etag
+    if ($connectorResponse) {
+        $dataConnectors = [PSCustomObject]@{
+            TotalConnectors     = if ($connectorResponse.value) { $connectorResponse.value.Count } else { 0 }
+            ConnectorSummary    = if ($connectorResponse.value) {
+                $connectorResponse.value | ForEach-Object {
+                    [PSCustomObject]@{
+                        Id        = $_.id
+                        Name      = $_.name
+                        Kind      = $_.kind
+                        Etag      = $_.etag
+                    }
                 }
             }
+            else { @() }
+            Office365Enabled    = $false
+            McasEnabled         = $false
         }
-        else { @() }
-        Office365Enabled    = $false
-        McasEnabled         = $false
-    }
 
-    if ($connectorResponse.value) {
-        $dataConnectors.Office365Enabled = ($connectorResponse.value | Where-Object { $_.kind -eq 'Office365' }).Count -gt 0
-        $dataConnectors.McasEnabled = ($connectorResponse.value | Where-Object { $_.kind -eq 'MicrosoftCloudAppSecurity' }).Count -gt 0
+        if ($connectorResponse.value) {
+            $dataConnectors.Office365Enabled = ($connectorResponse.value | Where-Object { $_.kind -eq 'Office365' }).Count -gt 0
+            $dataConnectors.McasEnabled = ($connectorResponse.value | Where-Object { $_.kind -eq 'MicrosoftCloudAppSecurity' }).Count -gt 0
 
-        if (-not $dataConnectors.Office365Enabled) {
-            $warnings.Add("Section 2: Office365 data connector is NOT enabled in workspace '$WorkspaceName'.")
-            Write-Warning $warnings[-1]
+            if (-not $dataConnectors.Office365Enabled) {
+                $warnings.Add("Section 2: Office365 data connector is NOT enabled in workspace '$WorkspaceName'.")
+                Write-Warning $warnings[-1]
+            }
+            if (-not $dataConnectors.McasEnabled) {
+                $warnings.Add("Section 2: MicrosoftCloudAppSecurity data connector is NOT enabled in workspace '$WorkspaceName'.")
+                Write-Warning $warnings[-1]
+            }
         }
-        if (-not $dataConnectors.McasEnabled) {
-            $warnings.Add("Section 2: MicrosoftCloudAppSecurity data connector is NOT enabled in workspace '$WorkspaceName'.")
-            Write-Warning $warnings[-1]
-        }
+        Write-Verbose "  Data connectors enumerated. Office365=$($dataConnectors.Office365Enabled), MCAS=$($dataConnectors.McasEnabled)"
     }
-    Write-Verbose "  Data connectors enumerated. Office365=$($dataConnectors.Office365Enabled), MCAS=$($dataConnectors.McasEnabled)"
+    else {
+        $warnings.Add("Section 2 (Data Connectors): Skipped — data connector API call was not executed.")
+        Write-Warning $warnings[-1]
+    }
 }
 catch {
     $warnings.Add("Section 2 (Data Connectors) failed: $($_.Exception.Message)")
@@ -236,37 +274,44 @@ try {
     if ($workspaceInfo) {
         $kqlQuery = 'AuditLogs | where OperationName contains "CopilotInteraction" | where TimeGenerated > ago(7d) | count'
 
-        $queryResult = Invoke-AzOperationalInsightsQuery `
-            -WorkspaceId $workspaceInfo.WorkspaceId `
-            -Query $kqlQuery `
-            -ErrorAction Stop
-
-        $recordCount = 0
-        if ($queryResult.Results) {
-            # The count query returns a single row with a Count column
-            $countValue = $queryResult.Results | Select-Object -First 1
-            if ($countValue.Count) {
-                $recordCount = [int]$countValue.Count
-            }
-            elseif ($countValue.'Count') {
-                $recordCount = [int]$countValue.'Count'
-            }
+        $queryResult = Invoke-CollectorOperation -Target $workspaceInfo.WorkspaceId -Action 'Run Copilot interaction KQL audit query' -ScriptBlock {
+            Invoke-AzOperationalInsightsQuery `
+                -WorkspaceId $workspaceInfo.WorkspaceId `
+                -Query $kqlQuery `
+                -ErrorAction Stop
         }
 
-        $kqlAuditCheck = [PSCustomObject]@{
-            Query           = $kqlQuery
-            RecordCount     = $recordCount
-            HasRecords      = ($recordCount -gt 0)
-            QueryTimeRange  = '7 days'
-            ExecutedAt      = (Get-Date -Format 'o')
-        }
+        if ($queryResult) {
+            $recordCount = 0
+            if ($queryResult.Results) {
+                # The count query returns a single row with a Count column
+                $countValue = $queryResult.Results | Select-Object -First 1
+                if ($countValue.Count) {
+                    $recordCount = [int]$countValue.Count
+                }
+                elseif ($countValue.'Count') {
+                    $recordCount = [int]$countValue.'Count'
+                }
+            }
 
-        if ($recordCount -eq 0) {
-            $warnings.Add("Section 3: No CopilotInteraction audit records found in the last 7 days. Verify audit ingestion pipeline.")
-            Write-Warning $warnings[-1]
+            $kqlAuditCheck = [PSCustomObject]@{
+                Query           = $kqlQuery
+                RecordCount     = $recordCount
+                HasRecords      = ($recordCount -gt 0)
+                QueryTimeRange  = '7 days'
+                ExecutedAt      = (Get-Date -Format 'o')
+            }
+
+            if ($recordCount -eq 0) {
+                $warnings.Add("Section 3: No CopilotInteraction audit records found in the last 7 days. Verify audit ingestion pipeline.")
+                Write-Warning $warnings[-1]
+            }
+            else {
+                Write-Verbose "  Found $recordCount CopilotInteraction record(s) in the last 7 days."
+            }
         }
         else {
-            Write-Verbose "  Found $recordCount CopilotInteraction record(s) in the last 7 days."
+            Write-Verbose "  KQL audit query skipped."
         }
     }
     else {

--- a/assessment/collectors/Collect-SharePoint.ps1
+++ b/assessment/collectors/Collect-SharePoint.ps1
@@ -46,7 +46,7 @@
 
 #Requires -Version 7.0
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]
     [ValidateNotNullOrEmpty()]
@@ -81,6 +81,21 @@ if (-not (Test-Path $collectedDir)) {
 }
 $outputFile = Join-Path $collectedDir 'sharepoint.json'
 
+function Invoke-CollectorOperation {
+    param(
+        [Parameter(Mandatory)][string]$Target,
+        [Parameter(Mandatory)][string]$Action,
+        [Parameter(Mandatory)][scriptblock]$ScriptBlock
+    )
+
+    if (-not $PSCmdlet.ShouldProcess($Target, $Action)) {
+        Write-Verbose "Skipping $Action on $Target because -WhatIf was specified."
+        return $null
+    }
+
+    & $ScriptBlock
+}
+
 # ─── Module Imports ──────────────────────────────────────────────────
 Import-Module Microsoft.Graph.Authentication -ErrorAction Stop
 Write-Verbose "Loaded Microsoft.Graph.Authentication module."
@@ -104,17 +119,21 @@ $requiredScopes = @('Sites.Read.All', 'Files.Read.All')
 Write-Verbose "Authenticating to Microsoft Graph in $AuthMode mode..."
 
 if ($AuthMode -eq 'Interactive') {
-    Connect-MgGraph -TenantId $TenantId -Scopes $requiredScopes -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'Connect to Microsoft Graph (interactive)' -ScriptBlock {
+        Connect-MgGraph -TenantId $TenantId -Scopes $requiredScopes -ErrorAction Stop
+    } | Out-Null
 }
 else {
     if (-not $ClientId -or -not $ClientSecret) {
         throw "ServicePrincipal auth requires -ClientId and -ClientSecret parameters."
     }
     $credential = [System.Management.Automation.PSCredential]::new($ClientId, $ClientSecret)
-    Connect-MgGraph -TenantId $TenantId -ClientSecretCredential $credential -ErrorAction Stop
+    Invoke-CollectorOperation -Target "Microsoft Graph tenant $TenantId" -Action 'Connect to Microsoft Graph (service principal)' -ScriptBlock {
+        Connect-MgGraph -TenantId $TenantId -ClientSecretCredential $credential -ErrorAction Stop
+    } | Out-Null
 }
 
-Write-Verbose "Microsoft Graph authentication successful."
+Write-Verbose "Microsoft Graph authentication stage complete."
 
 # ─── Graph API Helper ────────────────────────────────────────────────
 # Thin wrapper for Graph REST calls with consistent error handling.
@@ -125,7 +144,9 @@ function Invoke-GraphApi {
         [Parameter()][ValidateSet('GET', 'POST')][string]$Method = 'GET'
     )
     try {
-        $response = Invoke-MgGraphRequest -Uri $Uri -Method $Method -ErrorAction Stop
+        $response = Invoke-CollectorOperation -Target $Uri -Action "Invoke Microsoft Graph request ($Method)" -ScriptBlock {
+            Invoke-MgGraphRequest -Uri $Uri -Method $Method -ErrorAction Stop
+        }
         return $response
     }
     catch {

--- a/assessment/manifest/controls.json
+++ b/assessment/manifest/controls.json
@@ -83,6 +83,7 @@
     ],
     "priority": "critical",
     "applicable_drivers": [
+      "technology_data",
       "ai_governance"
     ],
     "applicable_patterns": [
@@ -211,7 +212,7 @@
     ],
     "priority": "high",
     "applicable_drivers": [
-      "ai_governance",
+      "ai_strategy",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -320,8 +321,7 @@
     ],
     "priority": "critical",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -438,7 +438,6 @@
     ],
     "priority": "high",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -554,7 +553,6 @@
     ],
     "priority": "critical",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -770,8 +768,7 @@
     ],
     "priority": "critical",
     "applicable_drivers": [
-      "ai_governance",
-      "technology_data"
+      "ai_governance"
     ],
     "applicable_patterns": [
       1,
@@ -1076,8 +1073,8 @@
     ],
     "priority": "high",
     "applicable_drivers": [
-      "ai_governance",
-      "organization_culture"
+      "organization_culture",
+      "ai_governance"
     ],
     "applicable_patterns": [
       1,
@@ -1208,7 +1205,6 @@
     ],
     "priority": "critical",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -1428,7 +1424,6 @@
     ],
     "priority": "high",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -1516,7 +1511,6 @@
     ],
     "priority": "medium",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -1628,7 +1622,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -1711,7 +1704,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -1807,7 +1799,6 @@
     ],
     "priority": "high",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -1914,7 +1905,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -2127,7 +2117,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -2425,7 +2414,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -2620,7 +2608,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -2727,7 +2714,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -3053,7 +3039,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -3165,8 +3150,8 @@
     ],
     "priority": "critical",
     "applicable_drivers": [
-      "ai_governance",
-      "technology_data"
+      "technology_data",
+      "ai_governance"
     ],
     "applicable_patterns": [
       1,
@@ -3277,8 +3262,8 @@
     ],
     "priority": "high",
     "applicable_drivers": [
-      "ai_governance",
-      "technology_data"
+      "technology_data",
+      "ai_governance"
     ],
     "applicable_patterns": [
       1,
@@ -3374,7 +3359,8 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance"
+      "ai_governance",
+      "ai_strategy"
     ],
     "applicable_patterns": [
       1,
@@ -3561,6 +3547,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
+      "business_strategy",
       "ai_governance"
     ],
     "applicable_patterns": [
@@ -3733,7 +3720,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "business_strategy",
       "ai_strategy",
       "ai_governance"
     ],
@@ -3838,7 +3824,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -3939,7 +3924,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
+      "business_strategy",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -4036,7 +4021,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -4202,8 +4186,8 @@
     ],
     "priority": "critical",
     "applicable_drivers": [
-      "business_strategy",
       "ai_governance",
+      "business_strategy",
       "organization_culture"
     ],
     "applicable_patterns": [
@@ -4294,7 +4278,7 @@
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
       "ai_strategy",
-      "ai_governance"
+      "business_strategy"
     ],
     "applicable_patterns": [
       1,
@@ -4375,8 +4359,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "organization_culture",
-      "ai_governance"
+      "organization_culture"
     ],
     "applicable_patterns": [
       1,
@@ -4481,7 +4464,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -4671,8 +4653,8 @@
     ],
     "priority": "medium",
     "applicable_drivers": [
-      "ai_governance",
-      "technology_data"
+      "technology_data",
+      "ai_governance"
     ],
     "applicable_patterns": [
       1,
@@ -4916,7 +4898,8 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance"
+      "ai_governance",
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -4995,7 +4978,7 @@
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
       "organization_culture",
-      "ai_governance"
+      "business_strategy"
     ],
     "applicable_patterns": [
       1,
@@ -5099,7 +5082,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -5296,7 +5278,8 @@
     ],
     "priority": "medium",
     "applicable_drivers": [
-      "ai_governance"
+      "ai_strategy",
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -5409,7 +5392,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
+      "ai_strategy",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -5518,8 +5501,8 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
-      "technology_data"
+      "technology_data",
+      "ai_governance"
     ],
     "applicable_patterns": [
       1,
@@ -5635,7 +5618,6 @@
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
       "ai_strategy",
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -5720,7 +5702,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
+      "business_strategy",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -5819,8 +5801,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
-      "technology_data"
+      "ai_governance"
     ],
     "applicable_patterns": [
       1,
@@ -6034,7 +6015,7 @@
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
       "ai_strategy",
-      "ai_governance"
+      "business_strategy"
     ],
     "applicable_patterns": [
       1,
@@ -6123,7 +6104,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
+      "ai_strategy",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -6315,7 +6296,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
+      "ai_strategy",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -6600,7 +6581,6 @@
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
       "ai_strategy",
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -6766,7 +6746,7 @@
     ],
     "priority": "medium",
     "applicable_drivers": [
-      "ai_governance",
+      "ai_strategy",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -6851,7 +6831,6 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "ai_governance",
       "technology_data"
     ],
     "applicable_patterns": [
@@ -6960,8 +6939,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -7058,8 +7036,8 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "ai_governance",
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -7165,8 +7143,8 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "ai_governance",
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -7272,8 +7250,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -7369,8 +7346,8 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "ai_governance",
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -7681,8 +7658,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "technology_data"
     ],
     "applicable_patterns": [
       1,
@@ -7765,8 +7741,7 @@
     ],
     "priority": "TODO: critical|high|medium|low",
     "applicable_drivers": [
-      "technology_data",
-      "ai_governance"
+      "technology_data"
     ],
     "applicable_patterns": [
       1,

--- a/assessment/tests/test_manifest_validation.py
+++ b/assessment/tests/test_manifest_validation.py
@@ -13,6 +13,7 @@ import copy
 import json
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -94,6 +95,27 @@ def test_control_doc_url_starts_with_slash():
     for ctrl in controls:
         assert ctrl["controlDocUrl"].startswith("/"), ctrl["id"]
         assert ctrl["portalPlaybookUrl"].startswith("/"), ctrl["id"]
+
+
+def test_capability_driver_tags_provide_rollup_signal():
+    """Driver tags must stay broad enough to produce a useful rollup signal."""
+    controls = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    counts = Counter(driver for ctrl in controls for driver in ctrl.get("applicable_drivers", []))
+
+    assert counts["ai_governance"] < len(controls), (
+        "ai_governance should not blanket every control or the driver rollup "
+        "collapses into the overall maturity score"
+    )
+
+    for driver in (
+        "ai_strategy",
+        "business_strategy",
+        "technology_data",
+        "organization_culture",
+    ):
+        assert counts[driver] >= 5, (
+            f"{driver} should tag enough controls to produce a meaningful rollup"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- close `F-ENGINE-COLLECTOR-NO-WHATIF-01` by adding `SupportsShouldProcess` to all six collectors and wrapping network/API calls so `-WhatIf` skips them
- close `F-ENGINE-ROLLUP-AI-GOV-SATURATED-01` by rebalancing `applicable_drivers` away from blanket `ai_governance` tagging and adding a regression test for rollup signal

## Validation
- `cd assessment; python -m pytest tests/ -v` *(140 passed)*
- `python -m pytest scripts/` *(267 passed)*
- `pwsh -c "Invoke-ScriptAnalyzer -Path assessment/collectors -Recurse -Settings ./PSScriptAnalyzerSettings.psd1"`
- `python scripts/check_manifest_doc_drift.py --check`
- `python scripts/generate_coverage_matrix.py --check`
- `mkdocs build --strict`

## Notes
- collector WhatIf support now covers `Collect-Frontier.ps1`, `Collect-Graph.ps1`, `Collect-PPAC.ps1`, `Collect-Purview.ps1`, `Collect-Sentinel.ps1`, and `Collect-SharePoint.ps1`
- driver tags now distribute as `technology_data=54`, `ai_governance=40`, `ai_strategy=12`, `business_strategy=7`, `organization_culture=6`