### PR TITLE
docs(1.10): add customer complaints handling (FINRA 4530(d))

### DIFF
--- a/assessment/manifest/controls.json
+++ b/assessment/manifest/controls.json
@@ -1049,7 +1049,7 @@
         "maturity_score": 4
       }
     },
-    "manual_question": "Has the supervision review queue been reviewed by a compliance officer in the last 30 days?",
+    "manual_question": "Has the supervision review queue been reviewed by a compliance officer in the last 30 days, and does the Communication Compliance configuration capture and tag AI-related customer complaints with linkage to the underlying agent interaction and feed into the FINRA Rule 4530(d) quarterly report?",
     "name": "Communication Compliance Monitoring",
     "zonesApplicable": [
       2,

--- a/docs/controls/pillar-1-security/1.10-communication-compliance-monitoring.md
+++ b/docs/controls/pillar-1-security/1.10-communication-compliance-monitoring.md
@@ -2,7 +2,7 @@
 
 **Control ID:** 1.10<br>
 **Pillar:** Security<br>
-**Regulatory Reference:** FINRA Rule 4511, FINRA Rule 3110(b), FINRA 25-07, SEC Rule 17a-3, SEC Rule 17a-4(b)(4), SEC Reg S-P, GLBA 501(b)<br>
+**Regulatory Reference:** FINRA Rule 4511, FINRA Rule 3110(b), FINRA Rule 4530(d), FINRA 25-07, SEC Rule 17a-3, SEC Rule 17a-4(b)(4), SEC Reg S-P, GLBA 501(b)<br>
 **Last UI Verified:** April 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
@@ -17,6 +17,7 @@ Detect and review policy-relevant content in agent-assisted interactions, includ
 ## Why This Matters for FSI
 
 - **FINRA Rule 4511 / Rule 3110(b):** Supervision of AI-assisted communications; firms must retain and review AI agent interactions. FINRA Rule 3110 requires written supervisory procedures reasonably designed for the firm's business.
+- **FINRA Rule 4530(d):** Firms must report quarterly statistics on written customer complaints. AI-related complaints received in writing, such as allegations that Copilot output was misleading, fabricated, unsuitable, or exposed confidential data, should be captured and routed into that reporting workflow.
 - **FINRA Notice 25-07 (and Notice 24-09):** Reinforces that firms are responsible for communications regardless of whether they are AI-generated. *Note: FINRA Notice 24-09 explicitly states it does not create new legal or regulatory requirements; the existing supervision and recordkeeping rules apply.*
 - **SEC Rule 17a-3 / 17a-4(b)(4):** Retention and review of customer communications; 2022 amendments allow an audit-trail alternative to WORM for electronic records. The durable books-and-records obligation is met via Exchange/Teams retention and records management (see Control 1.9), not by Communication Compliance Policy Match Preservation alone.
 - **SEC Regulation S-P:** Customer information safeguards apply to NPI surfaced through agent interactions.
@@ -46,9 +47,16 @@ Detect and review policy-relevant content in agent-assisted interactions, includ
 |------------|-------------|
 | Inappropriate content detection | Detect harassment, threats, discrimination in agent interactions |
 | Regulatory violation monitoring | Identify unsuitable recommendations, MNPI indicators |
+| Customer complaint routing | Detect, tag, and route AI-related written customer complaints for supervisory review and FINRA Rule 4530(d) quarterly statistics |
 | Sensitive data protection | Detect customer data in agent responses |
 | AI classifiers | Machine learning detection for complex scenarios |
 | Review workflow | Triage, escalation, and remediation workflow |
+
+### Customer complaint handling (FINRA Rule 4530(d))
+
+Communication Compliance should treat potential written customer complaints about AI-assisted communications as a supervisory-routing scenario, not just a generic policy hit. When a customer alleges in writing that a Copilot or agent response was misleading, fabricated, unsuitable, or exposed confidential data, reviewers should flag the event as a potential complaint, apply a firm-defined AI-complaint tag, and route the item to Compliance for supervisory review and quarterly FINRA Rule 4530(d) reporting.
+
+Each complaint record should carry a durable reference to the underlying AI interaction preserved through Control 1.7's preservation architecture, such as the prompt/response record, conversation ID, message ID, or evidence-manifest reference. That linkage supports reconstruction, retention, escalation, and downstream reporting. Organizations should verify the tagging taxonomy, case-routing workflow, and quarterly complaint-report process align to their written supervisory procedures and complaint-management standards.
 
 ### Monitored Channels and AI Locations
 
@@ -80,6 +88,8 @@ Communication Compliance policies operate across the channels and locations Micr
 - Use the built-in template **"Detect Microsoft Copilot interactions"** as the starting point for Copilot monitoring; Microsoft Learn's policy-template reference documents **Prompt Shields** and **Protected material** conditions for the Copilot interactions template, and administrators should verify the displayed conditions before creating the policy.
 - Use **"Detect inappropriate text"** (Exchange + Teams + Viva Engage) for harassment / threats / discrimination scenarios. Note that **"Detect inappropriate content"** is locked to Teams + Viva Engage with Hate / Violence / Sexual / Self-harm classifiers; it does not support Exchange or Copilot locations.
 - Use **"Detect financial regulatory compliance"** (Regulatory compliance template) for FINRA-specific scenarios. *This template defaults to a 10% review percentage; FSI customers supervising registered representatives typically need 100%; tune the review percentage explicitly and document the basis.*
+- Configure complaint-focused keywords, classifier coverage, or custom dictionaries so written allegations about misleading AI output, fabricated information, unauthorized recommendations, or confidential-data exposure are routed to the Regulatory compliance workflow.
+- Define a firm-standard complaint tag and escalation path for AI-related written complaints, including the case-management reference that links the complaint record to the underlying AI interaction preserved through Control 1.7's preservation architecture.
 - Use **Custom policy** when template-locked locations / direction / conditions do not fit the use case.
 - Configure OCR via the policy condition checkbox (it is not a tenant-level toggle). OCR processing typically takes about an hour to take effect per Learn.
 - Document each policy's **Reviewers**, **Locations**, **Conditions**, **Review percentage**, **Direction**, and **Policy Match Preservation** setting as part of the supervisory design record.
@@ -123,9 +133,9 @@ Verify per tenant before assuming a feature is at parity. Communication Complian
 
 | Zone | Requirement | Rationale |
 |------|-------------|-----------|
-| **Zone 1** (Personal) | Baseline templates (Inappropriate text + Inappropriate content); weekly sampling at template default | Minimal regulatory exposure |
-| **Zone 2** (Team) | Add Regulatory compliance template; daily review cadence; documented compensating-control plan if any policy is paused | Shared accountability |
-| **Zone 3** (Enterprise) | Add **Detect Microsoft Copilot interactions** template; review percentage tuned for FINRA-supervised populations (often 100%); pseudonymization opt-out audited; admin-unit scoping for reviewers | Maximum regulatory protection |
+| **Zone 1** (Personal) | Baseline templates (Inappropriate text + Inappropriate content); weekly sampling at template default; manual complaint log and Compliance escalation for any written AI-related customer complaint | Minimal regulatory exposure; manual complaint handling may be acceptable when customer-facing AI use is limited |
+| **Zone 2** (Team) | Add Regulatory compliance template; daily review cadence; complaint-related keywords/tags; documented manual feed into quarterly FINRA Rule 4530(d) complaint statistics when customer-facing AI is in scope | Shared accountability and increased supervisory expectations |
+| **Zone 3** (Enterprise) | Add **Detect Microsoft Copilot interactions** template; review percentage tuned for FINRA-supervised populations (often 100%); pseudonymization opt-out audited; admin-unit scoping for reviewers; dedicated AI-complaint tag/queue with automated routing to Compliance and the quarterly reporting register | Maximum regulatory protection and formalized complaint-reporting workflow |
 
 ---
 
@@ -136,9 +146,10 @@ Verify per tenant before assuming a feature is at parity. Communication Complian
 | Communication Compliance (catch-all role group) | Legacy "do everything" group; restrict assignment in production tenants |
 | Communication Compliance Admins | Policy configuration and management |
 | Communication Compliance Analysts | Alert triage and review (per-policy reviewer assignment also required) |
-| Communication Compliance Investigators | Investigation, remediation, opt-in to view unmasked content (audited) |
+| Communication Compliance Investigators | Investigation, remediation, complaint tagging, and opt-in to view unmasked content (audited) |
 | Communication Compliance Viewers | Read-only access to dashboards and reports |
-| Legal / Compliance Officer | Reportability decisions, regulatory-routing, legal-hold escalation |
+| Compliance Officer | Reportability decisions, quarterly FINRA Rule 4530(d) complaint-statistics input, and legal-hold / supervisory escalation coordination |
+| Purview Records Manager | Validate complaint-to-interaction retention linkage and evidence references against Control 1.7's preservation architecture |
 | Privacy Officer | Pseudonymization opt-out approvals; admin-unit scoping decisions |
 
 ---
@@ -147,10 +158,11 @@ Verify per tenant before assuming a feature is at parity. Communication Complian
 
 | Control | Relationship |
 |---------|--------------|
-| [1.7 - Audit Logging](1.7-comprehensive-audit-logging-and-compliance.md) | Audit evidence for communications |
-| [1.9 - Data Retention](1.9-data-retention-and-deletion-policies.md) | Retention of communications |
+| [1.7 - Audit Logging](1.7-comprehensive-audit-logging-and-compliance.md) | Preservation architecture and audit evidence for complaint-to-interaction linkage |
+| [1.9 - Data Retention](1.9-data-retention-and-deletion-policies.md) | Retention of communications and complaint records |
 | [1.13 - Sensitive Information Types](1.13-sensitive-information-types-sits-and-pattern-recognition.md) | SITs for detection |
 | [2.12 - Supervision](../pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) | Supervision requirements ([FINRA Supervision Workflow](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/finra-supervision-workflow)) |
+| [3.3 - Compliance and Regulatory Reporting](../pillar-3-reporting/3.3-compliance-and-regulatory-reporting.md) | Quarterly complaint statistics and supervisory reporting outputs |
 | [1.12 - Insider Risk](1.12-insider-risk-detection-and-response.md) | Insider risk correlation |
 
 ---
@@ -159,12 +171,14 @@ Verify per tenant before assuming a feature is at parity. Communication Complian
 
 !!! info "Step-by-Step Implementation"
 
-    This control has detailed playbooks for implementation, automation, testing, and troubleshooting:
+    This control has detailed playbooks for implementation, automation, testing, troubleshooting, and complaint-routing evidence:
 
     - [Portal Walkthrough](../../playbooks/control-implementations/1.10/portal-walkthrough.md) — Step-by-step portal configuration
     - [PowerShell Setup](../../playbooks/control-implementations/1.10/powershell-setup.md) — Automation scripts
     - [Verification & Testing](../../playbooks/control-implementations/1.10/verification-testing.md) — Test cases and evidence collection
     - [Troubleshooting](../../playbooks/control-implementations/1.10/troubleshooting.md) — Common issues and resolutions
+
+    The portal and verification playbooks include complaint-tagging, escalation, retention-linkage, and quarterly FINRA Rule 4530(d) reporting handoff steps for AI-related written customer complaints.
 
 ---
 
@@ -183,6 +197,7 @@ Confirm control effectiveness by verifying:
 9. **Admin units / scoping** — reviewer/investigator permissions are scoped per region or business unit using administrative units where applicable
 10. **PAYG billing enabled** for any policy location where Microsoft Learn requires it, including Enterprise AI apps, Other AI apps, and non-Microsoft 365 AI data in Microsoft Copilot experiences
 11. **Sovereign cloud parity** — for GCC / GCC High / DoD tenants, capability gaps are recorded as compensating-control notes rather than asserted as functioning
+12. **Complaint-handling workflow** — complaint-oriented detection and routing are configured for AI-related written customer complaints; the complaint record references the underlying AI interaction preserved through Control 1.7's preservation architecture; and the quarterly FINRA Rule 4530(d) reporting process includes this complaint category
 
 ---
 
@@ -221,6 +236,7 @@ The FINRA 2026 Annual Regulatory Oversight Report emphasizes that firms must con
 - [Microsoft Learn: Connect to Security & Compliance PowerShell](https://learn.microsoft.com/en-us/powershell/exchange/connect-to-scc-powershell)
 - [Microsoft Learn: Trainable Classifiers](https://learn.microsoft.com/en-us/purview/classifier-learn-about)
 - [FINRA Rule 2210](https://www.finra.org/rules-guidance/rulebooks/finra-rules/2210)
+- [FINRA Rule 4530](https://www.finra.org/rules-guidance/rulebooks/finra-rules/4530)
 - [FINRA Rule 3110](https://www.finra.org/rules-guidance/rulebooks/finra-rules/3110)
 - [FINRA Notice 24-09](https://www.finra.org/rules-guidance/notices/24-09)
 - [FINRA Notice 25-07](https://www.finra.org/rules-guidance/notices/25-07)

--- a/docs/playbooks/control-implementations/1.10/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.10/portal-walkthrough.md
@@ -322,6 +322,7 @@ For every template below:
 - Reviewers: registered principals with the appropriate qualification per population
 - Direction: Inbound + Outbound (template-locked)
 - Review percentage: **100%** for supervised populations; document any population kept at 10% with risk-based justification
+- Complaint workflow: apply a firm-defined AI-customer-complaint tag, record the message ID or Copilot conversation reference in the case note, and route tagged alerts to the Compliance Officer's FINRA Rule 4530(d) quarterly complaint register
 
 ### Policy C — Copilot interactions (the AI-monitoring template)
 
@@ -539,9 +540,16 @@ Document in your firm's WSP — not in CC settings — the reviewer SLAs (e.g., 
 | CC Analyst | CC Investigator (escalate alert) | Alert confirmed as a violation |
 | CC Investigator | HR | Personnel-conduct violation |
 | CC Investigator | Legal | Regulatory violation; possible disclosure obligation |
+| CC Investigator | Compliance Officer | Written customer complaint tied to an AI-assisted communication; determine FINRA Rule 4530(d) treatment and supervisory disposition |
 | CC Investigator | eDiscovery ([Control 1.19](../../../controls/pillar-1-security/1.19-ediscovery-for-agent-interactions.md)) | Legal hold or production scope expansion needed |
 | CC Investigator | Insider Risk Management ([Control 1.12](../../../controls/pillar-1-security/1.12-insider-risk-detection-and-response.md)) | Pattern of risky behavior across multiple alerts |
 | CC Investigator | CISO + Legal | Cyber / data-loss event; trigger SEV-1/2 incident handling per [Control 1.10 troubleshooting §1](troubleshooting.md) |
+
+### Customer complaint routing (FINRA Rule 4530(d))
+
+1. When a reviewer confirms a written complaint about an AI-generated or AI-assisted communication, apply the firm's complaint tag and record the underlying message ID, prompt/response reference, or Copilot conversation ID in the case note.
+2. Escalate the tagged item to the Compliance Officer or designated registered principal for reportability review, and notify the records team if additional preservation steps are required under Controls 1.7 and 1.9.
+3. Export tagged complaint counts and dispositions into the firm's quarterly FINRA Rule 4530(d) complaint-statistics workflow. Verify the same complaint is not double-counted across manual and automated queues.
 
 ### Integration with Insider Risk Management (Control 1.12)
 

--- a/docs/playbooks/control-implementations/1.10/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.10/verification-testing.md
@@ -380,6 +380,8 @@ Each test is deterministic: a named test user, a known input, and an asserted ou
 
 **Evidence collected.** Per sub-case: body file with SHA-256, sender screenshot with UTC clock, reviewer-portal screenshot with the yellow-banner classifier visible (pseudonymized usernames), `Get-SupervisoryReviewActivity` CSV, transcript. SHA-256 sidecars.
 
+**Additional requirement for sub-case 1.10-CLS-01e (Customer complaints).** After the `Pending` entry appears, apply the firm's AI-customer-complaint tag, record the interaction reference (message ID, conversation ID, or evidence-manifest pointer), and capture the case or register export showing that the complaint feeds the FINRA Rule 4530(d) quarterly statistics process.
+
 ---
 
 ### 1.10-SAM-01 — Review percentage verification
@@ -724,7 +726,7 @@ $entries = Get-ChildItem $evidenceDir -File -Exclude *.sha256,manifest.json |
 | 3 | Pseudonymization settings screenshot + opt-out trail CSV | 1.10-PSE-01 |
 | 4 | Policy inventory CSV + full policy JSON | 1.10-POL-01 |
 | 5 | Copilot location screenshot + policy/rules JSON + Copilot prompt screenshot + audit CSV + PAYG attestation reference | 1.10-COP-01 |
-| 6 | Per-classifier sub-case body files + sender + reviewer screenshots + activity CSVs | 1.10-CLS-01 |
+| 6 | Per-classifier sub-case body files + sender + reviewer screenshots + activity CSVs; for 1.10-CLS-01e also include complaint-tag screenshot + quarterly-report register or case export | 1.10-CLS-01 |
 | 7 | Sampling-rate diff CSV + signed supervisory plan reference | 1.10-SAM-01 |
 | 8 | OME sender screenshot + reviewer-portal screenshot + audit CSV + exclusions list | 1.10-OME-01 |
 | 9 | Three tag-action portal screenshots + activity CSV + notify-user email screenshot | 1.10-INV-01 |

--- a/docs/reference/regulatory-mappings.md
+++ b/docs/reference/regulatory-mappings.md
@@ -136,6 +136,25 @@ Framework provides supervision procedure guidance through 8 mapped controls. Imp
 
 ---
 
+## FINRA Rule 4530(d) - Quarterly Customer Complaint Reporting
+
+### Overview
+Requires firms to file quarterly statistical reports for written customer complaints. Written complaints about AI-assisted or AI-generated communications, including allegations of misleading, fabricated, or confidential-data-exposing outputs, should be routed into this reporting workflow when received in writing.
+
+### Applicable Controls
+
+| Control | Requirement | Mapping |
+|---------|-------------|---------|
+| [1.10](../controls/pillar-1-security/1.10-communication-compliance-monitoring.md) | Communication Compliance | AI-related written customer complaints detected, tagged, and routed for quarterly FINRA Rule 4530(d) complaint statistics |
+| [1.7](../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Comprehensive Audit Logging | Preserves the underlying interaction reference and evidence chain supporting complaint reconstruction |
+| [2.12](../controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md) | Supervision and Oversight | Written supervisory procedures define complaint escalation and reportability review |
+| [3.3](../controls/pillar-3-reporting/3.3-compliance-and-regulatory-reporting.md) | Compliance Reporting | Aggregates complaint counts, supervisory metrics, and quarterly reporting outputs |
+
+### Framework Coverage
+Framework coverage depends on aligning complaint detection, evidence linkage, and quarterly reporting across the mapped controls above. Implementation requires firms to validate how AI-related complaints enter the firm's established FINRA Rule 4530(d) reporting process.
+
+---
+
 ## FINRA AI Supervision and Governance
 
 !!! warning "FINRA Notice 25-07 Clarification"


### PR DESCRIPTION
## Summary
Closes finding U-048 (P2). Extends Control 1.10 (Communication Compliance Monitoring) to cover the FINRA 4530(d) customer complaint pathway for AI-related complaints. Per user decision during 2026-05-18 backlog discussion: fold into existing 1.10 rather than scaffold a new control (stays at 78 controls). U-049 (Quota/Rate-limit) deferred.

## Changes
- docs/controls/pillar-1-security/1.10-communication-compliance-monitoring.md — added FINRA 4530(d) coverage across Why-This-Matters, Description, Configuration, Zone Requirements, Roles, Related Controls, Verification, and Additional Resources sections
- docs/reference/regulatory-mappings.md — added FINRA 4530(d) row for Control 1.10
- ssessment/manifest/controls.json — extended Control 1.10 manual question to cover complaint handling
- docs/playbooks/control-implementations/1.10/* — light additions for complaint-tagging workflow / verification (if changes warranted)

## Out of scope
- U-049 Quota / Rate-limit resilience — deferred per user decision

## Validation
- python scripts/verify_language_rules.py ✅
- python scripts/verify_controls.py ✅
- python scripts/check_manifest_doc_drift.py --check ✅
- mkdocs build --strict ✅
- pytest assessment/tests/ -v ✅

Closes finding U-048.