### PR TITLE
docs(reg): add SR 26-2/OCC 2026-13 GenAI scope caveat + re-characterize GenAI mappings (PR-3)

### DIFF
--- a/docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md
+++ b/docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md
@@ -2,7 +2,7 @@
 
 **Control ID:** 1.4<br>
 **Pillar:** Security<br>
-**Regulatory Reference:** FINRA 3110, FINRA 4511, FINRA 25-07, SEC Reg S-P (2024 amendments), SEC Rule 17a-4(f), GLBA Safeguards Rule (16 CFR 314), SOX 404, OCC Bulletin 2026-13 (formerly OCC 2011-12), NIST SP 800-53 Rev. 5 SA-9 / AC-4<br>
+**Regulatory Reference:** FINRA 3110, FINRA 4511, FINRA 25-07, SEC Reg S-P (2024 amendments), SEC Rule 17a-4(f), GLBA Safeguards Rule (16 CFR 314), SOX 404, OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7), NIST SP 800-53 Rev. 5 SA-9 / AC-4<br>
 **Last UI Verified:** April 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 

--- a/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
+++ b/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
@@ -26,7 +26,7 @@ Implement comprehensive audit logging to capture Microsoft 365 Copilot and Copil
 - **SEC 17a-3:** Record creation requirements — distinct from 17a-4 preservation. Audit logs help evidence the *creation* events for required books and records.
 - **SOX 302/404:** Internal controls over AI system logging require audit trails sufficient to support management certification.
 - **GLBA 501(b):** Security safeguards including audit trails for non-public personal information access.
-- **OCC Bulletin 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly SR 11-7):** Model risk management — model identity, version, and use must be auditable. For Microsoft 365 Copilot, audit captures `ModelProviderName` only; full model identification requires the model-card store referenced in Control 2.16.
+- **OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7):** Model risk management — model identity, version, and use must be auditable. For Microsoft 365 Copilot, audit captures `ModelProviderName` only; full model identification requires the model-card store referenced in Control 2.16.
 - **CFTC 1.31:** 5-year retention of regulatory records (including AI-generated communications) for FCMs, swap dealers, and CPOs in tamper-evident format with complete metadata.
 
 !!! info "Updated February 2026"

--- a/docs/controls/pillar-2-management/2.7-vendor-and-third-party-risk-management.md
+++ b/docs/controls/pillar-2-management/2.7-vendor-and-third-party-risk-management.md
@@ -2,7 +2,7 @@
 
 **Control ID:** 2.7<br>
 **Pillar:** Management<br>
-**Regulatory Reference:** GLBA Section 501(b), SOX Section 404, FINRA Rule 4511, FINRA Rule 3110, FINRA Regulatory Notice 25-07, SEC Rule 17a-4(f), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), OCC Bulletin 2013-29, Federal Reserve SR 26-2 (formerly SR 11-7), Interagency Guidance on Third-Party Relationships (FRB/FDIC/OCC, June 2023), OWASP LLM Top 10 (2025)<br>
+**Regulatory Reference:** GLBA Section 501(b), SOX Section 404, FINRA Rule 4511, FINRA Rule 3110, FINRA Regulatory Notice 25-07, SEC Rule 17a-4(f), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7), OCC Bulletin 2013-29, Interagency Guidance on Third-Party Relationships (FRB/FDIC/OCC, June 2023), OWASP LLM Top 10 (2025)<br>
 **Last UI Verified:** April 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
@@ -18,7 +18,7 @@ Establish a comprehensive framework for identifying, assessing, and managing ris
 
 - **Interagency Guidance on Third-Party Relationships (FRB/FDIC/OCC, June 2023):** Establishes lifecycle expectations (planning, due diligence, contract negotiation, ongoing monitoring, termination) that supervised institutions are expected to apply to AI/connector vendors
 - **OCC Bulletin 2013-29 / Bulletin 2020-10 FAQs:** Third-party risk management expectations for national banks, including risk-tiered due diligence and ongoing monitoring
-- **OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) & Federal Reserve SR 26-2 (formerly SR 11-7):** Treat third-party AI/LLM providers as part of the model supply chain; vendor change can constitute a model change requiring re-validation
+- **OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7):** Treat third-party AI/LLM providers as part of the model supply chain; vendor change can constitute a model change requiring re-validation
 - **GLBA Section 501(b) (16 CFR Part 314 Safeguards Rule):** Requires service-provider oversight, written contracts, and periodic assessment for any vendor handling customer information
 - **SOX Section 404:** Internal controls over financial reporting extend to vendor-provided services that influence reportable processes; SOC 1/SOC 2 reporting helps support attestation
 - **FINRA Rule 3110(a):** Supervisory system must reasonably address risks introduced by third-party tools used in business communications and recordkeeping

--- a/docs/framework/regulatory-framework.md
+++ b/docs/framework/regulatory-framework.md
@@ -104,7 +104,7 @@ See: [FINRA Rule 3120](https://www.finra.org/rules-guidance/rulebooks/finra-rule
 |---------|-------------|---------|
 | [2.3](../controls/pillar-2-management/2.3-change-management-and-release-planning.md) | Change Management | Change control and approval |
 | [2.5](../controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md) | Testing and Validation | QA before production |
-| [2.6](../controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model Risk Management | SR 26-2 (formerly SR 11-7) alignment |
+| [2.6](../controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model Risk Management | OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7) alignment |
 | [2.11](../controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md) | Bias Testing | Fairness assessment |
 | [2.12](../controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) | Supervision and Oversight | Define supervisory procedures |
 | [2.17](../controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md) | Multi-Agent Orchestration Limits | Supervise agent interactions |
@@ -307,9 +307,12 @@ The 2026 Annual Regulatory Oversight Report contains FINRA's most detailed AI ag
 
 ---
 
-### OCC Bulletin 2026-13 (formerly OCC 2011-12) / Federal Reserve SR 26-2 (formerly SR 11-7) — Model Risk Management
+### OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7) — Model Risk Management
 
 **Overview:** Guidance on model risk management for banks using models in decision-making.
+
+!!! warning "Generative AI and agentic AI excluded from scope"
+    The interagency guidance underlying OCC Bulletin 2026-13 / Fed SR 26-2 explicitly states: *"Generative AI and agentic AI models are novel and rapidly evolving. As such, they are not within the scope of this guidance."* In this framework, direct mappings under this section apply to **traditional model risk** (for example, algorithmic credit scoring or fraud models). GenAI- and agentic-AI-specific controls are included here only as **analogous sound-risk-management principles**. See [Regulatory Mappings](../reference/regulatory-mappings.md) for the fuller scope caveat, including the guidance's "most relevant to" institutions over $30 billion in assets.
 
 **Key Requirements:**
 
@@ -324,10 +327,10 @@ The 2026 Annual Regulatory Oversight Report contains FINRA's most detailed AI ag
 |---------|-------------|---------|
 | [2.5](../controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md) | Testing and Validation | Model testing |
 | [2.6](../controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model Risk Management | Comprehensive MRM framework |
-| [2.11](../controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md) | Bias Testing | Fairness validation |
-| [2.16](../controls/pillar-2-management/2.16-rag-source-integrity-validation.md) | RAG Source Integrity | Input data validation |
+| [2.11](../controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md) | Bias Testing | Fairness validation for traditional models; analogous principle for GenAI reviews |
+| [2.16](../controls/pillar-2-management/2.16-rag-source-integrity-validation.md) | RAG Source Integrity | Analogous principle for GenAI grounding-source validation |
 | [3.2](../controls/pillar-3-reporting/3.2-usage-analytics-and-activity-monitoring.md) | Usage Analytics | Performance monitoring |
-| [3.10](../controls/pillar-3-reporting/3.10-hallucination-feedback-loop.md) | Hallucination Feedback | Output quality monitoring |
+| [3.10](../controls/pillar-3-reporting/3.10-hallucination-feedback-loop.md) | Hallucination Feedback | Analogous principle for GenAI output-quality monitoring |
 
 **Applicability:**
 

--- a/docs/reference/regulatory-mappings.md
+++ b/docs/reference/regulatory-mappings.md
@@ -85,7 +85,7 @@ Requires written policies and procedures for supervision of agents and AI techno
 | [2.12](../controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) | Supervision and Oversight | Define supervisory procedures |
 | [2.3](../controls/pillar-2-management/2.3-change-management-and-release-planning.md) | Change Management | Change control and approval |
 | [2.5](../controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md) | Testing and Validation | QA before production |
-| [2.6](../controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model Risk Management | SR 26-2 (formerly SR 11-7) alignment |
+| [2.6](../controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md) | Model Risk Management | OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7) alignment |
 | [2.11](../controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md) | Bias Testing | Fairness assessment |
 | [2.15](../controls/pillar-2-management/2.15-environment-routing.md) | Environment Routing | Enforce routing rules based on role/group membership for supervision |
 | [2.17](../controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md) | Multi-Agent Orchestration Limits | Supervise agent interactions |
@@ -760,6 +760,11 @@ Framework controls relevant to GLBA safeguards are listed in the Applicable Cont
 ### Overview
 Applies to national banks and federal savings associations. Requires governance framework for models used in business decisions.
 
+!!! warning "Generative AI and agentic AI excluded from scope"
+    Per the Federal Reserve's [SR 26-2](https://www.federalreserve.gov/supervisionreg/srletters/sr2602.htm) and OCC Bulletin 2026-13 (issued April 17, 2026), the underlying interagency Model Risk Management guidance explicitly states: *"Generative AI and agentic AI models are novel and rapidly evolving. As such, they are not within the scope of this guidance."* The mappings below apply to **traditional model risk** (algorithmic credit scoring, fraud detection, statistical models). The agencies have indicated they will issue a separate AI-specific request for information; until then, controls relating to generative or agentic AI capabilities reflect **analogous sound risk management principles** rather than direct SR 26-2 / OCC 2026-13 obligations.
+
+    The guidance is described as "most relevant to" banking organizations with **over $30 billion in total assets**, but it may also apply to smaller institutions with complex model portfolios. It does NOT apply to broker-dealers, RIAs, credit unions, or insurance carriers as a standalone regulatory authority for those institution types.
+
 ### Applicable Controls
 
 **Pillar 1 - Security Controls (7 controls):**
@@ -788,14 +793,14 @@ Applies to national banks and federal savings associations. Requires governance 
 | [2.7](../controls/pillar-2-management/2.7-vendor-and-third-party-risk-management.md) | Vendor Risk Management | Third-party model governance |
 | [2.8](../controls/pillar-2-management/2.8-access-control-and-segregation-of-duties.md) | Access Control and SoD | Model development controls |
 | [2.9](../controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md) | Performance Monitoring | Model performance tracking |
-| [2.11](../controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md) | Bias Testing | Fairness and discrimination testing |
+| [2.11](../controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md) | Bias Testing | Fairness and discrimination testing for traditional models; analogous principle for GenAI fairness review |
 | [2.12](../controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) | Supervision | Model governance oversight |
 | [2.13](../controls/pillar-2-management/2.13-documentation-and-record-keeping.md) | Documentation | Model documentation |
 | [2.15](../controls/pillar-2-management/2.15-environment-routing.md) | Environment Routing | Model environment governance |
-| [2.16](../controls/pillar-2-management/2.16-rag-source-integrity-validation.md) | RAG Source Integrity | Model data source validation |
+| [2.16](../controls/pillar-2-management/2.16-rag-source-integrity-validation.md) | RAG Source Integrity | Analogous principle for GenAI grounding-source validation |
 | [2.17](../controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md) | Multi-Agent Orchestration | Complex model governance |
 | [2.18](../controls/pillar-2-management/2.18-automated-conflict-of-interest-testing.md) | Conflict of Interest Testing | Model bias detection |
-| [2.20](../controls/pillar-2-management/2.20-adversarial-testing-and-red-team-framework.md) | Adversarial Testing | Model robustness testing |
+| [2.20](../controls/pillar-2-management/2.20-adversarial-testing-and-red-team-framework.md) | Adversarial Testing | Analogous principle for GenAI adversarial robustness testing |
 | [2.24](../controls/pillar-2-management/2.24-agent-feature-enablement-and-restriction-governance.md) | Feature Enablement Governance | Model risk management for AI capability controls |
 
 | Control | Requirement | SR 26-2 (formerly SR 11-7) Mapping |
@@ -807,7 +812,7 @@ Applies to national banks and federal savings associations. Requires governance 
 | [3.6](../controls/pillar-3-reporting/3.6-orphaned-agent-detection-and-remediation.md) | Orphaned Agent Detection | Model lifecycle management |
 | [3.7](../controls/pillar-3-reporting/3.7-ppac-security-posture-assessment.md) | Security Posture | Model security assessment |
 | [3.8](../controls/pillar-3-reporting/3.8-copilot-hub-and-governance-dashboard.md) | Copilot Hub | Model governance dashboard |
-| [3.10](../controls/pillar-3-reporting/3.10-hallucination-feedback-loop.md) | Hallucination Feedback Loop | Model output accuracy monitoring |
+| [3.10](../controls/pillar-3-reporting/3.10-hallucination-feedback-loop.md) | Hallucination Feedback Loop | Analogous principle for GenAI output-quality monitoring |
 | [3.11](../controls/pillar-3-reporting/3.11-centralized-agent-inventory-enforcement.md) | Centralized Inventory Enforcement | Model inventory and ongoing monitoring |
 | [3.12](../controls/pillar-3-reporting/3.12-agent-governance-exception-and-override-management.md) | Exception Management | Model governance exception and override tracking |
 


### PR DESCRIPTION
## Summary

Track C primary-source verification (federalreserve.gov + occ.gov) confirmed Audit #1's finding that the interagency MRM guidance issued April 17, 2026 explicitly excludes generative AI and agentic AI from scope. The framework currently maps several GenAI-specific controls to this guidance, which is technically incorrect under the guidance's own scope language.

## What this PR does

1. **Scope caveat** added to SR 26-2 / OCC 2026-13 sections in `regulatory-mappings.md` and `regulatory-framework.md` noting:
   - GenAI/agentic AI exclusion (verbatim quote)
   - `` "most relevant to" relevance marker (NOT a hard exclusion)
   - Agency intent to issue separate AI-specific RFIA

2. **Re-characterized** GenAI-specific control mappings as "analogous sound risk management principles" rather than direct regulatory obligations:
   - Control 2.11 (Bias Testing)
   - Control 2.16 (RAG Source Integrity)
   - Control 2.20 (Adversarial Testing)
   - Control 3.10 (Hallucination Feedback Loop)

3. **Residual naming canonicalization** in Controls 1.4, 1.7, 2.7 + master mapping refs.

## Preserved
- All SR 26-2 / OCC 2026-13 mappings for traditional ML controls (Control 2.6 MRM, etc.)
- Canonical compound naming `OCC Bulletin 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly Fed SR 11-7)` throughout

## Stats
- 5 files, +22/-14

## Validation
- `mkdocs build --strict`: pass
- `verify_language_rules.py`, `check_manifest_doc_drift.py`, `verify_controls.py`, `compile_researcher_package.py`: all pass

## Reference
- Track C: `maintainers-local/audits/2026-05-16/findings/track-c-regulatory-verification.md`
- Fix plan PR-3
