### PR TITLE
fix(assessment): reconcile collector payload contract with score.py

### DIFF
--- a/assessment/engine/score.py
+++ b/assessment/engine/score.py
@@ -223,9 +223,59 @@ def _first_present(mapping: dict, *keys: str) -> object:
     return None
 
 
+def _normalize_ppac_environment(environment: dict) -> dict:
+    """Normalize PPAC environment records to the evaluator-facing shape."""
+    normalized_environment = dict(environment)
+
+    properties = normalized_environment.get("Properties")
+    if isinstance(properties, dict):
+        properties = dict(properties)
+    else:
+        properties = {}
+
+    linked_metadata = properties.get("linkedEnvironmentMetadata")
+    if isinstance(linked_metadata, dict):
+        linked_metadata = dict(linked_metadata)
+    else:
+        linked_metadata = {}
+
+    environment_sku = properties.get("environmentSku")
+    if environment_sku is None:
+        environment_sku = _first_present(environment, "EnvironmentSku")
+    if environment_sku is not None:
+        properties["environmentSku"] = environment_sku
+
+    linked_type = linked_metadata.get("type")
+    if linked_type is None:
+        linked_type = _first_present(environment, "LinkedEnvironmentType")
+    if linked_type is not None:
+        linked_metadata["type"] = linked_type
+
+    security_group_id = linked_metadata.get("securityGroupId")
+    if security_group_id is None:
+        security_group_id = _first_present(environment, "SecurityGroupId")
+    if security_group_id is not None:
+        linked_metadata["securityGroupId"] = security_group_id
+
+    if linked_metadata:
+        properties["linkedEnvironmentMetadata"] = linked_metadata
+    if properties:
+        normalized_environment["Properties"] = properties
+
+    return normalized_environment
+
+
 def _normalize_ppac_data(ppac: dict) -> dict:
     """Backfill legacy evaluator keys from collector-real PPAC payloads."""
     normalized = dict(ppac)
+
+    environments = normalized.get("environments")
+    if isinstance(environments, list):
+        normalized["environments"] = [
+            _normalize_ppac_environment(environment)
+            for environment in environments
+            if isinstance(environment, dict)
+        ]
 
     if normalized.get("role_assignments") is None:
         role_assignments = _first_present(ppac, "roleAssignments")

--- a/assessment/tests/fixtures/ppac_collector_contract.json
+++ b/assessment/tests/fixtures/ppac_collector_contract.json
@@ -1,0 +1,53 @@
+{
+  "_metadata": {
+    "collector": "Collect-PPAC",
+    "timestamp": "2026-03-25T21:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "environments": [
+    {
+      "DisplayName": "Core Dataverse",
+      "EnvironmentName": "env-prod-001",
+      "IsDefault": false,
+      "EnvironmentSku": "Production",
+      "LinkedEnvironmentType": "Dataverse",
+      "SecurityGroupId": "sg-001",
+      "States": {
+        "management": {
+          "id": "Managed"
+        }
+      }
+    }
+  ],
+  "dlpPolicies": [
+    {
+      "DisplayName": "FSI Default DLP",
+      "Environments": ["env-prod-001"],
+      "ConnectorGroups": {
+        "BusinessDataGroup": ["SharePoint"],
+        "BlockedGroup": ["Twitter"]
+      }
+    }
+  ],
+  "roleAssignments": [
+    {
+      "EnvironmentName": "env-prod-001",
+      "DisplayName": "Production",
+      "Assignments": [
+        {
+          "PrincipalType": "User",
+          "PrincipalObjectId": "user-001",
+          "RoleDefinition": {
+            "name": "Environment Maker"
+          }
+        }
+      ]
+    }
+  ],
+  "routingRules": [],
+  "inactivityTimeout": null,
+  "securityPosture": null,
+  "agentFeatureFlags": {},
+  "environmentGroups": []
+}

--- a/assessment/tests/test_score.py
+++ b/assessment/tests/test_score.py
@@ -336,6 +336,49 @@ class TestZoneThresholdBoundary:
 
 
 # ---------------------------------------------------------------------------
+# Test: collector-real PPAC payloads normalize into score.py's contract
+# ---------------------------------------------------------------------------
+
+class TestCollectorContractNormalization:
+    """Representative collector payloads should score without contract drift."""
+
+    def test_ppac_collector_shape_supports_control_2_1(
+        self, tmp_path: Path, manifest: dict
+    ):
+        score = pytest.importorskip("score")  # type: ignore[import-untyped]
+
+        collected = tmp_path / "collected"
+        collected.mkdir()
+
+        write_json(
+            collected / "ppac.json",
+            load_fixture("ppac_collector_contract.json"),
+        )
+        for name in ("graph", "purview", "sharepoint", "sentinel"):
+            write_json(collected / f"{name}.json", load_fixture(f"{name}.json"))
+
+        manifest_path = tmp_path / "controls.json"
+        output_path = tmp_path / "scores.json"
+        write_json(manifest_path, manifest)
+
+        score.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected),
+            zone=2,
+            output_path=str(output_path),
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        ctrl = next(c for c in result["controls"] if c["id"] == "2.1")
+
+        assert ctrl["checks_passed"] == 2
+        assert ctrl["maturity_score"] == 2
+        assert ctrl["evidence"]["2.1.a"]["result"] == "pass"
+        assert "securityGroupId" in ctrl["evidence"]["2.1.a"]["value"]
+        assert ctrl["evidence"]["2.1.b"]["result"] == "pass"
+
+
+# ---------------------------------------------------------------------------
 # Test: summary calculation matches individual controls
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Closes finding U-031. The 6 PowerShell collectors under ssessment/collectors/ were emitting collector-real camelCase / flattened JSON which ssessment/engine/score.py only partially normalized. PPAC environment records in particular surfaced EnvironmentSku and SecurityGroupId as flattened fields, while the scoring evaluators expected nested Properties.environmentSku and Properties.linkedEnvironmentMetadata.securityGroupId; that made real collected payloads score false negatives or unknown results at runtime.

## Fix approach
Option B. I kept the collectors unchanged and extended score.py's normalization layer so collector-real PPAC environment payloads are translated into the evaluator-facing contract before scoring. I also added a contract fixture + pytest that stages a representative PPAC collector payload and proves control 2.1 now scores correctly end-to-end.

## Files touched
- ssessment/engine/score.py
- ssessment/tests/test_score.py
- ssessment/tests/fixtures/ppac_collector_contract.json

## Validation
- pytest assessment/tests/ -v ✅ (with new contract test added)
- uff check assessment scripts ✅
- python scripts/verify_language_rules.py ✅
- mkdocs build --strict ✅
- PSScriptAnalyzer on collectors: zero Errors ✅

## Follow-up noted
- Graph, Purview, and SharePoint collector payloads already had a normalization bridge in score.py.
- Sentinel and Frontier collector payloads are still largely outside score.py's bespoke evaluator path today; I left those broader evaluator/source-mapping gaps unchanged to keep U-031 scoped to payload-contract reconciliation.

Closes finding U-031.