### PR TITLE
docs(controls): reconcile WORM/preservation model in 1.1 and 1.7 (closes U-037)

### DIFF
--- a/docs/controls/pillar-1-security/1.1-restrict-agent-publishing-by-authorization.md
+++ b/docs/controls/pillar-1-security/1.1-restrict-agent-publishing-by-authorization.md
@@ -2,7 +2,7 @@
 
 **Control ID:** 1.1<br>
 **Pillar:** Security<br>
-**Regulatory Reference:** FINRA 4511(a), FINRA 3110(a)/(b), FINRA Regulatory Notice 25-07 *(in comment period — not yet enacted; treat as forward-looking guidance)*, SEC Rule 17a-4(f), GLBA Safeguards Rule 16 CFR §314.4(c), SOX §404 (ICFR), OCC Bulletin 2023-17, OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly SR 11-7)<br>
+**Regulatory Reference:** FINRA 4511(a), FINRA 3110(a)/(b), FINRA Regulatory Notice 25-07 *(in comment period — not yet enacted; treat as forward-looking guidance)*, SEC Rule 17a-4(a), SEC Rule 17a-4(b)(4), SEC Rule 17a-4(f), GLBA Safeguards Rule 16 CFR §314.4(c), SOX §404 (ICFR), OCC Bulletin 2023-17, OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly SR 11-7)<br>
 **Last UI Verified:** April 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
@@ -19,7 +19,7 @@ Restrict who can publish AI agents to production environments by implementing se
 - **FINRA 4511(a) — Books and Records:** Records of who created, modified, and published each agent must be preserved. Publishing-authorization controls produce the maker/publisher provenance that supports those records.
 - **FINRA 3110(a)/(b) — Supervision:** Supervisory systems must designate who may deploy AI capabilities and demonstrate enforcement. Restricting publishing to a defined `Publishers` group, with logged approvals, supports this.
 - **FINRA Regulatory Notice 25-07** *(in comment period — proposed)*: Anticipates explicit AI supervision requirements. Implementing publishing restrictions now positions the firm ahead of likely final rule.
-- **SEC Rule 17a-4(f) — Electronic Records:** Agent publish events and approval records must be captured in a regulator-acceptable electronic recordkeeping system. The control feeds the data into Purview Audit, which is a record-capture operational telemetry surface — not, by itself, a 17a-4(f)-compliant preservation layer. Compliant preservation requires either (a) the WORM / audit-trail alternative established by the October 2022 amendments (effective May 3, 2023) or (b) export to a third-party 17a-4(f)-compliant electronic recordkeeping system (for example, Smarsh, Global Relay, Proofpoint, Mimecast, Bloomberg Vault, Veritas). See [Control 1.7 - Comprehensive Audit Logging](1.7-comprehensive-audit-logging-and-compliance.md) for full preservation guidance.
+- **SEC Rules 17a-4(a), 17a-4(b)(4), and 17a-4(f) — Records Retention and Preservation:** Publish events, approval records, publisher-membership snapshots, and related change-ticket evidence must be retained according to the firm's record schedule. For most agent communications, the base preservation period is 3 years under SEC Rule 17a-4(b)(4); records that constitute financial or accounting records, supervisory/governance evidence, or other regulated books and records may require 6 years or longer under SEC Rule 17a-4(a), FINRA Rule 4511(b), or other applicable rules. Microsoft Purview Audit is the capture layer for publishing telemetry. Firms subject to SEC Rule 17a-4(f) should use the preservation architecture defined in Control 1.7 rather than treating Audit retention alone as the preservation layer.
 - **GLBA Safeguards Rule 16 CFR §314.4(c)(1) — Access Controls:** Limiting who can deploy agents that may handle customer NPI is an access-control safeguard.
 - **SOX §404 — Internal Controls over Financial Reporting:** Agents that touch financial data, reporting workflows, or material disclosures fall in ICFR scope. Restricting publishing supports SoD.
 - **OCC Bulletin 2023-17 — Third-Party Risk:** Documented governance over third-party AI platform usage, including who can deploy.
@@ -196,7 +196,7 @@ Confirm control effectiveness by verifying:
 9. Generative AI agent publishing is disabled at tenant level or governance review is documented
 10. Unapproved agents are blocked in M365 Admin Center agent inventory
 11. Each production agent's Protection status is reviewed in Copilot Studio; any "Needs review" status is resolved before publish approval
-12. Audit log retention is configured to meet firm-specific obligations (commonly 6 years per FINRA 4511(b) and SEC 17a-4(b)(4)). **Important:** Microsoft Purview Audit (Standard) retains audit logs for 180 days; Audit (Premium) defaults to 1 year. Retention beyond 1 year requires an explicit **Audit Retention Policy** in Purview (configured separately under Purview > Audit > Audit retention policies). Verify the active retention policy covers the required period and includes the `BotUpdateOperation-BotPublish` operation
+12. Audit log retention is configured to meet the firm's record schedule, using the record-type model in [Control 1.7 - Comprehensive Audit Logging](1.7-comprehensive-audit-logging-and-compliance.md): 3 years for communications under SEC Rule 17a-4(b)(4), 6 years for financial/accounting or governance records under SEC Rule 17a-4(a) and FINRA Rule 4511(b), 5 years for CFTC Rule 1.31 records, and longer only where a specific rule or firm schedule requires it. **Important:** Microsoft Purview Audit (Standard) retains audit logs for 180 days; Audit (Premium) defaults to 1 year. Retention beyond 1 year requires an explicit **Audit Retention Policy** in Purview (configured separately under Purview > Audit > Audit retention policies). Verify the active retention policy covers the required period and includes the `BotUpdateOperation-BotPublish` operation
 13. Publishing records (audit logs, approval records, group membership changes) are searchable and exportable via Microsoft Purview eDiscovery for regulatory examination readiness
 14. All agent environments are provisioned in US regions with documented data residency confirmation
 
@@ -221,4 +221,4 @@ Confirm control effectiveness by verifying:
 !!! note "Implementation Note"
     Organizations should verify that their implementation meets their specific regulatory obligations. This control supports compliance efforts but requires proper configuration and ongoing validation.
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current (April 2026)*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current (April 2026)*

--- a/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
+++ b/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
@@ -48,15 +48,8 @@ Implement comprehensive audit logging to capture Microsoft 365 Copilot and Copil
 
 ## Control Description
 
-Microsoft Purview Audit provides comprehensive logging of user and admin activities across Microsoft 365, including Microsoft 365 Copilot and agent interactions. Audit logs are essential for compliance monitoring, security investigations, and regulatory examinations.
-
 !!! danger "Capture vs Preservation — read first"
-    Microsoft 365 Audit (Standard and Premium, including the 10-Year Audit Log Retention add-on) is **record-CAPTURE operational telemetry**. It is **not**, by itself, a SEC Rule 17a-4(f)–compliant electronic recordkeeping system for the books-and-records record set. Broker-dealers, FCMs, swap dealers, and CPOs subject to SEC 17a-4 / FINRA 4511 / CFTC 1.31 must satisfy preservation through one of:
-
-    - **WORM-format storage** of the books-and-records record set (e.g., Azure immutable blob storage with a time-based retention policy in a locked state — Cohasset-attested for SEC 17a-4(f), CFTC 1.31, and FINRA 4511 — see [Microsoft Learn: Immutable storage for Azure blob data](https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-storage-overview)), **or**
-    - The **audit-trail alternative** introduced by the October 2022 amendments to Rule 17a-4(f) (compliance date 3 May 2023), which requires the system to preserve original records and a complete time-stamped audit trail of all modifications and deletions, **plus** a Designated Executive Officer (DEO) representation or a Designated Third Party (DTP) undertaking, **plus** an independent records-management assessment.
-
-    A 17a-4(f) program for AI agent communications typically combines (a) Microsoft 365 Audit (this control) for activity capture, (b) eDiscovery / Communication Compliance / DSPM for AI for content retrieval (Controls 1.10, 1.19, 1.6), and (c) a 17a-4(f)-attested archive — either Azure immutable blob storage or a journaling / capture pipeline into a books-and-records vendor (Smarsh Enterprise Archive, Global Relay Archive, Proofpoint Enterprise Archive, Mimecast Cloud Archive, Bloomberg Vault, Veritas Enterprise Vault.cloud) — for preservation. **Do not rely on the 10-year audit retention add-on as your 17a-4(f) preservation layer.**
+    Control 1.7 governs the capture, search, export, and preservation architecture for Copilot and agent records. Retention should be set by record class, not by a blanket zone default: use 3 years for communications records under SEC Rule 17a-4(b)(4), 6 years for financial/accounting or governance records under SEC Rule 17a-4(a) and FINRA Rule 4511(b), 5 years for CFTC Rule 1.31 records, and longer periods only when a specific rule or the firm's records schedule requires it. Microsoft 365 Audit, including the 10-Year Audit Log Retention add-on, extends the capture window but is not, by itself, the SEC Rule 17a-4(f) preservation layer. For broker-dealers, preservation requires one documented path: Azure immutable blob storage with a locked time-based policy, a 17a-4-attested archive vendor, or the post-October 2022 audit-trail alternative with DEO/DTP documentation and an annual independent records-management assessment.
 
 | Capability | Description |
 |------------|-------------|
@@ -133,7 +126,7 @@ The RFC addresses recordkeeping requirements for AI-generated communications, pr
 ### Tenant-Level Audit Configuration
 
 - Enable unified audit logging at tenant level
-- Configure retention policies per governance tier (180 days to 10 years)
+- Configure retention policies and preservation procedures to the firm's record-class schedule (3 years for communications, 6 years for financial/accounting or governance records, 5 years for CFTC Rule 1.31 records, and longer only where a specific rule or the firm's records schedule requires it); use the 10-Year Audit Log Retention add-on only when the firm intentionally extends the capture window beyond 1 year
 - Search for agent-related activities: CopilotInteraction, AgentPublished, ConnectorAdded
 - Export logs regularly for WORM storage (broker-dealers)
 - Integrate with SIEM for real-time monitoring (Zone 2-3)
@@ -239,7 +232,7 @@ Microsoft Entra admin center
 |------|-------------|-----------|
 | **Zone 1** (Personal) | Baseline logging; 180-day retention; monthly review | Low risk, standard coverage |
 | **Zone 2** (Team) | 1+ year retention; weekly review; SIEM recommended | Shared agents require accountability |
-| **Zone 3** (Enterprise) | 10-year retention via per-user 10-Year Audit Log Retention add-on (no native 7-year tier — 10 years used to satisfy a 7-year SEC 17a-4 / OCC examination floor); daily review; WORM storage or audit-trail alternative for broker-dealer environments per SEC 17a-4(f); SIEM required | Highest regulatory risk; per-user license alignment is mandatory or retention silently falls back to 180 days |
+| **Zone 3** (Enterprise) | Record-type-based retention and preservation: use 3 years for communications records, 6 years for financial/accounting or governance records, 5 years for CFTC Rule 1.31 records, and longer only where a specific rule or the firm's records schedule requires it; if the firm extends the Audit capture window beyond 1 year, assign the per-user 10-Year Audit Log Retention add-on only to users in that documented over-retention scope; daily review; WORM storage or audit-trail alternative for broker-dealer environments per SEC 17a-4(f); SIEM required | Highest regulatory risk; per-user license alignment is mandatory for any documented 10-year capture-window extension, and preservation still requires a separate 17a-4(f) path |
 
 ---
 
@@ -324,10 +317,10 @@ Confirm control effectiveness by verifying:
 
 1. Unified audit logging is enabled — run `Get-AdminAuditLogConfig | Format-List UnifiedAuditLogIngestionEnabled` from **Exchange Online PowerShell** (not Security & Compliance PowerShell, which always returns `False` per Microsoft Learn) and confirm the value is `True`
 2. Audit (Premium) license entitlement is verified for every Copilot user — without an E5 / Microsoft 365 E5 / Microsoft Purview Suite / E5 eDiscovery & Audit add-on assigned to the user generating the event, retention silently falls back to 180 days regardless of policy
-3. For Zone 3 (>1 year retention), the **per-user 10-Year Audit Log Retention add-on** is assigned to every Copilot user
+3. If the firm extends the Audit capture window beyond 1 year, the **per-user 10-Year Audit Log Retention add-on** is assigned to every Copilot user in that documented over-retention scope
 4. Copilot and agent record types appear in audit search results (`CopilotInteraction`, `ConnectedAIAppInteraction`, `MicrosoftCopilotStudio`); `AIAppInteraction` is enabled via PAYG if non-Microsoft AI apps are in scope
 5. Custom audit retention policies explicitly include the Copilot record types — the **default Audit (Premium) retention policy covers only `AzureActiveDirectory`, `Exchange`, `OneDrive`, and `SharePoint`**; Copilot record types fall back to 180 days unless a custom policy names them
-6. Retention policies are configured per governance tier (180 days / 1 year / 10 years; no native 7-year tier exists — use 10 years to satisfy a 7-year regulatory floor)
+6. Retention policies and preservation procedures follow the record-type schedule: 3 years for communications under SEC Rule 17a-4(b)(4), 6 years for financial/accounting or governance records under SEC Rule 17a-4(a) and FINRA Rule 4511(b), 5 years for CFTC Rule 1.31 records, and longer only where a specific rule or the firm's records schedule requires it; use the 10-Year Audit Log Retention add-on only as a documented capture-window extension where the firm chooses over-retention because Microsoft 365 Audit has no native 3-year/5-year/6-year tier
 7. Export capability produces complete audit records using `Search-UnifiedAuditLog -SessionCommand ReturnLargeSet -SessionId <guid>` paginated to completion (single-shot `-ResultSize` truncates silently)
 8. SIEM integration is functional with documented end-to-end ingestion latency (no fabricated SLA)
 9. WORM storage or audit-trail alternative is configured for broker-dealer environments per SEC 17a-4(f) (October 2022 amendments, compliance date May 3, 2023)
@@ -413,4 +406,4 @@ See [Microsoft Learn: Agent 365 SDK (Preview)](https://learn.microsoft.com/en-us
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/playbooks/control-implementations/1.1/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.1/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.1 - Restrict Agent Publishing by Authorization
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 ## Common Issues
 
@@ -198,7 +198,7 @@ if ($allUsers) {
 2. **Export the offending agent's full configuration** (Copilot Studio export, Dataverse solution export, or Power Platform CLI `pac copilot export`).
 3. **Capture audit log evidence** for the incident time window via `Search-UnifiedAuditLog` and export to CSV — preserve column headers; compute SHA-256.
 4. **Snapshot group memberships** at incident time (Microsoft Graph JSON export).
-5. **Hash and WORM-store everything** before applying any remediation that may alter state.
+5. **Hash and preserve everything through the Control 1.7 architecture** before applying any remediation that may alter state: Azure immutable blob storage with a locked time-based policy, a 17a-4-attested archive vendor, or the documented audit-trail alternative with DEO/DTP documentation and an independent records-management assessment.
 
 ### Compensating Controls During Outage
 
@@ -210,7 +210,7 @@ if ($allUsers) {
 
 ### Chain of Custody
 
-For each evidence artifact: file name, SHA-256, capture UTC timestamp, operator UPN, source system, storage location, retention period. Store the index in WORM-capable storage with the artifacts. Do not modify file contents after capture.
+For each evidence artifact: file name, SHA-256, capture UTC timestamp, operator UPN, source system, storage location, retention period. Store the index with the artifacts in the preservation path documented under [Control 1.7](../../../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md). Do not modify file contents after capture.
 
 ### Incident Report Template (Control 1.1 — stub)
 

--- a/docs/playbooks/control-implementations/1.1/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.1/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.1 - Restrict Agent Publishing by Authorization
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 !!! warning "Audit-log methodology prerequisites"
     Before running Test 4 / Test 5 / SSPM-1.1-05–06, verify the following — otherwise a second admin will get "no results" and incorrectly conclude the control is broken:
@@ -108,7 +108,7 @@ If Teams/M365 distribution is used:
 
 ## Evidence to Retain
 
-> **Audit-grade evidence requires more than screenshots.** SEC Rule 17a-4(f) and FINRA 4511(b) expect immutable, query-able, hashed records with chain of custody. Use this list as the working artifact set; store all files in WORM-capable storage (SharePoint with retention label or Azure Storage with immutability policy).
+> **Audit-grade evidence requires more than screenshots.** SEC Rule 17a-4(f) and FINRA 4511(b) expect immutable, query-able, hashed records with chain of custody. Use this list as the working artifact set; preserve all exported evidence through the Control 1.7 architecture: Azure immutable blob storage with a locked time-based policy, a 17a-4-attested archive vendor, or the documented audit-trail alternative with DEO/DTP documentation and an independent records-management assessment. Do not treat SharePoint record labels alone as the preservation layer for this evidence set.
 
 ### Identity & Authorization
 
@@ -140,7 +140,7 @@ If Teams/M365 distribution is used:
 
 ### Storage & Chain of Custody
 
-- [ ] Storage location is WORM-compliant (SharePoint with **Record** retention label, or Azure Storage with immutability policy in **Locked** state). Do not store evidence in user OneDrive.
+- [ ] Storage location follows the preservation path documented in [Control 1.7](../../../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md): Azure immutable blob storage with a locked time-based policy, a 17a-4-attested archive vendor, or the documented audit-trail alternative with DEO/DTP documentation and an independent records-management assessment. Do not store authoritative evidence in user OneDrive or treat SharePoint record labels alone as the preservation layer.
 - [ ] Storage region is US per data-residency requirements
 - [ ] Access to evidence container is logged and least-privileged
 
@@ -149,8 +149,8 @@ If Teams/M365 distribution is used:
 - [ ] Signed statement from control owner confirming:
   - Production publishing is restricted to `FSI-Agent-Publishers-Prod`
   - All production publishes require documented approval
-  - Evidence is retained per policy in US-only WORM-capable storage
-  - The retention period applied meets firm-specific obligations (commonly 6 years)
+  - Evidence is retained per policy through the preservation path documented in [Control 1.7](../../../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md)
+  - The retention period applied matches the firm's record schedule and the record-type model in Control 1.7 (3 years for communications, 6 years for financial/accounting or governance records, 5 years for CFTC records, and longer only where a specific rule or firm schedule requires it)
 
 ---
 

--- a/docs/playbooks/control-implementations/1.7/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.7/portal-walkthrough.md
@@ -5,7 +5,7 @@
 **Last UI Verified:** April 2026
 **Estimated Time:** 4–8 hours initial buildout (single tenant); 60–120 minutes per environment for Dataverse audit enablement; 30–45 minutes per quarterly evidence-pack refresh
 **Audience:** Purview Audit Admin, Purview Compliance Admin, Exchange Online Organization Configuration role holder, SOC Analyst, Power Platform Admin, Entra Security Admin, Azure Storage Account Owner
-**Prerequisites:** Microsoft 365 E5 (or Office 365 E5 / Microsoft Purview Suite / E5 eDiscovery & Audit add-on) per Copilot user; per-user **10-Year Audit Log Retention** add-on for any Zone 3 user; Exchange Online PowerShell module v3.0+; Azure subscription for immutable blob storage (if WORM export is in scope); change-management ticket open for any tenant-wide audit ingestion change.
+**Prerequisites:** Microsoft 365 E5 (or Office 365 E5 / Microsoft Purview Suite / E5 eDiscovery & Audit add-on) per Copilot user; per-user **10-Year Audit Log Retention** add-on for any user placed on a documented 10-year capture-window policy; Exchange Online PowerShell module v3.0+; Azure subscription for immutable blob storage (if WORM export is in scope); change-management ticket open for any tenant-wide audit ingestion change.
 
 ---
 
@@ -167,7 +167,7 @@ Audit retention policies that exceed the entitlement of the underlying user **si
 
 1. Open `https://admin.microsoft.com` > **Billing > Licenses**.
 2. Capture the assigned counts for each of: `Microsoft 365 E5`, `Office 365 E5`, `Microsoft Purview Suite`, `E5 eDiscovery and Audit add-on`, `10-Year Audit Log Retention add-on`.
-3. Cross-reference against the user list assigned a Microsoft 365 Copilot license (any user without one of the four Audit Premium SKUs above caps at 180 days; any user assigned to a Zone 3 retention policy without the 10-Year add-on caps at 1 year).
+3. Cross-reference against the user list assigned a Microsoft 365 Copilot license (any user without one of the four Audit Premium SKUs above caps at 180 days; any user assigned to a documented 10-year capture-window policy without the 10-Year add-on caps at 1 year).
 4. Export the user × SKU × add-on matrix to CSV; SHA-256 hash and add to the evidence pack as `Control-1.7_{Tenant}_LicenseMatrix_{YYYYMMDD-UTC}.csv` plus `.sha256` sidecar.
 
 ### 1.3 Change-management gate
@@ -275,7 +275,7 @@ The audit record carries metadata only. To retrieve the prompt and response body
 | `AIAppInteraction` for non-Microsoft AI apps (network/browser DLP `AIApp` workload) | ⛔ | ⛔ unless PAYG enabled | ⛔ unless PAYG enabled | ✅ — explicit enablement; 180-day retention; consumption billed against an Azure subscription |
 | Per-user license required at event ingestion time | n/a (universal) | ✅ Yes — without it, retention silently caps at 180 days | ✅ Yes — without the add-on, retention silently caps at 1 year | n/a (PAYG fixed retention) |
 
-**There is no native 7-year tier.** To meet a 7-year SEC 17a-4 / OCC examination floor, configure a **10-year** custom retention policy and document the over-retention decision in the records schedule.
+**There is no native 3-year, 5-year, 6-year, or 7-year Audit tier.** Use the record-class schedule as the governing rule — 3 years for communications, 6 years for financial/accounting or governance records, 5 years for CFTC records, and longer only where a specific rule or the firm's records schedule requires it. If the firm wants a capture window beyond 1 year in Microsoft 365 Audit, configure a **10-year** custom retention policy only as a documented capture-window extension / over-retention choice.
 
 ---
 
@@ -289,7 +289,7 @@ The audit record carries metadata only. To retrieve the prompt and response body
 
 1. In the Purview portal Audit solution, open **Policies > Create audit retention policy**.
 2. Enter a descriptive **Policy name** that encodes the zone and intent (e.g., `FSI-Zone3-Copilot-10y`, `FSI-Zone2-Copilot-1y`).
-3. Set **Duration** to one of the supported values: `Three Months`, `Six Months`, `Nine Months`, `Twelve Months` (Audit Premium), `Ten Years` (Audit Premium + per-user 10-Year add-on). **No native 7-year tier exists** — use 10 years and record the over-retention decision.
+3. Set **Duration** to one of the supported values: `Three Months`, `Six Months`, `Nine Months`, `Twelve Months` (Audit Premium), `Ten Years` (Audit Premium + per-user 10-Year add-on). Apply the firm's record-class schedule — 3 years for communications, 6 years for financial/accounting or governance records, 5 years for CFTC records, and longer only where a specific rule or the firm's records schedule requires it — and use `Ten Years` only when the firm intentionally extends the Audit capture window beyond 1 year because Microsoft 365 Audit has no native intermediate tier for those record classes.
 4. Under **Record types**, explicitly add **every** Copilot record type in scope:
     - `CopilotInteraction`
     - `ConnectedAIAppInteraction`
@@ -473,7 +473,7 @@ Per the SEC's October 2022 amendments to Rule 17a-4(f) (compliance date 3 May 20
     - **3 years** for SEC 17a-4(b)(4) communications records (first 2 years readily accessible).
     - **5 years** for CFTC 1.31 regulatory records.
     - **6 years** for SEC 17a-4(a) financial / accounting records.
-    - **7 years** for OCC examination records (use 10 years if the firm standardizes on the 10-year retention tier).
+    - **Longer periods** only where a specific rule or the firm's records schedule requires them (for example, an OCC-driven or firm-standard over-retention decision may be documented separately).
     - **NYDFS 23 NYCRR 500.06** records retention obligation: minimum 5 years for cybersecurity-event records (verify against your firm's NYDFS program).
 5. **Lock** the policy after validation — once locked, retention can be extended but never shortened or removed. The lock action itself is auditable via Azure Activity Log.
 6. Capture the policy state and add to the evidence pack:
@@ -539,7 +539,7 @@ All artifacts: SHA-256 hashed at capture time; copied to the §10 immutable blob
 |---|---|
 | Unified audit logging | Enabled |
 | Audit retention policy | `Twelve Months` (minimum) policy named `FSI-Zone2-Copilot-1y`; consider `Ten Years` for departments touching books-and-records data |
-| 10-Year Audit Log Retention add-on | Required for any user whose interactions feed a 10-year retention policy |
+| 10-Year Audit Log Retention add-on | Required for any user whose interactions feed a documented 10-year capture-window policy |
 | PAYG `AIAppInteraction` | Required if non-Microsoft AI is in scope |
 | Dataverse environment audit | Enabled, 365-day retention, **all** non-default environments |
 | Per-table audit on Copilot Studio entities | Required across all environments hosting shared agents |
@@ -554,8 +554,8 @@ All artifacts: SHA-256 hashed at capture time; copied to the §10 immutable blob
 | Configuration | Setting |
 |---|---|
 | Unified audit logging | Enabled |
-| Audit retention policy | `Ten Years` policy named `FSI-Zone3-Copilot-10y` covering **every** Copilot record type in scope; per-user 10-Year add-on assigned to every user in scope (silent fallback to 1 year otherwise) |
-| 10-Year Audit Log Retention add-on | **Required per user**; reconcile against the §1.2 license matrix on every binder refresh |
+| Audit retention policy | Record-class-based: apply the preservation schedule from Control 1.7 (3 years for communications, 6 years for financial/accounting or governance records, 5 years for CFTC records, and longer only where a specific rule or the firm's records schedule requires it). Because Microsoft 365 Audit has no native 3-year/5-year/6-year tier, firms that need a capture window beyond 1 year typically use a documented `Ten Years` policy as a capture-window extension / over-retention choice. |
+| 10-Year Audit Log Retention add-on | Required only for users included in that documented 10-year capture-window scope; reconcile against the §1.2 license matrix on every binder refresh |
 | PAYG `AIAppInteraction` | Required (non-Microsoft AI assumed in scope unless explicitly blocked by [Control 1.5](../../../controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md)) |
 | Dataverse environment audit | Enabled, 730-day minimum retention (or **Forever**), all environments |
 | Per-table audit on the six Copilot Studio entities | Required across all environments |
@@ -646,7 +646,7 @@ After completing this walkthrough, hand off to [Verification & Testing](verifica
 
 1. Unified audit logging enabled (run `Get-AdminAuditLogConfig | Format-List UnifiedAuditLogIngestionEnabled` from Exchange Online PowerShell).
 2. Audit (Premium) license entitlement verified per Copilot user.
-3. Per-user 10-Year Audit Log Retention add-on assigned for every Zone 3 user.
+3. Per-user 10-Year Audit Log Retention add-on assigned for every user included in a documented 10-year capture-window policy.
 4. Copilot record types appear in audit search results.
 5. Custom audit retention policies explicitly include the Copilot record types.
 6. Retention policies configured per governance tier.

--- a/docs/playbooks/control-implementations/1.7/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.7/verification-testing.md
@@ -22,7 +22,7 @@ This playbook is **three-tier verification**: it confirms that audit telemetry i
 
 Microsoft 365 Audit (Standard, Premium, the 10-Year Audit Log Retention add-on, and the Pay-As-You-Go billing model for non-Microsoft AI app interactions) is **record-capture operational telemetry**. It is not, by itself, a SEC Rule 17a-4(f)–compliant electronic recordkeeping system for the books-and-records record set. The playbook treats the three tiers as separate verification problems with separate failure modes:
 
-1. **Capture-tier failures** — audit ingestion is off, a Copilot RecordType is not flowing, a Dataverse environment has audit disabled, a per-user license is missing so a Zone 3 retention policy silently downgrades to 180 days, an Audit Premium-only feature (e.g., `MailItemsAccessed`) is not firing, or an invalid `-RecordType` value is producing false-clean evidence.
+1. **Capture-tier failures** — audit ingestion is off, a Copilot RecordType is not flowing, a Dataverse environment has audit disabled, a per-user license is missing so a documented 10-year capture-window policy silently downgrades to 1 year, an Audit Premium-only feature (e.g., `MailItemsAccessed`) is not firing, or an invalid `-RecordType` value is producing false-clean evidence.
 2. **Preservation-tier failures** — for broker-dealers, FCMs, swap dealers, or CPOs, no 17a-4(f)-compliant preservation pipeline exists for the Copilot / agent communications record set; or one exists but the time-based retention policy is unlocked, or the third-party archive's attestation has lapsed, or the audit-trail alternative is in use without the Designated Executive Officer (DEO) representation / Designated Third Party (DTP) undertaking and independent records-management assessment.
 3. **Content-tier failures** — prompt and response body cannot be retrieved through DSPM for AI, eDiscovery (Premium), or Communication Compliance for a `CopilotInteraction` event identified in the audit log, breaking the join from audit metadata to communication content that an examiner expects.
 
@@ -78,7 +78,7 @@ This playbook is designed to detect defects in the **audit, preservation, and co
 1. **Unified audit ingestion off** — the tenant-level switch is `False`, or a `Get-AdminAuditLogConfig` call from the wrong session (Security & Compliance PowerShell) is producing a false `False`.
 2. **Copilot RecordType silent gaps** — `CopilotInteraction`, `ConnectedAIAppInteraction` (mixed Microsoft built-in + PAYG scope), `AIAppInteraction` (PAYG-only), or `MicrosoftCopilotStudio` returning zero rows for a window in which user activity is known to have occurred.
 3. **PAYG enablement omissions** — non-Microsoft AI app interactions and the PAYG portion of Connected AI App scope captured in audit only after explicit enablement; firms assuming default coverage produce false-clean evidence.
-4. **License-induced silent retention downgrades** — a Zone 3 user holds a Copilot license without the 10-Year Audit Log Retention add-on, so their records drop at 180 days regardless of the custom retention policy duration.
+4. **License-induced silent retention downgrades** — a user assigned to a documented 10-year capture-window policy holds a Copilot license without the 10-Year Audit Log Retention add-on, so the custom retention policy cannot extend beyond 1 year for that user.
 5. **Custom retention policy gaps** — the platform default Audit (Premium) policy excludes Copilot record types, so any RecordType not covered by an enabled custom policy falls back to 180 days.
 6. **Dataverse audit gaps** — environment-level audit disabled, retention below the zone floor, or per-table audit not enabled on the six Copilot Studio entities (`bot`, `botcomponent`, `botcomponentcollection`, `botpublishstatus`, and the current additions per the Microsoft Learn Power Platform table reference at the time of test).
 7. **Entra agent sign-in invisibility** — the `agentSignIn` log type is not forwarded to Log Analytics / SIEM, the sign-in log filter affordance for agent identities is misnamed in tenant runbooks (the prior `Is Agent = Yes` label has shifted across UI revisions — verify the live label), or `AppOwnerTenantId` / `ResourceOwnerTenantId` / `SessionId` / `SourceAppClientID` / `ASN` are missing from the SIEM ingestion schema.
@@ -166,7 +166,7 @@ The audit and preservation surfaces this playbook depends on do **not** have uni
 |---|---|---|---|---|---|
 | Unified audit log (Audit Standard) | GA | GA | GA | GA | Required everywhere; absence is a hard blocker |
 | Audit (Premium) including `MailItemsAccessed` | GA | GA | GA / verify | GA / verify | Required for breach-investigation reconstruction; record SOV-01 compensating control if unavailable |
-| 10-Year Audit Log Retention add-on | GA | GA / verify | Verify | Verify | Required for Zone 3 retention; without it, records drop at 180 days |
+| 10-Year Audit Log Retention add-on | GA | GA / verify | Verify | Verify | Required only when the firm uses a documented 10-year capture-window policy; without it, a custom policy cannot extend beyond 1 year for the affected user |
 | Audit Pay-As-You-Go billing model | GA | Verify | Verify | Verify | Required to capture `AIAppInteraction` and the PAYG portion of `ConnectedAIAppInteraction`; record SOV-02 if unavailable |
 | `CopilotInteraction` RecordType | GA | GA | GA / verify | GA / verify | Hard blocker if absent |
 | `ConnectedAIAppInteraction` RecordType (Microsoft built-in scope) | GA | GA | Verify | Verify | Hard blocker if absent for in-scope agents |
@@ -250,14 +250,18 @@ $result
 
 #### CAP-02 — Per-user license entitlement reconciliation (Audit Standard / Premium / 10-Year add-on / PAYG)
 
-**Expected:** every Copilot-licensed user has Audit Premium; every Zone 3 Copilot user additionally has the 10-Year Audit Log Retention add-on; tenants in scope for non-Microsoft AI app coverage have PAYG enrollment recorded.
+**Expected:** every Copilot-licensed user has Audit Premium; every user assigned to a documented 10-year capture-window policy additionally has the 10-Year Audit Log Retention add-on; tenants in scope for non-Microsoft AI app coverage have PAYG enrollment recorded.
 
 ```powershell
 $report = Get-MgUser -All -Property Id,UserPrincipalName,AssignedLicenses |
     ForEach-Object { Get-UserAuditEntitlement -UserId $_.Id }
 
+$tenYearScope = Get-Content '.\inputs\ten-year-capture-users.txt'
 $gaps = $report | Where-Object {
-    $_.HasCopilot -and (-not $_.HasAuditPremium -or -not $_.Has10YearRetention)
+    $_.HasCopilot -and (
+        -not $_.HasAuditPremium -or
+        ($_.UserPrincipalName -in $tenYearScope -and -not $_.Has10YearRetention)
+    )
 }
 
 # Optional: PAYG enrollment check (verify against the current Purview billing surface)
@@ -279,7 +283,7 @@ $cap02
 ```
 
 - `[PASS]` if `gapCount -eq 0` and PAYG enrollment matches the firm's regulated-data scope.
-- `[FAIL]` if any user has Copilot without Audit Premium, any Zone 3 Copilot user lacks the 10-year add-on (records will silently drop at 180 days), or the firm is in scope for non-Microsoft AI app coverage and PAYG is not enrolled.
+- `[FAIL]` if any user has Copilot without Audit Premium, any user in the documented 10-year capture-window scope lacks the 10-year add-on (the custom policy will silently fall back to 1 year for that user), or the firm is in scope for non-Microsoft AI app coverage and PAYG is not enrolled.
 
 #### CAP-03 — Copilot RecordType coverage smoke test
 
@@ -317,13 +321,13 @@ Verify the live `ConnectedAIAppInteraction` scope split (Microsoft built-in vs P
 
 #### CAP-04 — Custom retention policy coverage map and horizon
 
-**Expected:** every Copilot RecordType in scope is covered by an explicit, enabled custom retention policy with `RetentionDuration` matching the documented zone horizon.
+**Expected:** every Copilot RecordType in scope is covered by an explicit, enabled custom retention policy with `RetentionDuration` matching the documented record-class schedule and any documented 10-year capture-window extension.
 
 ```powershell
 $expected = @(
     @{ Zone = 'Zone 1'; Duration = 'SixMonths';    LicenseFloor = 'Any commercial M365 enterprise SKU' },
     @{ Zone = 'Zone 2'; Duration = 'TwelveMonths'; LicenseFloor = 'Audit Premium' },
-    @{ Zone = 'Zone 3'; Duration = 'TenYears';     LicenseFloor = 'Audit Premium + 10-Year Audit Log Retention add-on' }
+    @{ Zone = 'Zone 3'; Duration = 'RecordClassSchedule'; LicenseFloor = 'Audit Premium; add 10-Year Audit Log Retention only for users on a documented 10-year capture-window policy' }
 )
 
 $policies = Get-UnifiedAuditLogRetentionPolicy
@@ -893,7 +897,7 @@ Statements (capture tier):
 3. Each Copilot RecordType in scope returned non-zero rows, or a documented expected-zero,
    in the smoke test (sha256 {CAP-03}).
 4. Custom audit retention policies are in place for every Copilot record type in scope at
-   the documented zone horizon (sha256 {CAP-04}).
+   the documented record-class schedule and any documented 10-year capture-window extension (sha256 {CAP-04}).
 5. Per-environment Dataverse audit and per-table audit on the Copilot Studio entities
    are enabled for all {N} environments (sha256 {CAP-05}).
 6. DLP override justification is captured in the audit log (sha256 {CAP-06}).

--- a/docs/reference/regulatory-mappings.md
+++ b/docs/reference/regulatory-mappings.md
@@ -269,7 +269,7 @@ Requires SEC-registered firms to maintain records for varying periods: 3 years f
 
 | Control | Requirement | Mapping |
 |---------|-------------|---------|
-| [1.7](../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Comprehensive Audit Logging | 6-year retention, first 2 years in easily accessible place |
+| [1.7](../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) | Comprehensive Audit Logging | Retention per record type (3 years for communications, 6 years for financial/governance records, 5 years for CFTC records; first 2 years readily accessible where required) |
 | [1.9](../controls/pillar-1-security/1.9-data-retention-and-deletion-policies.md) | Data Retention | Retention policies enforced |
 | [1.20](../controls/pillar-1-security/1.20-network-isolation-private-connectivity.md) | Network Isolation | Secure storage network architecture |
 | [1.21](../controls/pillar-1-security/1.21-adversarial-input-logging.md) | Adversarial Input Logging | Security event records |
@@ -321,7 +321,7 @@ Requires SEC-registered firms to maintain records for varying periods: 3 years f
 
 **Zone 3:**
 
-- 6-year retention, first 2 years in easily accessible place
+- Record-type-based retention: 3 years for communications, 6 years for financial/accounting and governance records, 5 years for CFTC records, with longer periods only where a specific rule or firm schedule requires them; first 2 years readily accessible where required
 - WORM or audit-trail alternative (per SEC October 2022 amendments)
 - Real-time audit trail
 - Weekly compliance verification


### PR DESCRIPTION
## Summary
Closes finding U-037 (P1). Reconciles contradictory WORM/preservation guidance between Controls 1.1 and 1.7. User chose **Option C — synthesize both around a record-type-based preservation model** during plan discussion 2026-05-18.

## Changes
- **Control 1.1** narrows to publish-provenance / approval evidence; preservation architecture is deferred to 1.7. Removes the "commonly 6 years per SEC 17a-4(b)(4)" line (the wrong-citation drift).
- **Control 1.7** keeps the capture vs preservation architecture (Azure immutable blob locked OR 17a-4 vendor OR audit-trail alternative + DEO/DTP + annual independent assessment) but corrects the Zone 3 wording from blanket 10-year shorthand to a record-type-based matrix (3 yr communications / 6 yr financial-governance / 5 yr CFTC). 10-Year Audit Log Retention add-on described as capture-window extension, not a preservation layer.
- **1.1 playbooks** stop treating SharePoint Record retention labels as the default WORM answer; defer to 1.7's preservation architecture.
- **1.7 playbooks** light-touch to remove Zone 3 10-year blanket wording.
- **regulatory-mappings.md** stale shorthand row for 1.7 replaced with the retention matrix language.

## Validation
- python scripts/verify_language_rules.py ✅
- python scripts/verify_controls.py ✅
- python scripts/check_manifest_doc_drift.py --check ✅
- mkdocs build --strict ✅

Source: maintainers-local/audits/2026-05-18/u-037-worm-investigation.md (Option C synthesis, lines 230-289).

Closes finding U-037.