### PR TITLE
ci+build: add post-build output verification (closes U-038)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -247,6 +247,7 @@ See `AGENTS.md` Multi-Agent Coordination section for full protocol.
 ```bash
 # Validate site builds without errors
 mkdocs build --strict
+python scripts/verify_build_output.py
 
 # Preview locally
 mkdocs serve

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -11,6 +11,7 @@ on:
       - 'mkdocs.yml'
       - 'overrides/**'
       - 'VERSION'
+      - 'scripts/verify_build_output.py'
       - '.github/workflows/docs-validation.yml'
       # Required-check coverage gate: mkdocs-strict is a required check by
       # branch protection. Playwright specs (tests/**) often reference docs
@@ -51,6 +52,13 @@ jobs:
 
       - name: Build documentation (strict)
         run: mkdocs build --strict
+
+      - name: Verify built site output completeness
+        # Closes U-038 — `mkdocs build --strict` can exit 0 while a widened
+        # exclude_docs pattern or partial artifact step drops major route
+        # families from site/. This asserts the expected subtrees + search
+        # asset exist before downstream validators run.
+        run: python scripts/verify_build_output.py site
 
       - name: Verify OpenGraph and Twitter Card meta tags on built site
         # Closes AS22 — verify_meta_tags.py was added in AS16 but never

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Validate Documentation
         run: mkdocs build --strict
 
+      - name: Verify built site output completeness
+        run: python scripts/verify_build_output.py site
+
       - name: Verify mkdocs.yml site_url is explicit (defense-in-depth)
         shell: bash
         run: |

--- a/.github/workflows/required-check-shims.yml
+++ b/.github/workflows/required-check-shims.yml
@@ -34,6 +34,7 @@ on:
       - 'overrides/**'
       - 'mkdocs.yml'
       - 'VERSION'
+      - 'scripts/verify_build_output.py'
       - '.github/workflows/e2e-smoke.yml'
       - '.github/workflows/docs-validation.yml'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,8 +331,9 @@ When writing control documentation:
 Always run before completing work:
 
 ```bash
-mkdocs build --strict              # Validates links and structure
-python scripts/verify_controls.py  # Validates control files
+mkdocs build --strict                # Validates links and structure
+python scripts/verify_build_output.py  # Verifies built site completeness
+python scripts/verify_controls.py    # Validates control files
 ```
 
 Additional validations (when applicable):

--- a/scripts/verify_build_output.py
+++ b/scripts/verify_build_output.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""verify_build_output.py — fail CI on incomplete MkDocs build output.
+
+Why this exists:
+  `mkdocs build --strict` catches warnings/errors emitted during the build, but
+  it does not assert that the rendered `site/` tree still contains the expected
+  route families and search assets. A widened `exclude_docs` pattern or a
+  partial artifact/deploy step can therefore exit 0 while omitting large parts
+  of the published site.
+
+Usage:
+  python scripts/verify_build_output.py
+  python scripts/verify_build_output.py site
+  python scripts/verify_build_output.py --min-reference-html 20 --min-controls-html 60
+
+Run this immediately after `python -m mkdocs build --strict` (or `mkdocs build
+--strict`) so the assertions inspect a fresh `site/` tree.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_SITE_ROOT = Path("site")
+DEFAULT_MIN_REFERENCE_HTML = 20
+DEFAULT_MIN_CONTROLS_HTML = 60
+DEFAULT_MIN_SEARCH_BYTES = 100_000
+DEFAULT_MIN_INDEX_BYTES = 1_024
+SEARCH_INDEX_CANDIDATES = (
+    Path("search/search_index.json"),
+    Path("search/search_index.json.gz"),
+)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """One human-readable post-build assertion result."""
+
+    label: str
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    """Thresholds for required built-site artifacts."""
+
+    min_reference_html: int
+    min_controls_html: int
+    min_search_bytes: int
+    min_index_bytes: int
+
+
+def count_html(directory: Path) -> int:
+    """Return the number of HTML files under a directory tree."""
+    if not directory.is_dir():
+        return 0
+    return sum(1 for _ in directory.rglob("*.html"))
+
+
+def find_search_index(site_root: Path) -> Path | None:
+    """Return the emitted search index asset, if any."""
+    for relative_path in SEARCH_INDEX_CANDIDATES:
+        candidate = site_root / relative_path
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def verify(site_root: Path, thresholds: Thresholds) -> list[CheckResult]:
+    """Collect post-build assertions for the rendered site tree."""
+    results: list[CheckResult] = []
+
+    index_html = site_root / "index.html"
+    if index_html.is_file():
+        index_bytes = index_html.stat().st_size
+        results.append(CheckResult(
+            label="site index",
+            ok=index_bytes >= thresholds.min_index_bytes,
+            detail=(
+                f"expected {index_html} to be at least {thresholds.min_index_bytes} bytes; "
+                f"found {index_bytes}"
+            ),
+        ))
+    else:
+        results.append(CheckResult(
+            label="site index",
+            ok=False,
+            detail=f"expected {index_html} to exist after the MkDocs build",
+        ))
+
+    reference_dir = site_root / "reference"
+    reference_html_count = count_html(reference_dir)
+    results.append(CheckResult(
+        label="reference subtree",
+        ok=reference_html_count >= thresholds.min_reference_html,
+        detail=(
+            f"expected at least {thresholds.min_reference_html} HTML files under {reference_dir}; "
+            f"found {reference_html_count}"
+        ),
+    ))
+
+    controls_dir = site_root / "controls"
+    controls_html_count = count_html(controls_dir)
+    results.append(CheckResult(
+        label="controls subtree",
+        ok=controls_html_count >= thresholds.min_controls_html,
+        detail=(
+            f"expected at least {thresholds.min_controls_html} HTML files under {controls_dir}; "
+            f"found {controls_html_count}"
+        ),
+    ))
+
+    search_index = find_search_index(site_root)
+    if search_index is None:
+        expected_paths = ", ".join(str(site_root / path) for path in SEARCH_INDEX_CANDIDATES)
+        results.append(CheckResult(
+            label="search index",
+            ok=False,
+            detail=(
+                "expected a generated search index asset after the MkDocs build; "
+                f"looked for {expected_paths}"
+            ),
+        ))
+    else:
+        search_bytes = search_index.stat().st_size
+        results.append(CheckResult(
+            label="search index",
+            ok=search_bytes >= thresholds.min_search_bytes,
+            detail=(
+                f"expected {search_index} to be at least {thresholds.min_search_bytes} bytes; "
+                f"found {search_bytes}"
+            ),
+        ))
+
+    return results
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "site_root",
+        nargs="?",
+        default=DEFAULT_SITE_ROOT,
+        type=Path,
+        help="Path to the built MkDocs site/ directory (default: site).",
+    )
+    parser.add_argument(
+        "--min-reference-html",
+        type=int,
+        default=DEFAULT_MIN_REFERENCE_HTML,
+        help=(
+            "Minimum number of rendered HTML files expected under site/reference/ "
+            f"(default: {DEFAULT_MIN_REFERENCE_HTML})."
+        ),
+    )
+    parser.add_argument(
+        "--min-controls-html",
+        type=int,
+        default=DEFAULT_MIN_CONTROLS_HTML,
+        help=(
+            "Minimum number of rendered HTML files expected under site/controls/ "
+            f"(default: {DEFAULT_MIN_CONTROLS_HTML})."
+        ),
+    )
+    parser.add_argument(
+        "--min-search-bytes",
+        type=int,
+        default=DEFAULT_MIN_SEARCH_BYTES,
+        help=(
+            "Minimum size for site/search/search_index.json (or .json.gz) in bytes "
+            f"(default: {DEFAULT_MIN_SEARCH_BYTES})."
+        ),
+    )
+    parser.add_argument(
+        "--min-index-bytes",
+        type=int,
+        default=DEFAULT_MIN_INDEX_BYTES,
+        help=(
+            "Minimum size for site/index.html in bytes "
+            f"(default: {DEFAULT_MIN_INDEX_BYTES})."
+        ),
+    )
+    return parser
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not args.site_root.is_dir():
+        print(f"ERROR: built site root not found: {args.site_root}", file=sys.stderr)
+        print("Run `python -m mkdocs build --strict` before invoking this verifier.", file=sys.stderr)
+        return 2
+
+    thresholds = Thresholds(
+        min_reference_html=args.min_reference_html,
+        min_controls_html=args.min_controls_html,
+        min_search_bytes=args.min_search_bytes,
+        min_index_bytes=args.min_index_bytes,
+    )
+    results = verify(args.site_root, thresholds)
+    failures = [result for result in results if not result.ok]
+
+    if failures:
+        print("FAIL: built site output assertions failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure.label}: {failure.detail}", file=sys.stderr)
+        print(
+            "Re-run the MkDocs build and inspect mkdocs.yml exclude_docs/not_in_nav, "
+            "workflow artifact handling, or deploy-copy steps.",
+            file=sys.stderr,
+        )
+        return 1
+
+    index_html = args.site_root / "index.html"
+    reference_html_count = count_html(args.site_root / "reference")
+    controls_html_count = count_html(args.site_root / "controls")
+    search_index = find_search_index(args.site_root)
+    search_label = search_index.name if search_index else "missing"
+    search_bytes = search_index.stat().st_size if search_index else 0
+    print(
+        "OK: build output verified "
+        f"(index.html={index_html.stat().st_size} bytes, "
+        f"reference_html={reference_html_count}, "
+        f"controls_html={controls_html_count}, "
+        f"search_asset={search_label}, "
+        f"search_bytes={search_bytes})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Closes finding U-038 (P1). `mkdocs build --strict` only detects warnings/errors at build-time; it does not assert that the rendered `site/` tree contains the expected subtrees and search index. A partial build (e.g., `exclude_docs` accidentally widened, or a workflow producing an incomplete deploy) would silently pass.

## Fix
Adds `scripts/verify_build_output.py` that asserts:
- N HTML files under `site/reference/`
- N HTML files under `site/controls/`
- `site/search/search_index.json` present and non-trivial
- Site index page exists

Wired into the workflows that actually run `mkdocs build --strict` (`docs-validation.yml` and `publish_docs.yml`) immediately after the strict build step. Documented in `AGENTS.md` and `.github/copilot-instructions.md` under build validation commands.

## Validation
- Positive case: script exits 0 against current `site/` build
- Negative case: artificially reducing `site/` causes a clear non-zero exit with actionable detail

Closes finding U-038.