### PR TITLE
docs(framework+start-here): align Zone 3 retention; add license prereqs (closes U-010, U-027)

### DIFF
--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -57,7 +57,7 @@ This separation ensures governance stability while allowing rapid updates to imp
 
 ### 1. Risk-Based Governance
 
-Controls scale with risk. Zone 1 (personal productivity) requires minimal oversight while Zone 3 (enterprise/customer-facing) requires comprehensive governance including committee approval, model risk management, and 10-year retention.
+Controls scale with risk. Zone 1 (personal productivity) requires minimal oversight while Zone 3 (enterprise/customer-facing) requires comprehensive governance including committee approval, model risk management, and record-class retention as defined in [Control 1.7](../controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md) rather than a blanket retention period.
 
 ### 2. Regulatory Alignment
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -11,6 +11,18 @@
 !!! warning "Disclaimer"
     This framework is provided for informational purposes only and does not constitute legal, regulatory, or compliance advice. See [full disclaimer](disclaimer.md).
 
+## Before you start: License prerequisites
+
+Most implementations in this framework rely on a mix of Copilot Studio, Power Platform, and Microsoft 365 security/compliance licensing rather than a single SKU. Zone 3 scenarios commonly need Microsoft 365 E5 or Microsoft Purview Suite capabilities for audit, retention, investigation, and reporting controls, while some implementations also add Microsoft Defender for Cloud Apps, Microsoft Sentinel, or SharePoint Advanced Management. Validate the exact license mix for each control before rollout.
+
+- **Copilot Studio** is the baseline for agent development across the framework.
+- **Power Platform Premium** is commonly needed for managed environments, environment governance, and related PPAC controls.
+- **Microsoft 365 E5 or Microsoft Purview Suite** is commonly needed for Purview-heavy controls such as audit logging, data retention, eDiscovery, and Communication Compliance.
+- **Microsoft 365 E5 Security or full Microsoft 365 E5** may be needed when controls depend on Microsoft Defender for Cloud Apps or Microsoft Sentinel.
+- **SharePoint Advanced Management** is commonly needed for SharePoint governance controls in Pillar 4.
+
+For the full per-control breakdown, see the **[License Requirements Matrix](reference/license-requirements.md)**.
+
 ---
 
 ## Is This the Right Repository?


### PR DESCRIPTION
## Summary
Closes U-010 (P3) and U-027 (P3) — both surfaced by verification sweep 2026-05-18.

## Changes
- **U-010:** `docs/framework/index.md:60` — Zone 3 retention statement replaced. Was a blanket "10-year retention" claim; now uses the record-class language Control 1.7 standardized in PR #297 (3 yr communications / 6 yr financial-governance / 5 yr CFTC / longer only where rule requires).
- **U-027:** `docs/start-here.md` — new "Before you start: License prerequisites" section with bullet orientation and a prominent link to the license requirements matrix.

## Validation
- `python scripts/verify_language_rules.py` ✅
- `python scripts/verify_controls.py` ✅
- `python scripts/check_manifest_doc_drift.py --check` ✅
- `python scripts/verify_xref_graph.py` ✅
- `mkdocs build --strict` ✅

Closes findings U-010, U-027.