### PR TITLE
fix(license): correct Copilot Studio Dataverse baseline capacity

### DIFF
--- a/docs/reference/license-requirements.md
+++ b/docs/reference/license-requirements.md
@@ -219,11 +219,11 @@ License mapping guidance for the current FSI Agent Governance Framework control 
 
 | Product | Premium Connectors | Dataverse Access | Notes |
 |---------|-------------------|------------------|-------|
-| **Copilot Studio** | ✅ Included | ✅ Included (15 GB default) | No additional connector licensing required |
+| **Copilot Studio** | ✅ Included | ✅ Included via tenant default environment baseline (3 GB database + 3 GB file + 1 GB log = 7 GB) plus per-license accruals | No fixed '15 GB default'; verify tenant capacity in [Power Platform Admin Center](https://learn.microsoft.com/en-us/power-platform/admin/capacity-storage) |
 | **Power Apps** | Requires Premium license | Requires Premium license | Per-user or per-app licensing |
 | **Power Automate** | Requires Premium license | Requires Premium license | Per-user or per-flow licensing |
 
-**Common Misconception:** Teams building Copilot Studio agents do NOT need separate premium connector licenses. All premium connectors and Dataverse access (15 GB default capacity) are included with the Copilot Studio license at no additional cost.
+**Common Misconception:** Teams building Copilot Studio agents do NOT need separate premium connector licenses. Copilot Studio — Dataverse — Included via tenant default environment baseline (3 GB database + 3 GB file + 1 GB log = 7 GB) plus per-license accruals. No fixed '15 GB default'; verify tenant capacity in [Power Platform Admin Center](https://learn.microsoft.com/en-us/power-platform/admin/capacity-storage).
 
 **Power Apps/Power Automate Context:** Premium connector and Dataverse access require Power Apps Premium, Power Apps per app, Power Automate Premium, or Power Automate per flow licenses for all accessing users.
 

--- a/docs/reference/solutions-architecture-guide.md
+++ b/docs/reference/solutions-architecture-guide.md
@@ -133,7 +133,7 @@ Graph API throttling applies to all solutions using Microsoft 365 data.
 
 ### Dataverse Capacity
 
-As of December 2025, Microsoft significantly increased default Dataverse capacity.
+As of December 2025, Microsoft significantly increased default Dataverse capacity for several Power Platform licenses. Copilot Studio remains separate: it uses the tenant default environment baseline (3 GB database + 3 GB file + 1 GB log = 7 GB) plus per-license accruals rather than a fixed 15 GB default.
 
 | License | Previous Database Capacity | New Database Capacity (Dec 2025) |
 |---------|---------------------------:|---------------------------------:|
@@ -141,10 +141,10 @@ As of December 2025, Microsoft significantly increased default Dataverse capacit
 | Power Apps Premium | 10 GB | 20 GB |
 | Power Automate Premium | 10 GB | 20 GB |
 | Dynamics 365 Sales/CS | 10 GB | 30 GB |
-| Copilot Studio | 5 GB | 15 GB |
+| Copilot Studio | Not documented as fixed amount | Tenant default environment baseline (3 GB database + 3 GB file + 1 GB log = 7 GB) plus per-license accruals |
 
 !!! note "No Technical Limit"
-    There's no technical limit on Dataverse environment size—limits are entitlement-based. Organizations can purchase additional capacity if needed.
+    There's no technical limit on Dataverse environment size—limits are entitlement-based. Organizations can purchase additional capacity if needed. For Copilot Studio, verify actual tenant capacity in [Power Platform Admin Center](https://learn.microsoft.com/en-us/power-platform/admin/capacity-storage) rather than assuming a fixed 15 GB default.
 
 **ELM Capacity Guidance:**
 
@@ -153,7 +153,7 @@ For Environment Lifecycle Management:
 - EnvironmentRequest records: ~2 KB each
 - ProvisioningLog records: ~1 KB each
 - 100 environments/month = ~0.5 MB/month
-- 15 GB default capacity supports years of requests
+- The documented 3 GB default database baseline alone supports years of requests at this volume; verify total tenant capacity in Power Platform Admin Center.
 
 **Sources:**
 - [Dataverse capacity-based storage details](https://learn.microsoft.com/en-us/power-platform/admin/capacity-storage)


### PR DESCRIPTION
## Summary
Replaces the incorrect "15 GB Dataverse default" claim with the documented tenant default-environment baseline:
- **3 GB database** + **3 GB file** + **1 GB log** (= 7 GB nominal)
- Plus per-license accruals (capacity grows as Power Apps / Power Automate / Copilot Studio licenses are assigned)

Applied to:
- `docs/reference/license-requirements.md`
- `docs/reference/solutions-architecture-guide.md`

## Why this is P0
Customer right-sizing decisions were being made against a 2× overstated baseline. Microsoft researcher validation (handoff doc 2026-05-17) confirmed the correct values with Microsoft Learn citation.

## Validation
- `python scripts/verify_language_rules.py` ✅
- `mkdocs build --strict` ✅

Source: `maintainers-local/audits/2026-05-16/researcher-responses/fsi-agentgov-master-handoff.md` row P0-3 and `fsi-licensing-validation-report.md`.

Closes finding U-046 (Dataverse baseline subset; broader licensing report integration tracked separately as Phase 2).