### PR TITLE
test(assessment): add contract fixtures for 5 remaining collectors (closes U-032)

### DIFF
--- a/assessment/tests/fixtures/frontier_collector_contract.json
+++ b/assessment/tests/fixtures/frontier_collector_contract.json
@@ -1,0 +1,29 @@
+{
+  "_metadata": {
+    "collector_version": "1.0.0",
+    "timestamp": "2026-05-18T12:00:00Z",
+    "facilitator": "Test Facilitator",
+    "session_duration_minutes": 18,
+    "mode": "batch",
+    "manifest_version": "1.0.0",
+    "warnings": [],
+    "errors": []
+  },
+  "answers": {
+    "Q01": {
+      "value": "yes",
+      "evidence_note": "Executive sponsor and AI governance lead are named in the intake charter.",
+      "respondent": "CIO"
+    },
+    "Q02": {
+      "value": 4,
+      "evidence_note": "Quarterly steering committee reviews an AI initiative portfolio.",
+      "respondent": "Risk Office"
+    },
+    "Q03": {
+      "value": "Strategy narrative stored in the governance workspace.",
+      "evidence_note": "Manual evidence link captured by facilitator.",
+      "respondent": "Program Office"
+    }
+  }
+}

--- a/assessment/tests/fixtures/graph_collector_contract.json
+++ b/assessment/tests/fixtures/graph_collector_contract.json
@@ -1,0 +1,82 @@
+{
+  "_metadata": {
+    "collector": "Collect-Graph",
+    "timestamp": "2026-05-18T12:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "conditionalAccessPolicies": [
+    {
+      "Id": "ca-001",
+      "DisplayName": "Require MFA for Copilot Studio",
+      "State": "enabled",
+      "IncludeApplications": ["96ff4394-9197-43aa-b393-6a41652e21f8"],
+      "ExcludeApplications": [],
+      "IncludeUsers": ["All"],
+      "ExcludeUsers": [],
+      "IncludeGroups": [],
+      "ExcludeGroups": [],
+      "BuiltInControls": ["mfa"],
+      "Operator": "OR",
+      "SignInFrequency": {
+        "value": 4,
+        "type": "hours"
+      },
+      "PersistentBrowser": null
+    }
+  ],
+  "fsiSecurityGroups": [
+    {
+      "Id": "sg-publishers-001",
+      "DisplayName": "FSI Agent Publishers",
+      "SecurityEnabled": true,
+      "GroupTypes": [],
+      "MembershipRule": null,
+      "MemberCount": 12
+    }
+  ],
+  "informationBarriers": {
+    "available": false,
+    "reason": "ExchangeOnlineManagement module not installed — IB policies cannot be collected via Graph alone."
+  },
+  "privilegedRoleAssignments": [
+    {
+      "RoleDefinitionId": "role-001",
+      "RoleName": "Power Platform Administrator",
+      "PrincipalId": "user-001",
+      "DirectoryScopeId": "/"
+    }
+  ],
+  "copilotServicePrincipals": [
+    {
+      "AppId": "96ff4394-9197-43aa-b393-6a41652e21f8",
+      "DisplayName": "Microsoft Copilot Studio",
+      "AccountEnabled": true,
+      "Id": "sp-001",
+      "ServicePrincipalType": "Application"
+    }
+  ],
+  "tenantSecuritySettings": {
+    "DisplayName": "Contoso",
+    "TenantId": "test-tenant",
+    "TenantType": "AAD",
+    "VerifiedDomains": [
+      {
+        "Name": "contoso.com",
+        "IsDefault": true,
+        "IsInitial": false,
+        "Type": "Managed"
+      }
+    ],
+    "OnPremisesSyncEnabled": true
+  },
+  "aiLeadershipUsers": [
+    {
+      "DisplayName": "Alex Kim",
+      "UserPrincipalName": "alex.kim@contoso.com",
+      "JobTitle": "Head of AI Governance",
+      "Department": "Technology Risk",
+      "MatchedKeyword": "Head of AI"
+    }
+  ]
+}

--- a/assessment/tests/fixtures/purview_collector_contract.json
+++ b/assessment/tests/fixtures/purview_collector_contract.json
@@ -1,0 +1,93 @@
+{
+  "_metadata": {
+    "collector": "Collect-Purview",
+    "timestamp": "2026-05-18T12:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": []
+  },
+  "auditConfig": {
+    "UnifiedAuditLogIngestionEnabled": true,
+    "AdminAuditLogAgeLimit": "180.00:00:00",
+    "AuditConfigurationPolicies": [
+      {
+        "Identity": "audit-standard",
+        "Priority": 1,
+        "Workload": "All"
+      }
+    ]
+  },
+  "dlpCompliancePolicies": [
+    {
+      "Name": "Copilot Data Loss Prevention",
+      "Mode": "Enable",
+      "Workload": "Exchange,SharePoint",
+      "Enabled": true,
+      "Rules": [
+        {
+          "Name": "Block public sharing of sensitive content",
+          "Disabled": false,
+          "ContentContainsSensitiveInformation": [
+            {
+              "Name": "U.S. Social Security Number"
+            }
+          ],
+          "BlockAccess": true,
+          "Priority": 0
+        }
+      ]
+    }
+  ],
+  "retentionPolicies": [
+    {
+      "Name": "Copilot Interaction Retention",
+      "Enabled": true,
+      "Mode": "Enforce",
+      "Workload": "CopilotInteraction",
+      "RetentionDuration": "365",
+      "RetentionAction": "KeepAndDelete",
+      "CopilotWorkloadFound": true
+    }
+  ],
+  "communicationCompliance": [
+    {
+      "Name": "Copilot Supervision",
+      "Mode": "Enforce",
+      "Enabled": true,
+      "PolicyType": "SupervisoryReview"
+    }
+  ],
+  "eDiscoveryCases": [
+    {
+      "Name": "AI Investigations",
+      "Status": "Active",
+      "CaseType": "Standard"
+    }
+  ],
+  "insiderRiskPolicies": [
+    {
+      "Name": "Agent Data Exfiltration",
+      "Enabled": true,
+      "Mode": "Enforce"
+    }
+  ],
+  "dspmForAi": {
+    "Available": true,
+    "AlertsEnabled": true,
+    "LastAssessment": "2026-05-18T12:00:00Z"
+  },
+  "sensitivityLabelPolicies": [
+    {
+      "Name": "Confidential Financial Data",
+      "Enabled": true,
+      "Priority": 1
+    }
+  ],
+  "endpointDlp": [
+    {
+      "Name": "Endpoint DLP Baseline",
+      "Mode": "Enable",
+      "Workload": "Endpoint",
+      "Enabled": true
+    }
+  ]
+}

--- a/assessment/tests/fixtures/sentinel_collector_contract.json
+++ b/assessment/tests/fixtures/sentinel_collector_contract.json
@@ -1,0 +1,47 @@
+{
+  "_metadata": {
+    "collector": "Collect-Sentinel",
+    "timestamp": "2026-05-18T12:00:00Z",
+    "tenant_id": "test-tenant",
+    "subscription_id": "sub-001",
+    "resource_group": "rg-security",
+    "workspace_name": "law-prod",
+    "warnings": []
+  },
+  "workspace": {
+    "WorkspaceId": "ws-001",
+    "ResourceId": "/subscriptions/sub-001/resourceGroups/rg-security/providers/Microsoft.OperationalInsights/workspaces/law-prod",
+    "Name": "law-prod",
+    "Location": "eastus",
+    "ProvisioningState": "Succeeded",
+    "Sku": "PerGB2018",
+    "RetentionInDays": 30,
+    "WorkspaceCapping": null
+  },
+  "dataConnectors": {
+    "TotalConnectors": 2,
+    "ConnectorSummary": [
+      {
+        "Id": "connector-001",
+        "Name": "Office365",
+        "Kind": "Office365",
+        "Etag": "etag-1"
+      },
+      {
+        "Id": "connector-002",
+        "Name": "MicrosoftCloudAppSecurity",
+        "Kind": "MicrosoftCloudAppSecurity",
+        "Etag": "etag-2"
+      }
+    ],
+    "Office365Enabled": true,
+    "McasEnabled": true
+  },
+  "kqlAuditCheck": {
+    "Query": "AuditLogs | where TimeGenerated >= ago(7d) | summarize Count = count()",
+    "RecordCount": 142,
+    "HasRecords": true,
+    "QueryTimeRange": "7 days",
+    "ExecutedAt": "2026-05-18T12:00:00Z"
+  }
+}

--- a/assessment/tests/fixtures/sharepoint_collector_contract.json
+++ b/assessment/tests/fixtures/sharepoint_collector_contract.json
@@ -1,0 +1,62 @@
+{
+  "_metadata": {
+    "collector": "Collect-SharePoint",
+    "timestamp": "2026-05-18T12:00:00Z",
+    "tenant_id": "test-tenant",
+    "warnings": [],
+    "approvedSitesCsvUsed": true
+  },
+  "siteInventory": [
+    {
+      "Id": "site-001",
+      "DisplayName": "Agent Knowledge Base",
+      "WebUrl": "https://contoso.sharepoint.com/sites/agentKB",
+      "CreatedDateTime": "2026-03-01T00:00:00Z",
+      "IsPersonalSite": false
+    }
+  ],
+  "externalSharing": [
+    {
+      "SiteId": "site-001",
+      "DisplayName": "Agent Knowledge Base",
+      "WebUrl": "https://contoso.sharepoint.com/sites/agentKB",
+      "SharingCapability": "Disabled"
+    }
+  ],
+  "retentionLabels": [
+    {
+      "SiteId": "site-001",
+      "SiteDisplayName": "Agent Knowledge Base",
+      "ListId": "list-001",
+      "ListDisplayName": "Documents",
+      "ListTemplate": "documentLibrary",
+      "ContentTypesEnabled": true
+    }
+  ],
+  "guestAccess": [
+    {
+      "SiteId": "site-001",
+      "DisplayName": "Agent Knowledge Base",
+      "WebUrl": "https://contoso.sharepoint.com/sites/agentKB",
+      "GuestCount": 0,
+      "HasGuestAccess": false
+    }
+  ],
+  "itemLevelPermissions": [
+    {
+      "SiteId": "site-001",
+      "DisplayName": "Agent Knowledge Base",
+      "WebUrl": "https://contoso.sharepoint.com/sites/agentKB",
+      "SampledItems": 50,
+      "FlaggedItems": [],
+      "FlaggedCount": 0
+    }
+  ],
+  "groundingCrossRef": {
+    "ApprovedSitesTotal": 1,
+    "ApprovedFound": 1,
+    "ApprovedMissing": [],
+    "UnapprovedSiteCount": 0,
+    "UnapprovedSites": []
+  }
+}

--- a/assessment/tests/test_score.py
+++ b/assessment/tests/test_score.py
@@ -61,6 +61,22 @@ def build_manifest_with_controls(controls: list[dict]) -> dict:
     }
 
 
+def build_frontier_manifest_with_questions(questions: list[dict]) -> dict:
+    """Wrap frontier question dicts into a minimal manifest envelope."""
+    return {
+        "version": "1.0.0",
+        "drivers": [
+            {"id": "ai_strategy", "name": "AI Strategy"},
+            {"id": "business_strategy", "name": "Business Strategy"},
+            {"id": "ai_governance", "name": "AI Governance"},
+            {"id": "technology_data", "name": "Technology & Data"},
+            {"id": "organization_culture", "name": "Organization & Culture"},
+        ],
+        "questions": questions,
+        "pattern_target_profiles": {},
+    }
+
+
 # ---------------------------------------------------------------------------
 # Fixtures (pytest)
 # ---------------------------------------------------------------------------
@@ -336,7 +352,7 @@ class TestZoneThresholdBoundary:
 
 
 # ---------------------------------------------------------------------------
-# Test: collector-real PPAC payloads normalize into score.py's contract
+# Test: collector-real payloads keep engine contracts stable
 # ---------------------------------------------------------------------------
 
 class TestCollectorContractNormalization:
@@ -376,6 +392,229 @@ class TestCollectorContractNormalization:
         assert ctrl["evidence"]["2.1.a"]["result"] == "pass"
         assert "securityGroupId" in ctrl["evidence"]["2.1.a"]["value"]
         assert ctrl["evidence"]["2.1.b"]["result"] == "pass"
+
+    def test_graph_collector_shape_supports_controls_1_1_and_1_3(
+        self, tmp_path: Path, manifest: dict
+    ):
+        score = pytest.importorskip("score")  # type: ignore[import-untyped]
+
+        collected = tmp_path / "collected"
+        collected.mkdir()
+
+        write_json(
+            collected / "graph.json",
+            load_fixture("graph_collector_contract.json"),
+        )
+        for name in ("ppac", "purview", "sharepoint", "sentinel"):
+            write_json(collected / f"{name}.json", load_fixture(f"{name}.json"))
+
+        manifest_path = tmp_path / "controls.json"
+        output_path = tmp_path / "scores.json"
+        write_json(manifest_path, manifest)
+
+        score.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected),
+            zone=2,
+            output_path=str(output_path),
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        ctrl_11 = next(c for c in result["controls"] if c["id"] == "1.1")
+        ctrl_13 = next(c for c in result["controls"] if c["id"] == "1.3")
+
+        assert ctrl_11["evidence"]["1.1.b"]["result"] == "pass"
+        assert ctrl_13["checks_passed"] == 2
+        assert ctrl_13["maturity_score"] == 2
+        assert ctrl_13["evidence"]["1.3.a"]["result"] == "pass"
+        assert "app ID" in ctrl_13["evidence"]["1.3.a"]["value"]
+        assert ctrl_13["evidence"]["1.3.b"]["result"] == "pass"
+
+    def test_purview_collector_shape_supports_control_3_1(
+        self, tmp_path: Path, manifest: dict
+    ):
+        score = pytest.importorskip("score")  # type: ignore[import-untyped]
+
+        collected = tmp_path / "collected"
+        collected.mkdir()
+
+        write_json(
+            collected / "purview.json",
+            load_fixture("purview_collector_contract.json"),
+        )
+        for name in ("ppac", "graph", "sharepoint", "sentinel"):
+            write_json(collected / f"{name}.json", load_fixture(f"{name}.json"))
+
+        manifest_path = tmp_path / "controls.json"
+        output_path = tmp_path / "scores.json"
+        write_json(manifest_path, manifest)
+
+        score.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected),
+            zone=2,
+            output_path=str(output_path),
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        ctrl = next(c for c in result["controls"] if c["id"] == "3.1")
+
+        assert ctrl["checks_passed"] == 2
+        assert ctrl["maturity_score"] == 2
+        assert ctrl["evidence"]["3.1.a"]["result"] == "pass"
+        assert "UnifiedAuditLogIngestionEnabled is true" in ctrl["evidence"]["3.1.a"]["value"]
+        assert ctrl["evidence"]["3.1.b"]["result"] == "pass"
+        assert "Copilot Interaction Retention" in ctrl["evidence"]["3.1.b"]["value"]
+
+    def test_sharepoint_collector_shape_supports_control_4_4(
+        self, tmp_path: Path, manifest: dict
+    ):
+        score = pytest.importorskip("score")  # type: ignore[import-untyped]
+
+        collected = tmp_path / "collected"
+        collected.mkdir()
+
+        write_json(
+            collected / "sharepoint.json",
+            load_fixture("sharepoint_collector_contract.json"),
+        )
+        for name in ("ppac", "graph", "purview", "sentinel"):
+            write_json(collected / f"{name}.json", load_fixture(f"{name}.json"))
+
+        manifest_path = tmp_path / "controls.json"
+        output_path = tmp_path / "scores.json"
+        write_json(manifest_path, manifest)
+
+        score.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected),
+            zone=2,
+            output_path=str(output_path),
+        )
+
+        result = json.loads(output_path.read_text(encoding="utf-8"))
+        ctrl = next(c for c in result["controls"] if c["id"] == "4.4")
+
+        assert ctrl["checks_passed"] == 2
+        assert ctrl["maturity_score"] == 2
+        assert ctrl["evidence"]["4.4.a"]["result"] == "pass"
+        assert ctrl["evidence"]["4.4.b"]["result"] == "pass"
+        assert "Disabled" in ctrl["evidence"]["4.4.b"]["value"]
+
+    def test_sentinel_collector_shape_supports_frontier_q17(
+        self, tmp_path: Path
+    ):
+        score_frontier = pytest.importorskip("score_frontier")  # type: ignore[import-untyped]
+
+        collected = tmp_path / "collected"
+        collected.mkdir()
+
+        write_json(collected / "ppac.json", load_fixture("ppac.json"))
+        write_json(
+            collected / "sentinel.json",
+            load_fixture("sentinel_collector_contract.json"),
+        )
+
+        manifest_data = build_frontier_manifest_with_questions(
+            [
+                {
+                    "question_id": "Q17",
+                    "driver": "technology_data",
+                    "level": 100,
+                    "question_text": "Are environments tagged and is telemetry available?",
+                    "fsi_context": "Contract test",
+                    "scoring_weight": 1.0,
+                    "answer_format": "yes_no_partial",
+                    "auto_evaluable": True,
+                    "pass_condition": "tagged_environments_with_basic_telemetry",
+                    "collection_methods": ["PPAC_PowerShell", "Sentinel"],
+                }
+            ]
+        )
+        manifest_path = tmp_path / "frontier-manifest.json"
+        output_path = tmp_path / "frontier-summary.json"
+        write_json(manifest_path, manifest_data)
+
+        result = score_frontier.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected),
+            output_path=str(output_path),
+        )
+
+        q17 = result["evaluator_results"]["Q17"]
+        driver = result["driver_scores"]["technology_data"]
+
+        assert q17["answer_value"] == "partial"
+        assert "Sentinel workspace" in q17["evidence"]
+        assert driver["score"] == 50
+
+    def test_frontier_collector_shape_supports_frontier_run(
+        self, tmp_path: Path
+    ):
+        score_frontier = pytest.importorskip("score_frontier")  # type: ignore[import-untyped]
+
+        collected = tmp_path / "collected"
+        collected.mkdir()
+
+        write_json(
+            collected / "frontier.json",
+            load_fixture("frontier_collector_contract.json"),
+        )
+
+        manifest_data = build_frontier_manifest_with_questions(
+            [
+                {
+                    "question_id": "Q01",
+                    "driver": "ai_strategy",
+                    "level": 100,
+                    "question_text": "Is an AI initiative owner identified?",
+                    "fsi_context": "Contract test",
+                    "scoring_weight": 1.0,
+                    "answer_format": "yes_no_partial",
+                    "auto_evaluable": False,
+                    "collection_methods": ["Manual"],
+                },
+                {
+                    "question_id": "Q02",
+                    "driver": "ai_strategy",
+                    "level": 200,
+                    "question_text": "How repeatable is the AI initiative review process?",
+                    "fsi_context": "Contract test",
+                    "scoring_weight": 1.0,
+                    "answer_format": "scale_1_5",
+                    "auto_evaluable": False,
+                    "collection_methods": ["Manual"],
+                },
+                {
+                    "question_id": "Q03",
+                    "driver": "ai_strategy",
+                    "level": 300,
+                    "question_text": "Describe where the AI strategy narrative is stored.",
+                    "fsi_context": "Contract test",
+                    "scoring_weight": 1.0,
+                    "answer_format": "text",
+                    "auto_evaluable": False,
+                    "collection_methods": ["Manual"],
+                },
+            ]
+        )
+        manifest_path = tmp_path / "frontier-manifest.json"
+        output_path = tmp_path / "frontier-summary.json"
+        write_json(manifest_path, manifest_data)
+
+        result = score_frontier.run(
+            manifest_path=str(manifest_path),
+            collected_dir=str(collected),
+            output_path=str(output_path),
+        )
+
+        driver = result["driver_scores"]["ai_strategy"]
+
+        assert driver["questions_answered"] == 2
+        assert driver["questions_total"] == 3
+        assert driver["level_breakdown"]["200"]["ratio"] == 0.75
+        assert driver["score"] == 200
+        assert result["evaluator_coverage"]["questions"]["manual_only"] == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes finding U-032 (P2). Adds contract fixtures + tests for the 5 collectors not covered by PR #294.

## Files added
- `assessment/tests/fixtures/graph_collector_contract.json`
- `assessment/tests/fixtures/purview_collector_contract.json`
- `assessment/tests/fixtures/sentinel_collector_contract.json`
- `assessment/tests/fixtures/sharepoint_collector_contract.json`
- `assessment/tests/fixtures/frontier_collector_contract.json`

## Files modified
- `assessment/tests/test_score.py` — 5 new contract tests, one per fixture

## Pattern followed
Mirrors the PPAC fixture from PR #294: realistic minimal payload exercising the most common evaluator inputs + at least one nested structure + any normalization edge cases that score.py handles.

## Validation
- `pytest assessment/tests/ -v` ✅ (141 → 146 tests)
- `ruff check assessment scripts` ✅
- `python scripts/verify_language_rules.py` ✅
- `mkdocs build --strict` ✅

## Discovered during implementation
- `score.py` still has no bespoke Sentinel evaluator/normalization path for the collector's live `dataConnectors` / `kqlAuditCheck` shape. This PR stays fixtures-only, so the Sentinel contract is exercised through the live `score_frontier.py` Q17 path instead of adding new `score.py` logic.
- `frontier.json` is consumed by `score_frontier.py`, not `score.py`. The frontier contract test therefore lives in `test_score.py` but intentionally executes the frontier engine entry point.

Closes finding U-032.