### PR TITLE
fix(collectors): Sentinel KQL must use OfficeActivity table

### DIFF
--- a/assessment/collectors/Collect-Sentinel.ps1
+++ b/assessment/collectors/Collect-Sentinel.ps1
@@ -272,7 +272,7 @@ try {
     Write-Verbose "Section 3: Running KQL audit check for CopilotInteraction records..."
 
     if ($workspaceInfo) {
-        $kqlQuery = 'AuditLogs | where OperationName contains "CopilotInteraction" | where TimeGenerated > ago(7d) | count'
+        $kqlQuery = 'OfficeActivity | where OfficeWorkload == "Copilot" or RecordType == "CopilotInteraction" | where TimeGenerated > ago(7d) | count'
 
         $queryResult = Invoke-CollectorOperation -Target $workspaceInfo.WorkspaceId -Action 'Run Copilot interaction KQL audit query' -ScriptBlock {
             Invoke-AzOperationalInsightsQuery `


### PR DESCRIPTION
## Summary
Replaces the Copilot Sentinel KQL in `Collect-Sentinel.ps1`. Query now targets `OfficeActivity` instead of `AuditLogs`. Restores actual Copilot audit signal detection.

## Why this is P0
`AuditLogs` is the Entra ID audit table — it never contains `CopilotInteraction` operations. The Sentinel collector therefore returned zero Copilot signal in production. Microsoft researcher validation (handoff doc 2026-05-17) confirmed the correct table is `OfficeActivity` for `Microsoft Copilot` workloads.

## Validation
- No remaining `AuditLogs.*Copilot` regex matches in `Collect-Sentinel.ps1`
- PSScriptAnalyzer pass
- PowerShell syntax check pass

Source: `maintainers-local/audits/2026-05-16/researcher-responses/fsi-agentgov-master-handoff.md` row P0-1.

Closes finding U-044.
