### PR TITLE
docs(downloads): describe governance-maturity-dashboard accurately (closes U-036)

### DIFF
--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -19,7 +19,7 @@ Role names below use the framework's canonical short naming. See the [Administra
 | [Purview Administrator Checklist](purview-administrator-checklist.xlsx) | Purview Compliance Admin | Purview controls: DLP, DSPM for AI, Audit, eDiscovery |
 | [SharePoint Administrator Checklist](sharepoint-administrator-checklist.xlsx) | SharePoint Admin | SharePoint governance controls: access, retention, external sharing |
 | [Compliance Officer Checklist](compliance-officer-checklist.xlsx) | Compliance Officer | Regulatory mappings and audit evidence tracking |
-| [Governance Maturity Dashboard](governance-maturity-dashboard.xlsx) | AI Governance Lead | All 78 controls with maturity scoring and dashboard |
+| [Governance Maturity Dashboard](governance-maturity-dashboard.xlsx) | AI Governance Lead | All 78 controls with status tracking and pillar-level summary aggregation |
 
 ---
 


### PR DESCRIPTION
## Summary
Closes finding U-036 (P1). PR #293 already addressed the substantive defect by adding 20 formulas to the Summary sheet (COUNTIF aggregations from pillar sheets + SUM totals). The remaining issue was just that docs/downloads/index.md described the workbook as "maturity scoring and dashboard" — but the workbook does status tracking with auto-aggregated pillar counts, not numeric 0-4 maturity scoring. (The assessment engine under ssessment/ already does numeric maturity scoring programmatically.)

## Change
- docs/downloads/index.md line 22 — replaced "maturity scoring and dashboard" with "status tracking and pillar-level summary aggregation"

## Validation
- python scripts/verify_excel_templates.py ✅
- python scripts/verify_language_rules.py ✅
- mkdocs build --strict ✅

User decision recorded during 2026-05-18 backlog discussion (Option A — close as resolved, fix description only).

Closes finding U-036.