### PR TITLE
ci+scripts: add control cross-reference graph validator (closes PR-12)

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -133,6 +133,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+      - name: Verify control doc structure
+        run: python scripts/verify_controls.py
+      - name: Verify control cross-reference graph
+        run: python scripts/verify_xref_graph.py
       - name: Check control IDs in manifest, CONTROL-INDEX, and mkdocs nav
         run: python scripts/check_manifest_doc_drift.py --check
       - name: Check assessment coverage matrix is up to date

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,8 @@ Always run before completing work:
 mkdocs build --strict                # Validates links and structure
 python scripts/verify_build_output.py  # Verifies built site completeness
 python scripts/verify_controls.py    # Validates control files
+# Cross-reference integrity (Control X.Y IDs + inline labels)
+python scripts/verify_xref_graph.py
 ```
 
 Additional validations (when applicable):

--- a/docs/playbooks/control-implementations/1.22/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.22/troubleshooting.md
@@ -133,7 +133,7 @@
 
 1. Multi-Segment IB is **not** enforced via Exchange Address Book Policies. Mail-flow blocking semantics differ from Legacy.
 2. If the firm requires hard mail-flow blocking between segments (e.g., research → trading), supplement IB with **Exchange transport rules** that reject messages when sender and recipient have specific group memberships or attributes.
-3. Document the supplement as a compensating control under Control 1.7 (DLP) or Control 2.13 (Communication Compliance) and reference it in the Control 1.22 attestation.
+3. Document the supplement as a compensating control under Control 1.5 (Data Loss Prevention (DLP) and Sensitivity Labels) or Control 1.10 (Communication Compliance Monitoring) and reference it in the Control 1.22 attestation.
 
 ---
 

--- a/docs/playbooks/control-implementations/2.12/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.12/powershell-setup.md
@@ -1895,7 +1895,7 @@ function Export-Sup212Rule2210Bundle {
 
 ## §11 — Sponsor Attestation Runner
 
-The sponsorship model documented in Control 2.12 (Entra Agent ID) is operationalized through quarterly Entra access reviews targeting Zone 3 agents. This section pulls the review status, flags auto-approval (defect #0.13), and emits a signed quarterly attestation evidence bundle.
+The sponsorship model documented in Control 2.26 (Entra Agent ID — Identity Governance for Agents) is operationalized through quarterly Entra access reviews targeting Zone 3 agents. This section pulls the review status, flags auto-approval (defect #0.13), and emits a signed quarterly attestation evidence bundle.
 
 ### 11.1 Get-Sup212SponsorAttestation
 

--- a/docs/playbooks/control-implementations/2.12/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.12/troubleshooting.md
@@ -68,7 +68,7 @@ Every pillar follows this standardized subsection layout to keep the on-call's c
 ### §0.5 What This Playbook Does **Not** Cover
 
 - **Copilot Studio authoring / builder issues** unrelated to HITL — see the Copilot Studio general troubleshooting guidance in Microsoft Learn.
-- **Entra directory-level identity issues** — see Control 1.1 (Entra Conditional Access) and the Entra admin center diagnostics.
+- **Entra directory-level identity issues** — see Control 1.11 (Conditional Access and Phishing-Resistant MFA) and the Entra admin center diagnostics.
 - **Power Platform DLP policy authoring** — see Control 2.14.
 - **Agent registry / metadata issues** — see [Control 3.1 — Agent Inventory and Metadata Management](../../../controls/pillar-3-reporting/3.1-agent-inventory-and-metadata-management.md).
 - **Incident reporting mechanics (post-incident lifecycle)** — see [Control 3.4 — Incident Reporting and Root Cause Analysis](../../../controls/pillar-3-reporting/3.4-incident-reporting-and-root-cause-analysis.md). This playbook covers the **supervisory-control** incident response; Control 3.4 covers the broader incident reporting and RCA discipline.

--- a/docs/playbooks/control-implementations/2.24/verification-testing.md
+++ b/docs/playbooks/control-implementations/2.24/verification-testing.md
@@ -988,7 +988,7 @@ Describe "AGT224-SOV" -Tag 'AGT224','SOV' {
 
 ### §2.12 SIEM — forwarding to Microsoft Sentinel
 
-**Criterion mapping.** Cross-cutting; chains with Control 3.1 (Audit Log Telemetry) and Control 3.9 (SIEM Integration).
+**Criterion mapping.** Cross-cutting; chains with Control 1.7 (Comprehensive Audit Logging and Compliance) and Control 3.9 (Microsoft Sentinel Integration).
 
 **Pester suite.**
 

--- a/docs/playbooks/control-implementations/3.6/verification-testing.md
+++ b/docs/playbooks/control-implementations/3.6/verification-testing.md
@@ -801,7 +801,7 @@ Supporting evidence for VC-1 / VC-3: the orphan detector cannot detect sponsor-d
 ### 6.2 Pre-conditions
 
 - Entra Identity Governance Admin can read `/identityGovernance/workflowsHrSync/connectors`.
-- HR connector has been configured per Control 3.5 (Identity Lifecycle for Agent Sponsors and Makers).
+- HR connector has been configured per Control 2.26 (Entra Agent ID — Identity Governance for Agents).
 
 ### 6.3 Pester suite
 

--- a/docs/playbooks/control-implementations/4.7/powershell-setup.md
+++ b/docs/playbooks/control-implementations/4.7/powershell-setup.md
@@ -509,7 +509,7 @@ function Set-Agt47CopilotDlp {
 - The prompt-block rule **does not** prevent a user from seeing labeled content in SharePoint — it only blocks Copilot from grounding on it and from accepting prompts that contain selected SITs. Use this rule to enforce SEC Reg S-P customer-information protections inside Copilot prompts.
 - For MNPI/NPI grounding exclusion, set `BlockAccessScope = 'PerUser'`, not `'All'`. `'All'` blocks anonymous web crawlers as well, which has no effect on Copilot but generates noisy alerts.
 - Set `GenerateAlert = $true` so violations land in Defender XDR for SOC review under Control 3.6 (Risky Use Detection).
-- Audit Copilot prompt and response activity via `UnifiedAuditLog` (record types `CopilotInteraction`, `CopilotEvent`); Control 3.1 (Activity Audit Log) covers the export pipeline.
+- Audit Copilot prompt and response activity via `UnifiedAuditLog` (record types `CopilotInteraction`, `CopilotEvent`); Control 1.7 (Comprehensive Audit Logging and Compliance) covers the export pipeline.
 
 ---
 

--- a/scripts/verify_xref_graph.py
+++ b/scripts/verify_xref_graph.py
@@ -1,0 +1,364 @@
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+if sys.platform == 'win32':
+    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stderr.reconfigure(encoding='utf-8')
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / 'assessment' / 'manifest' / 'controls.json'
+CONTROL_INDEX_PATH = REPO_ROOT / 'docs' / 'controls' / 'CONTROL-INDEX.md'
+SCAN_ROOTS = [
+    REPO_ROOT / 'docs' / 'controls',
+    REPO_ROOT / 'docs' / 'playbooks',
+    REPO_ROOT / 'docs' / 'framework',
+    REPO_ROOT / 'docs' / 'reference',
+]
+EXPECTED_CONTROL_COUNT = 78
+CONTROL_ID_PATTERN = r'[1-4]\.(?:[1-9]|1\d|2\d)'
+CONTROL_ID_RE = re.compile(rf'\b({CONTROL_ID_PATTERN})\b')
+CONTROL_INDEX_ROW_RE = re.compile(
+    rf'^\|\s*(?P<id>{CONTROL_ID_PATTERN})\s*\|\s*\[(?P<name>[^\]]+)\]\(',
+    re.MULTILINE,
+)
+BRACKETED_CONTROL_RE = re.compile(
+    rf'\[Control\s+(?P<id>{CONTROL_ID_PATTERN})(?:\s*\((?P<paren_label>[^)]+)\))?\]',
+    re.IGNORECASE,
+)
+CONTROL_PAREN_RE = re.compile(
+    rf'\bControl\s+(?P<id>{CONTROL_ID_PATTERN})\s*\((?P<label>[^)]+)\)',
+    re.IGNORECASE,
+)
+BARE_PAREN_RE = re.compile(rf'(?<![\w.])(?P<id>{CONTROL_ID_PATTERN})\s*\((?P<label>[^)]+)\)')
+CONTROL_LIST_RE = re.compile(
+    rf'\bControls?\s+(?P<body>{CONTROL_ID_PATTERN}(?:\s*(?:,\s*|,?\s+(?:and|or)\s+|&\s*){CONTROL_ID_PATTERN})+)',
+    re.IGNORECASE,
+)
+SIMPLE_CONTROL_RE = re.compile(rf'\bControl\s+(?P<id>{CONTROL_ID_PATTERN})\b', re.IGNORECASE)
+CODE_FENCE_RE = re.compile(r'^\s*(```|~~~)')
+URL_RE = re.compile(r'https?://\S+')
+ANCHOR_LINK_RE = re.compile(r'\[[^\]]+\]\(#.*?\)')
+INLINE_CODE_RE = re.compile(r'`[^`]*`')
+
+
+@dataclass
+class Reference:
+    control_id: str
+    found_text: str
+    label: str | None
+    start: int
+    end: int
+
+
+@dataclass
+class Finding:
+    file: str
+    line: int
+    severity: str
+    found_text: str
+    control_id: str
+    expected: str
+
+
+def load_manifest_controls() -> dict[str, str]:
+    data = json.loads(MANIFEST_PATH.read_text(encoding='utf-8'))
+    return {str(item['id']).strip(): str(item['name']).strip() for item in data if item.get('id') and item.get('name')}
+
+
+def load_control_index() -> dict[str, str]:
+    content = CONTROL_INDEX_PATH.read_text(encoding='utf-8')
+    return {match.group('id'): match.group('name').strip() for match in CONTROL_INDEX_ROW_RE.finditer(content)}
+
+
+def build_canonical_map() -> dict[str, str]:
+    manifest_controls = load_manifest_controls()
+    index_controls = load_control_index()
+    canonical: dict[str, str] = {}
+
+    for control_id in sorted(set(manifest_controls) | set(index_controls), key=sort_control_id):
+        canonical[control_id] = index_controls.get(control_id) or manifest_controls.get(control_id, '')
+
+    if len(canonical) != EXPECTED_CONTROL_COUNT:
+        print(
+            f'ERROR: expected {EXPECTED_CONTROL_COUNT} canonical controls but found {len(canonical)}',
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    return canonical
+
+
+def sort_control_id(control_id: str) -> tuple[int, int]:
+    pillar, number = control_id.split('.')
+    return int(pillar), int(number)
+
+
+def iter_markdown_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        files.extend(path for path in root.rglob('*.md') if path.name != 'CONTROL-INDEX.md')
+    return sorted(files)
+
+
+def normalize_text(value: str) -> str:
+    value = value.casefold().replace('&', ' and ')
+    value = re.sub(r'[^a-z0-9]+', ' ', value)
+    return ' '.join(value.split())
+
+
+GENERIC_LABEL_TOKENS = {
+    'a',
+    'an',
+    'and',
+    'by',
+    'control',
+    'controls',
+    'detection',
+    'for',
+    'governance',
+    'management',
+    'monitoring',
+    'only',
+    'operation',
+    'operations',
+    'or',
+    'plane',
+    'policies',
+    'policy',
+    'premium',
+    'program',
+    'reporting',
+    'review',
+    'reviews',
+    'setup',
+    'testing',
+    'the',
+    'to',
+    'troubleshooting',
+    'under',
+    'update',
+    'verification',
+    'walkthrough',
+    'with',
+}
+
+
+def meaningful_tokens(value: str) -> set[str]:
+    tokens = normalize_text(value).split()
+    expanded_tokens: set[str] = set()
+    for token in tokens:
+        if token in GENERIC_LABEL_TOKENS:
+            continue
+        expanded_tokens.add(token)
+        if token.endswith('s') and len(token) <= 5:
+            expanded_tokens.add(token[:-1])
+    return {token for token in expanded_tokens if len(token) > 1}
+
+
+
+def matching_token_count(label: str, canonical_name: str) -> int:
+    label_tokens = meaningful_tokens(label)
+    canonical_tokens = meaningful_tokens(canonical_name)
+    matches = 0
+    for label_token in label_tokens:
+        if any(
+            label_token == canonical_token
+            or label_token.startswith(canonical_token)
+            or canonical_token.startswith(label_token)
+            for canonical_token in canonical_tokens
+        ):
+            matches += 1
+    return matches
+
+
+
+def label_matches_canonical(label: str, canonical_name: str) -> bool:
+    label_normalized = normalize_text(label)
+    canonical_normalized = normalize_text(canonical_name)
+    if not label_normalized:
+        return False
+    if label_normalized in canonical_normalized or canonical_normalized in label_normalized:
+        return True
+
+    label_tokens = meaningful_tokens(label)
+    canonical_tokens = meaningful_tokens(canonical_name)
+    if not label_tokens or not canonical_tokens:
+        return False
+    if label_tokens.issubset(canonical_tokens) or canonical_tokens.issubset(label_tokens):
+        return True
+    return matching_token_count(label, canonical_name) >= 1
+
+
+
+def best_canonical_label_match(label: str, canonical: dict[str, str], referenced_control_id: str) -> str | None:
+    best_control_id: str | None = None
+    best_score = 0
+    tied = False
+    label_normalized = normalize_text(label)
+
+    for control_id, control_name in canonical.items():
+        if control_id == referenced_control_id:
+            continue
+
+        canonical_normalized = normalize_text(control_name)
+        if label_normalized and (label_normalized in canonical_normalized or canonical_normalized in label_normalized):
+            score = 100
+        else:
+            score = matching_token_count(label, control_name)
+
+        if score > best_score:
+            best_control_id = control_id
+            best_score = score
+            tied = False
+        elif score and score == best_score:
+            tied = True
+
+    if tied:
+        return None
+    if best_score >= 2 or best_score == 100:
+        return best_control_id
+    return None
+
+
+
+def should_validate_label(label: str | None) -> bool:
+    if not label:
+        return False
+
+    stripped = label.strip()
+    if not stripped or not stripped[0].isalpha():
+        return False
+
+    starts_like_title = stripped[0].isupper() or (len(stripped) > 1 and stripped[0].islower() and stripped[1].isupper())
+    return starts_like_title and len(meaningful_tokens(stripped)) >= 2
+
+
+def is_excluded_bare_reference(line: str, match_start: int) -> bool:
+    prefix = line[max(0, match_start - 16):match_start].lower()
+    return prefix.endswith('section ') or prefix.endswith('v')
+
+
+def overlaps(existing_spans: list[tuple[int, int]], start: int, end: int) -> bool:
+    return any(start < existing_end and end > existing_start for existing_start, existing_end in existing_spans)
+
+
+def cleaned_line(line: str) -> str:
+    without_urls = URL_RE.sub('', line)
+    without_anchors = ANCHOR_LINK_RE.sub('', without_urls)
+    return INLINE_CODE_RE.sub('', without_anchors)
+
+
+def collect_references(line: str) -> list[Reference]:
+    references: list[Reference] = []
+    occupied_spans: list[tuple[int, int]] = []
+    filtered_line = cleaned_line(line)
+
+    def register_reference(control_id: str, found_text: str, label: str | None, start: int, end: int) -> None:
+        if overlaps(occupied_spans, start, end):
+            return
+        occupied_spans.append((start, end))
+        references.append(Reference(control_id=control_id, found_text=found_text, label=label, start=start, end=end))
+
+    for pattern in (BRACKETED_CONTROL_RE, CONTROL_PAREN_RE, BARE_PAREN_RE):
+        for match in pattern.finditer(filtered_line):
+            if pattern is BARE_PAREN_RE and is_excluded_bare_reference(filtered_line, match.start()):
+                continue
+            label = match.groupdict().get('paren_label') or match.groupdict().get('label')
+            register_reference(match.group('id'), match.group(0), label, match.start(), match.end())
+
+    for match in CONTROL_LIST_RE.finditer(filtered_line):
+        body = match.group('body')
+        for id_match in CONTROL_ID_RE.finditer(body):
+            start = match.start('body') + id_match.start(1)
+            end = match.start('body') + id_match.end(1)
+            register_reference(id_match.group(1), id_match.group(1), None, start, end)
+
+    for match in SIMPLE_CONTROL_RE.finditer(filtered_line):
+        register_reference(match.group('id'), match.group(0), None, match.start(), match.end())
+
+    return references
+
+
+def scan_files(canonical: dict[str, str]) -> tuple[int, int, list[Finding], list[Finding]]:
+    files_scanned = 0
+    refs_found = 0
+    broken_id: list[Finding] = []
+    mislabeled: list[Finding] = []
+
+    for path in iter_markdown_files():
+        if 'maintainers-local' in path.parts:
+            continue
+
+        files_scanned += 1
+        relative_path = path.relative_to(REPO_ROOT).as_posix()
+        lines = path.read_text(encoding='utf-8').splitlines()
+        in_code_fence = False
+
+        for line_number, line in enumerate(lines, start=1):
+            if CODE_FENCE_RE.match(line):
+                in_code_fence = not in_code_fence
+                continue
+            if in_code_fence:
+                continue
+
+            for reference in collect_references(line):
+                refs_found += 1
+                canonical_name = canonical.get(reference.control_id)
+                if not canonical_name:
+                    broken_id.append(
+                        Finding(
+                            file=relative_path,
+                            line=line_number,
+                            severity='BROKEN-ID',
+                            found_text=reference.found_text,
+                            control_id=reference.control_id,
+                            expected='<existing canonical control>',
+                        )
+                    )
+                    continue
+
+                has_explicit_control_prefix = 'control' in reference.found_text.casefold()
+                if has_explicit_control_prefix and should_validate_label(reference.label):
+                    label = reference.label or ''
+                    if not label_matches_canonical(label, canonical_name):
+                        likely_control_id = best_canonical_label_match(label, canonical, reference.control_id)
+                        if likely_control_id:
+                            mislabeled.append(
+                                Finding(
+                                    file=relative_path,
+                                    line=line_number,
+                                    severity='MISLABELED',
+                                    found_text=reference.found_text,
+                                    control_id=reference.control_id,
+                                    expected=canonical_name,
+                                )
+                            )
+
+    return files_scanned, refs_found, broken_id, mislabeled
+
+
+def main() -> int:
+    canonical = build_canonical_map()
+    files_scanned, refs_found, broken_id, mislabeled = scan_files(canonical)
+
+    for finding in broken_id + mislabeled:
+        print(
+            f'{finding.file}:{finding.line}: {finding.severity}: {finding.found_text} — expected {finding.expected}',
+            file=sys.stderr,
+        )
+
+    summary = {
+        'files_scanned': files_scanned,
+        'refs_found': refs_found,
+        'broken_id': [asdict(finding) for finding in broken_id],
+        'mislabeled': [asdict(finding) for finding in mislabeled],
+    }
+    print(json.dumps(summary, ensure_ascii=False))
+    return 1 if broken_id or mislabeled else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds `scripts/verify_xref_graph.py` to mechanically validate every `Control X.Y` reference across `docs/` resolves to a real control in `assessment/manifest/controls.json` and matches the canonical control name. Wired into `.github/workflows/python-quality.yml` so future PRs can't introduce the class of bug PR #289 fixed (1.8/troubleshooting.md had `1.5 (Communication Compliance)` when 1.5 = DLP and 1.10 = CC).

## How it works
- Walks `docs/controls/`, `docs/playbooks/`, `docs/framework/`, `docs/reference/`
- Regex-matches `Control N.M`, `Controls N.M and N.M`, `N.M (Label)`, `[Control N.M]` patterns
- Validates each ID exists in canonical manifest
- Validates inline labels against canonical control names when the label strongly resolves to a control title, avoiding section-descriptor false positives
- On any finding: prints `<file>:<line>: <severity>: <text> — expected <canonical>` to stderr; exits 1
- Prints JSON summary to stdout

## Findings surfaced and fixed in this PR
- Fixed `1.22/troubleshooting.md` to point DLP + communication-compliance compensating controls at canonical Controls 1.5 and 1.10.
- Fixed `2.12/powershell-setup.md` to point the Entra sponsorship model reference at canonical Control 2.26.
- Fixed `2.12/troubleshooting.md` to point Entra directory-level identity guidance at canonical Control 1.11.
- Fixed `2.24/verification-testing.md` to point SIEM chaining at canonical Controls 1.7 and 3.9.
- Fixed `3.6/verification-testing.md` to point HR connector lifecycle governance at canonical Control 2.26.
- Fixed `4.7/powershell-setup.md` to point Copilot audit-log export guidance at canonical Control 1.7.

## Validation
- `python scripts/verify_xref_graph.py` exits 0 ✅
- Negative case: tested by intentionally introducing a stale ref, confirmed non-zero exit with clear error message ✅
- `ruff check scripts` ✅
- `mkdocs build --strict` ✅

Per Option A of user decision 2026-05-18 backlog discussion.