### PR TITLE
chore(docs): replace 2 Microsoft Learn URL redirects (PR-13)

### DIFF
--- a/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
+++ b/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
@@ -352,7 +352,7 @@ Confirm control effectiveness by verifying:
 **Microsoft Documentation:**
 
 - [Microsoft Learn: Microsoft Purview Audit Solutions](https://learn.microsoft.com/en-us/purview/audit-solutions-overview)
-- [Microsoft Learn: Search the Audit Log](https://learn.microsoft.com/en-us/purview/audit-log-search)
+- [Microsoft Learn: Search the Audit Log](https://learn.microsoft.com/en-us/purview/audit-search)
 - [Microsoft Learn: Audit Log Retention Policies](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies)
 - [Microsoft Learn: Azure Immutable Blob Storage](https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-storage-overview)
 - [Microsoft Learn: Office 365 Management Activity API](https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference)

--- a/docs/controls/pillar-3-reporting/3.12-agent-governance-exception-and-override-management.md
+++ b/docs/controls/pillar-3-reporting/3.12-agent-governance-exception-and-override-management.md
@@ -215,7 +215,7 @@ Confirm control effectiveness by verifying:
 - [Power Automate Approval Flows](https://learn.microsoft.com/en-us/power-automate/get-started-approvals)
 - [Dataverse Custom Tables](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/create-custom-entity)
 - [SharePoint Lists for Governance Tracking](https://learn.microsoft.com/en-us/sharepoint/dev/business-apps/get-started/set-up-sharepoint-site-lists-libraries)
-- [Microsoft Purview Audit Log](https://learn.microsoft.com/en-us/purview/audit-log-search)
+- [Microsoft Purview Audit Log](https://learn.microsoft.com/en-us/purview/audit-search)
 - [Power Apps Canvas Apps for Governance Forms](https://learn.microsoft.com/en-us/power-apps/maker/canvas-apps/getting-started)
 - [Teams Adaptive Cards for Notifications](https://learn.microsoft.com/en-us/power-automate/create-adaptive-cards)
 

--- a/docs/controls/pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md
+++ b/docs/controls/pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md
@@ -223,7 +223,7 @@ For baseline configuration that enables usage insights from environment creation
 - [Set Up Alerts in PPAC](https://learn.microsoft.com/en-us/power-platform/admin/monitoring/monitor-copilot-studio)
 - [Managed Environment Usage Insights](https://learn.microsoft.com/en-us/power-platform/admin/managed-environment-usage-insights)
 - [Copilot Studio Analytics](https://learn.microsoft.com/en-us/microsoft-copilot-studio/analytics-overview)
-- [Unified Audit Log](https://learn.microsoft.com/en-us/purview/audit-log-search)
+- [Unified Audit Log](https://learn.microsoft.com/en-us/purview/audit-search)
 
 ### Microsoft Audit Reporting Tools
 

--- a/docs/playbooks/advanced-implementations/microsoft-audit-reporting-tools.md
+++ b/docs/playbooks/advanced-implementations/microsoft-audit-reporting-tools.md
@@ -237,7 +237,7 @@ These tools enhance the following FSI Agent Governance Framework controls:
 ### Related Microsoft Learn Documentation
 
 - [Microsoft Purview Audit Solutions](https://learn.microsoft.com/en-us/purview/audit-solutions-overview)
-- [Search the Audit Log](https://learn.microsoft.com/en-us/purview/audit-log-search)
+- [Search the Audit Log](https://learn.microsoft.com/en-us/purview/audit-search)
 - [Audit Log Retention Policies](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies)
 - [Copilot Usage Reports](https://learn.microsoft.com/en-us/microsoft-365/admin/activity-reports/microsoft-365-copilot-usage?view=o365-worldwide)
 - [Office 365 Management Activity API](https://learn.microsoft.com/en-us/office/office-365-management-api/office-365-management-activity-api-reference)

--- a/docs/playbooks/control-implementations/1.7/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.7/portal-walkthrough.md
@@ -227,7 +227,7 @@ In the Microsoft Purview portal:
 In the Purview portal:
 
 1. Open **Audit > New search**.
-2. Set **Date and time range (UTC)** for the period of interest. The portal search window is capped at **180 days**; for longer windows use PowerShell `Search-UnifiedAuditLog -SessionCommand ReturnLargeSet` paginated to completion, or the [Audit Search Graph API](https://learn.microsoft.com/en-us/purview/audit-log-search) (supported on both Audit Standard and Audit Premium).
+2. Set **Date and time range (UTC)** for the period of interest. The portal search window is capped at **180 days**; for longer windows use PowerShell `Search-UnifiedAuditLog -SessionCommand ReturnLargeSet` paginated to completion, or the [Audit Search Graph API](https://learn.microsoft.com/en-us/purview/audit-search) (supported on both Audit Standard and Audit Premium).
 3. In **Record types**, select the Copilot / agent types in scope:
     - `CopilotInteraction` — Microsoft 365 Copilot interactions.
     - `ConnectedAIAppInteraction` — Connected AI app interactions (Microsoft-built Copilot Studio agents at no incremental cost; some non-Microsoft AI app scenarios under this RecordType are PAYG-billable — see §6).

--- a/docs/playbooks/control-implementations/4.6/troubleshooting.md
+++ b/docs/playbooks/control-implementations/4.6/troubleshooting.md
@@ -238,7 +238,7 @@ Get-SPOSite -Identity 'https://contoso.sharepoint.com/sites/legal-drafts' |
 
 **Learn.**
 - https://learn.microsoft.com/sharepoint/restricted-content-discovery
-- https://learn.microsoft.com/microsoft-365-copilot/microsoft-365-copilot-privacy
+- https://learn.microsoft.com/en-us/microsoft-365/copilot/microsoft-365-copilot-privacy
 - https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-default-policy
 
 ---
@@ -355,7 +355,7 @@ Get-SPOSite -Identity 'https://contoso.sharepoint.com/sites/legal-drafts' |
 
 **Learn.**
 - https://learn.microsoft.com/en-us/microsoft-copilot-studio/knowledge-copilot-studio
-- https://learn.microsoft.com/microsoft-365-copilot/microsoft-365-copilot-privacy
+- https://learn.microsoft.com/en-us/microsoft-365/copilot/microsoft-365-copilot-privacy
 
 ---
 
@@ -676,7 +676,7 @@ External (verify URL currency at time of operation):
 - https://learn.microsoft.com/sharepoint/restricted-sharepoint-search
 - https://learn.microsoft.com/sharepoint/advanced-management
 - https://learn.microsoft.com/sharepoint/data-access-governance-reports
-- https://learn.microsoft.com/microsoft-365-copilot/microsoft-365-copilot-privacy
+- https://learn.microsoft.com/en-us/microsoft-365/copilot/microsoft-365-copilot-privacy
 - https://learn.microsoft.com/microsoft-365-copilot/microsoft-365-copilot-licensing
 - https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-default-policy
 - https://learn.microsoft.com/en-us/microsoft-copilot-studio/knowledge-copilot-studio

--- a/docs/playbooks/control-implementations/4.7/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/4.7/portal-walkthrough.md
@@ -641,7 +641,7 @@ This portal walkthrough hands off to its siblings as follows:
 
 ### 13.3 External references
 
-- Microsoft Learn — [Microsoft 365 Copilot data, privacy, and security](https://learn.microsoft.com/microsoft-365-copilot/microsoft-365-copilot-privacy)
+- Microsoft Learn — [Microsoft 365 Copilot data, privacy, and security](https://learn.microsoft.com/en-us/microsoft-365/copilot/microsoft-365-copilot-privacy)
 - Microsoft Learn — [Sensitivity labels for Copilot](https://learn.microsoft.com/purview/sensitivity-labels-coauthoring)
 - Microsoft Learn — [DLP for Microsoft 365 Copilot](https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-learn-about)
 - Microsoft Learn — [Restricted SharePoint Search](https://learn.microsoft.com/sharepoint/restricted-sharepoint-search)

--- a/docs/playbooks/control-implementations/4.7/troubleshooting.md
+++ b/docs/playbooks/control-implementations/4.7/troubleshooting.md
@@ -1086,7 +1086,7 @@ The following 20 anti-patterns are recurring causes of Control 4.7 incidents in 
 
 ## Related Resources
 
-- Microsoft Learn: [Microsoft 365 Copilot data protection](https://learn.microsoft.com/microsoft-365-copilot/microsoft-365-copilot-privacy)
+- Microsoft Learn: [Microsoft 365 Copilot data protection](https://learn.microsoft.com/en-us/microsoft-365/copilot/microsoft-365-copilot-privacy)
 - Microsoft Learn: [Restricted SharePoint Search](https://learn.microsoft.com/sharepoint/restricted-sharepoint-search)
 - Microsoft Learn: [DLP for Microsoft 365 Copilot](https://learn.microsoft.com/en-us/purview/dlp-microsoft365-copilot-location-learn-about)
 - Microsoft Learn: [Microsoft Purview Audit (Premium)](https://learn.microsoft.com/purview/audit-premium)


### PR DESCRIPTION
## Summary

Per audit triage enum-04 (Microsoft Learn URL health), 2 URL patterns currently 301-redirect. Replace in-place to avoid the redirect hop.

## Changes (8 files, 10 line changes)

| Old URL | New URL | Files |
|---|---|---|
| `learn.microsoft.com/en-us/purview/audit-log-search` | `learn.microsoft.com/en-us/purview/audit-search` | 5 (Control 1.7, 3.2, 3.12 + 2 playbooks) |
| `learn.microsoft.com/microsoft-365-copilot/microsoft-365-copilot-privacy` | `learn.microsoft.com/en-us/microsoft-365/copilot/microsoft-365-copilot-privacy` | 3 (Control 4.6, 4.7 playbooks) |

## Validation

- `Select-String` confirms no remaining occurrences of old URL forms
- `python scripts/verify_language_rules.py` passes
- `enum-04` sampled 98 of 100 most-cited Learn URLs as LIVE; no other redirect patterns identified, so this PR is appropriately scoped

## Reference

- Audit triage: `maintainers-local/audits/2026-05-16/findings/enum-04-learn-urls.md`
- Fix plan PR-13: `maintainers-local/audits/2026-05-16/fix-plan.md`
