### PR TITLE
docs+spa: canonicalize remaining OCC 2011-12 / SR 11-7 standalone refs (closes U-002, U-009)

### DIFF
--- a/docs/controls/pillar-1-security/1.24-defender-ai-security-posture-management.md
+++ b/docs/controls/pillar-1-security/1.24-defender-ai-security-posture-management.md
@@ -183,7 +183,7 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Multi-cloud security (AWS/GCP)](https://learn.microsoft.com/en-us/azure/defender-for-cloud/multicloud)
 - [Microsoft Learn: Real-time agent protection during runtime (Defender for Cloud Apps)](https://learn.microsoft.com/en-us/defender-cloud-apps/real-time-agent-protection-during-runtime)
 - [NIST AI Risk Management Framework 1.0](https://www.nist.gov/itl/ai-risk-management-framework)
-- [OCC Bulletin 2011-12: Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13: Sound Practices for Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [FINRA Regulatory Notice 25-07: AI Supervisory Controls](https://www.finra.org/rules-guidance/notices/25-07)
 
 ### FSI Scope Note
@@ -201,4 +201,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/controls/pillar-1-security/1.29-global-secure-access-network-controls.md
+++ b/docs/controls/pillar-1-security/1.29-global-secure-access-network-controls.md
@@ -225,10 +225,10 @@ When an agent initiates a request to an external resource:
 - [Microsoft Learn: Global Secure Access traffic logs](https://learn.microsoft.com/en-us/entra/global-secure-access/concept-traffic-dashboard)
 - [GLBA Safeguards Rule — FTC 16 CFR Part 314](https://www.ftc.gov/legal-library/browse/rules/safeguards-rule)
 - [FINRA Rule 4511 — General Requirements](https://www.finra.org/rules-guidance/rulebooks/finra-rules/4511)
-- [OCC Bulletin 2011-12 — Technology Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13 — Technology Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [FSI-AgentGov Control 1.20 — Network Isolation and Private Connectivity](./1.20-network-isolation-private-connectivity.md)
 - [FSI-AgentGov Control 3.9 — Microsoft Sentinel Integration](../pillar-3-reporting/3.9-microsoft-sentinel-integration.md)
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md
+++ b/docs/controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md
@@ -140,7 +140,7 @@ Confirm control effectiveness by verifying:
 ## Additional Resources
 
 - [Federal Reserve SR 26-2 (formerly SR 11-7): Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm)
-- [OCC 2011-12: Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC 2026-13: Sound Practices for Model Risk Management (formerly OCC 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [CFPB Circular 2022-03: Adverse action notification requirements in connection with credit decisions based on complex algorithms](https://www.consumerfinance.gov/compliance/circulars/circular-2022-03-adverse-action-notification-requirements-in-connection-with-credit-decisions-based-on-complex-algorithms/)
 - [CFPB Circular 2023-03: Adverse action notices when using AI / complex algorithms (sample-form usage)](https://www.consumerfinance.gov/compliance/circulars/circular-2023-03-adverse-action-notification-requirements-and-the-proper-use-of-the-cfpbs-sample-forms-provided-in-regulation-b/)
 - [U.S. Treasury (Dec 2024): Uses, Opportunities, and Risks of Artificial Intelligence in the Financial Services Sector](https://home.treasury.gov/system/files/136/Artificial-Intelligence-in-Financial-Services.pdf)

--- a/docs/controls/pillar-2-management/2.14-training-and-awareness-program.md
+++ b/docs/controls/pillar-2-management/2.14-training-and-awareness-program.md
@@ -121,7 +121,7 @@ Confirm control effectiveness by verifying:
 - [FINRA Rule 3110: Supervision](https://www.finra.org/rules-guidance/rulebooks/finra-rules/3110)
 - [FINRA Regulatory Notice 25-07 (AI supervision)](https://www.finra.org/rules-guidance/notices/25-07)
 - [FINRA 2026 Annual Regulatory Oversight Report — GenAI](https://www.finra.org/rules-guidance/guidance/reports/2026-finra-annual-regulatory-oversight-report/gen-ai)
-- [OCC Bulletin 2011-12: Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13: Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [Federal Reserve SR 26-2 (formerly SR 11-7): Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm)
 
 ---
@@ -129,4 +129,4 @@ Confirm control effectiveness by verifying:
 !!! note "Implementation Note"
     Organizations should verify that their implementation meets their specific regulatory obligations. This control supports compliance efforts but requires proper configuration and ongoing validation.
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/controls/pillar-2-management/2.16-rag-source-integrity-validation.md
+++ b/docs/controls/pillar-2-management/2.16-rag-source-integrity-validation.md
@@ -157,8 +157,8 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Microsoft Purview DSPM for AI](https://learn.microsoft.com/en-us/purview/dspm-for-ai)
 - [Microsoft Learn: Copilot Studio Citations](https://learn.microsoft.com/en-us/microsoft-copilot-studio/nlu-boost-node)
 - [Federal Reserve SR 26-2 (formerly SR 11-7): Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm)
-- [OCC Bulletin 2011-12: Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13: Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md
+++ b/docs/controls/pillar-2-management/2.17-multi-agent-orchestration-limits.md
@@ -256,7 +256,7 @@ customEvents
 
 - [Microsoft Learn: Copilot Studio Agent Orchestration](https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-plugin-actions)
 - [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/)
-- [OCC 2011-12: Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC 2026-13: Model Risk Management (formerly OCC 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [MITRE ATLAS: AI Threat Framework](https://atlas.mitre.org/)
 - [Microsoft Learn: MCP Server Support](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-microsoft-mcp-servers)
 - [MCP Server Governance for FSI — Three flavors of MCP](../../playbooks/advanced-implementations/mcp-server-governance/index.md#three-flavors-of-mcp) — See also for governance differences among Copilot Studio custom MCP, Microsoft-published MCP servers, and Agent 365 BYO MCP when orchestration designs rely on MCP tools.

--- a/docs/controls/pillar-2-management/2.24-agent-feature-enablement-and-restriction-governance.md
+++ b/docs/controls/pillar-2-management/2.24-agent-feature-enablement-and-restriction-governance.md
@@ -311,7 +311,7 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Data Loss Prevention for Power Platform](https://learn.microsoft.com/en-us/power-platform/admin/wp-data-loss-prevention)
 - [Microsoft Learn: Multi-Agent Orchestration in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/advanced-generative-actions)
 - [Microsoft Learn: Power Platform Settings and Features](https://learn.microsoft.com/en-us/power-platform/admin/settings-features)
-- [OCC Bulletin 2011-12: Supervisory Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13: Supervisory Guidance on Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 
 ---
 

--- a/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
+++ b/docs/controls/pillar-2-management/2.25-agent-365-admin-center-governance-console.md
@@ -156,7 +156,7 @@ Confirm control effectiveness by verifying:
 - [FINRA Rule 4511 — General Requirements (Books and Records)](https://www.finra.org/rules-guidance/rulebooks/finra-rules/4511)
 - [FINRA Regulatory Notice 25-07 — AI Tools](https://www.finra.org/rules-guidance/notices/25-07)
 - [SEC Rule 17a-4 — Records Retention](https://www.sec.gov/rules/final/34-38245.txt)
-- [OCC Bulletin 2011-12 — Technology Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13 — Technology Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [NYDFS 23 NYCRR 500 — Cybersecurity Requirements](https://www.dfs.ny.gov/industry_guidance/cybersecurity)
 
 !!! note "Post-GA Verification Recommended"

--- a/docs/controls/pillar-2-management/2.26-entra-agent-id-identity-governance.md
+++ b/docs/controls/pillar-2-management/2.26-entra-agent-id-identity-governance.md
@@ -180,7 +180,7 @@ The following criteria constitute the minimum evidence set required to attest th
 - [Access reviews overview](https://learn.microsoft.com/entra/id-governance/access-reviews-overview)
 - [Microsoft 365 Copilot Frontier program (historical reference — Agent 365 reached GA May 1, 2026)](https://adoption.microsoft.com/copilot/frontier-program/)
 - [FINRA 4511 — Books and Records Requirements](https://www.finra.org/rules-guidance/rulebooks/finra-rules/4511)
-- [OCC Bulletin 2011-12 — Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13 — Sound Practices for Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [SOX Section 404 — Internal Control Over Financial Reporting (PCAOB AS 2201)](https://pcaobus.org/Standards/Auditing/Pages/AS2201.aspx)
 
 ---

--- a/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md
+++ b/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md
@@ -8,14 +8,14 @@
 
 ---
 
-!!! warning "Regulatory update — SR 11-7 / OCC 2011-12 superseded April 17, 2026"
-    On **April 17, 2026**, the Federal Reserve, OCC, and FDIC jointly issued [Federal Reserve SR 26-2 — Revised Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) and [OCC Bulletin 2026-13 — Updated Interagency Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-13.html). These instruments **expressly supersede and rescind** SR letter 11-7 (April 4, 2011) and OCC Bulletin 2011-12 ("Sound Practices for Model Risk Management"), respectively, along with related items including SR 21-8 / OCC Bulletin 2021-19 (Interagency Statement on MRM for BSA/AML systems), the OCC's *"Model Risk Management"* booklet of the *Comptroller's Handbook*, and OCC Bulletin 1997-24 (Credit Scoring Models). The original `sr1107.htm` URL no longer resolves on the Federal Reserve site.
+!!! warning "Regulatory update — Fed SR 26-2 / OCC 2026-13 superseded their predecessors (formerly SR 11-7 / OCC 2011-12) on April 17, 2026"
+    On **April 17, 2026**, the Federal Reserve, OCC, and FDIC jointly issued [Federal Reserve SR 26-2 — Revised Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) and [OCC Bulletin 2026-13 — Updated Interagency Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-13.html). These instruments **expressly supersede and rescind** the predecessor guidance now referenced as Federal Reserve SR 26-2 (formerly SR letter 11-7, April 4, 2011) and OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12, "Sound Practices for Model Risk Management"), respectively, along with related items including SR 21-8 / OCC Bulletin 2021-19 (Interagency Statement on MRM for BSA/AML systems), the OCC's *"Model Risk Management"* booklet of the *Comptroller's Handbook*, and OCC Bulletin 1997-24 (Credit Scoring Models). The original `sr1107.htm` URL no longer resolves on the Federal Reserve site.
 
-    **What carried forward.** SR 26-2 / OCC 2026-13 retains the SR 11-7 conceptual framework — model definition, model inventory, independent validation, effective challenge, ongoing monitoring, outcomes analysis, three-lines-of-defense, vendor-model rigor — and tailors it to a risk-based approach calibrated to the firm's model risk profile and the size and complexity of its operations. Section / paragraph numbering may not match the prior letter; the historical `§V` (validation) and `§VI` (model risk management framework) anchors used throughout this control refer to the predecessor structure and are retained for reader continuity until the firm's MRM policy is re-mapped to the SR 26-2 published text.
+    **What carried forward.** SR 26-2 / OCC 2026-13 retains the conceptual framework published in Federal Reserve SR 26-2 (formerly SR 11-7) — model definition, model inventory, independent validation, effective challenge, ongoing monitoring, outcomes analysis, three-lines-of-defense, vendor-model rigor — and tailors it to a risk-based approach calibrated to the firm's model risk profile and the size and complexity of its operations. Section / paragraph numbering may not match the prior letter; the historical `§V` (validation) and `§VI` (model risk management framework) anchors used throughout this control refer to the predecessor structure and are retained for reader continuity until the firm's MRM policy is re-mapped to the SR 26-2 published text.
 
     **Generative and agentic AI scope caveat.** SR 26-2 / OCC 2026-13 expressly states that *"generative AI and agentic AI models are novel and rapidly evolving. As such, they are not within the scope of this guidance."* The Federal Reserve, OCC, and FDIC have **not** withdrawn the broader supervisory expectation that AI agents in customer-facing or decision-support roles be governed with model-equivalent rigor — that expectation continues to apply via existing safety-and-soundness, FINRA, SEC, NYDFS, and SOX regimes covered elsewhere in this control. Treat this control as the firm's **model-risk-equivalent** governance for AI agents until the agencies issue AI-specific guidance.
 
-    **File slug.** This control's file slug is `2.6-model-risk-management-sr-26-2.md`. The control was renamed from its predecessor "OCC 2011-12 / SR 11-7" slug once the SR 11-7 → SR 26-2 supersession was confirmed; the legacy URL path no longer resolves on this site. References to "SR 11-7" and "OCC 2011-12" in this document and its playbooks refer to the superseded guidance unless otherwise marked. The operative citations as of the verification date are **SR 26-2** and **OCC Bulletin 2026-13**.
+    **File slug.** This control's file slug is `2.6-model-risk-management-sr-26-2.md`. The control was renamed from its predecessor "OCC 2026-13 / Fed SR 26-2 (formerly OCC 2011-12 / SR 11-7)" slug once the supersession was confirmed; the legacy URL path no longer resolves on this site. References to "Federal Reserve SR 26-2 (formerly SR 11-7)" and "OCC Bulletin 2026-13 (formerly OCC 2011-12)" in this document and its playbooks refer to the superseded guidance unless otherwise marked. The operative citations as of the verification date are **SR 26-2** and **OCC Bulletin 2026-13**.
 
 ---
 
@@ -271,16 +271,16 @@ Confirm control effectiveness by verifying:
 
 **Regulatory sources — current (April 2026)**
 
-- [OCC Bulletin 2026-13 — Updated Interagency Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-13.html) — supersedes and rescinds OCC Bulletin 2011-12 (April 17, 2026)
-- [Federal Reserve SR 26-2 — Revised Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) — supersedes and replaces SR letter 11-7 and SR letter 21-8 (April 17, 2026)
+- [OCC Bulletin 2026-13 — Updated Interagency Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2026/bulletin-2026-13.html) — operative guidance; supersedes and rescinds the predecessor bulletin (formerly OCC Bulletin 2011-12) as of April 17, 2026
+- [Federal Reserve SR 26-2 — Revised Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) — operative guidance; supersedes and replaces the predecessor letter (formerly SR 11-7) and SR letter 21-8 (April 17, 2026)
 - [FDIC FIL-22-2017 — Adoption of Supervisory Guidance on Model Risk Management](https://www.fdic.gov/news/financial-institution-letters/2017/fil17022.html) — historical FDIC adoption of the 2011 guidance; refer to FDIC supervisory communications for adoption status of the 2026 revised guidance
 - [FFIEC IT Examination Handbook](https://ithandbook.ffiec.gov/)
 - [FINRA Regulatory Notice 25-07 — Use of Artificial Intelligence (RFC)](https://www.finra.org/rules-guidance/notices/25-07)
 
 **Regulatory sources — historical (rescinded April 2026, retained for audit-trail context)**
 
-- [OCC Bulletin 2011-12 — Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html) — *rescinded by OCC Bulletin 2026-13*
-- Federal Reserve SR 11-7 — Supervisory Guidance on Model Risk Management — *superseded by SR 26-2; the predecessor URL `sr1107.htm` no longer resolves on the Federal Reserve site*
+- [OCC Bulletin 2026-13 — Sound Practices for Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html) — *historical rescinded bulletin retained for audit-trail context*
+- Federal Reserve SR 26-2 (formerly SR 11-7) — Supervisory Guidance on Model Risk Management — *historical superseded letter retained for audit-trail context; the predecessor URL `sr1107.htm` no longer resolves on the Federal Reserve site*
 
 **Microsoft Learn — surfaces this control depends on (verified May 2026)**
 

--- a/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md
+++ b/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md
@@ -182,7 +182,7 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Azure Monitor Alerts](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview)
 - [Microsoft Learn: Azure AI Evaluation SDK](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/evaluate-sdk)
 - [Federal Reserve SR 26-2 (formerly SR 11-7): Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm)
-- [OCC Bulletin 2011-12: Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13: Sound Practices for Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 
 ---
 

--- a/docs/controls/pillar-3-reporting/3.14-agent-365-observability-sdk.md
+++ b/docs/controls/pillar-3-reporting/3.14-agent-365-observability-sdk.md
@@ -155,7 +155,7 @@ The following playbooks provide step-by-step implementation guidance for Control
 - [Microsoft Purview: Audit Log Retention Policies](https://learn.microsoft.com/en-us/purview/audit-log-retention-policies)
 - [FINRA Rule 4511 — General Requirements for Books and Records](https://www.finra.org/rules-guidance/rulebooks/finra-rules/4511)
 - [SEC Rule 17a-4 — Records to Be Preserved](https://www.ecfr.gov/current/title-17/chapter-II/part-240/section-240.17a-4)
-- [OCC Bulletin 2011-12 — Sound Practices for Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
+- [OCC Bulletin 2026-13 — Sound Practices for Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 - [Control 3.13 — Agent 365 Admin Center Analytics](./3.13-agent-365-admin-center-analytics.md) *(Dashboard consumer of 3.14 telemetry)*
 - [Control 1.7 — Comprehensive Audit Logging](../pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md)
 - [OpenTelemetry Project Documentation](https://opentelemetry.io/docs/)

--- a/docs/controls/pillar-3-reporting/3.3-compliance-and-regulatory-reporting.md
+++ b/docs/controls/pillar-3-reporting/3.3-compliance-and-regulatory-reporting.md
@@ -119,7 +119,7 @@ Regulatory Impact Categories (check all that apply):
 [ ] Consumer Protection (CFPB UDAAP)
 [ ] Fair Lending (ECOA, FCRA)
 [ ] AML/BSA Compliance
-[ ] Model Risk (OCC 2011-12, SR 11-7)
+[ ] Model Risk (OCC 2026-13 / Fed SR 26-2 — formerly OCC 2011-12 / SR 11-7)
 
 Required Controls: ____________________
 Compliance Officer Sign-Off: ____________________
@@ -228,4 +228,4 @@ For enhanced Copilot/AI reporting beyond native M365 Admin Center capabilities, 
 !!! note "Implementation Note"
     Organizations should verify that their implementation meets their specific regulatory obligations. This control supports compliance efforts but requires proper configuration and ongoing validation.
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/playbooks/advanced-implementations/agent-usage-workbook/customization-guide.md
+++ b/docs/playbooks/advanced-implementations/agent-usage-workbook/customization-guide.md
@@ -264,7 +264,7 @@ customEvents
 Extend the Q09 latency query with SLA threshold lines by adding a parameter-driven target:
 
 ```kql
-// OCC 2011-12: SLA compliance monitoring
+// OCC 2026-13 (formerly OCC 2011-12): SLA compliance monitoring
 let SLATargetMs = 5000;  // Adjust to your SLA target
 customEvents
 | where timestamp {TimeRange}

--- a/docs/playbooks/control-implementations/1.10/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.10/verification-testing.md
@@ -788,8 +788,8 @@ compliance with:
   • SEC Rule 17a-4 (records retention — paired with Control 1.12)
   • SEC Reg S-P / Reg S-ID (where customer information is detected)
   • GLBA 501(b) (safeguards for customer information)
-  • OCC 2011-12 / Federal Reserve SR 11-7 (model risk management ongoing
-    monitoring expectations as they apply to CC classifier coverage)
+  • OCC 2026-13 (formerly OCC 2011-12) / Federal Reserve SR 26-2 (formerly SR 11-7)
+    (model risk management ongoing monitoring expectations as they apply to CC classifier coverage)
   • SOX 404 (IT general controls over the supervisory pipeline)
 
 This attestation does not constitute a legal determination. Reportability

--- a/docs/playbooks/control-implementations/1.14/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.14/troubleshooting.md
@@ -577,7 +577,7 @@ REPORTABILITY DECISION (§1.2 result):
   Step 1 (NPI / Reg S-P):       <Y|N>  Decision-maker:  Date:
   Step 2 (FINRA 4530):          <Y|N>  Decision-maker:  Date:
   Step 3 (17a-4 books):         <Y|N>  Decision-maker:  Date:
-  Step 4 (OCC / SR 11-7):       <Y|N>  Decision-maker:  Date:
+  Step 4 (OCC 2026-13 / Fed SR 26-2 — formerly OCC 2011-12 / SR 11-7):       <Y|N>  Decision-maker:  Date:
   Step 5 (CFTC 1.31):           <Y|N>  Decision-maker:  Date:
   Step 6 (CCPA / state):        <Y|N>  Decision-maker:  Date:
 

--- a/docs/playbooks/control-implementations/1.21/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.21/verification-testing.md
@@ -1001,8 +1001,8 @@ Every test emits a single JSON file conforming to this schema. The shape is inte
     "SEC Reg S-P (2024)",
     "SOX 404",
     "GLBA 501(b)",
-    "OCC 2011-12",
-    "Fed SR 11-7",
+    "OCC 2026-13 (formerly OCC 2011-12)",
+    "Fed SR 26-2 (formerly SR 11-7)",
     "CFTC 1.31"
   ],
   "schemaVersion": "1.0",
@@ -1137,7 +1137,7 @@ function Write-EvidenceRecord {
         skipReason        = $SkipReason
         auditAssertion    = $AuditAssertion
         evidenceFiles     = $hashes
-        regulatoryDriver  = @('FINRA 4511','FINRA Reg Notice 25-07','SEC 17a-4(f)','SEC Reg S-P (2024)','SOX 404','GLBA 501(b)','OCC 2011-12','Fed SR 11-7','CFTC 1.31')
+        regulatoryDriver  = @('FINRA 4511','FINRA Reg Notice 25-07','SEC 17a-4(f)','SEC Reg S-P (2024)','SOX 404','GLBA 501(b)','OCC 2026-13 (formerly OCC 2011-12)','Fed SR 26-2 (formerly SR 11-7)','CFTC 1.31')
         schemaVersion     = '1.0'
     }
     $outFile = Join-Path $cycleDir "$TestId.json"
@@ -1326,7 +1326,7 @@ The cycle attestation is a single signed statement covering the cycle's results.
     "Microsoft.PowerApps.Administration.PowerShell": "2.0.180"
   },
   "regulatoryAttestation": {
-    "statement": "The cycle results above are intended to support compliance with FINRA 4511, FINRA Regulatory Notice 25-07, SEC 17a-4(f), SEC Reg S-P (2024), SOX 404, GLBA 501(b), OCC Bulletin 2011-12, Federal Reserve SR 11-7, and CFTC Regulation 1.31. They do not guarantee legal compliance. Tenant-specific regulatory applicability has been confirmed with qualified counsel.",
+    "statement": "The cycle results above are intended to support compliance with FINRA 4511, FINRA Regulatory Notice 25-07, SEC 17a-4(f), SEC Reg S-P (2024), SOX 404, GLBA 501(b), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), Federal Reserve SR 26-2 (formerly SR 11-7), and CFTC Regulation 1.31. They do not guarantee legal compliance. Tenant-specific regulatory applicability has been confirmed with qualified counsel.",
     "caveats": [
       "Microsoft does not publish a single guaranteed SLA for Unified Audit Log ingestion; operative latency for this cycle is the tenant-measured p99 captured in PRE-04 / UAL-04, not a vendor SLA.",
       "Azure AI Content Safety Prompt Shields is the Microsoft-supported jailbreak detection surface for Azure-AI-fronted agents; first-party Microsoft 365 Copilot uses internal controls that surface (where applicable) via Defender XDR.",

--- a/docs/playbooks/control-implementations/1.22/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.22/verification-testing.md
@@ -224,7 +224,7 @@ I attest that, for the period above:
 This attestation supports compliance with FINRA Rules 2241, 2242, 3110 (and
 Notice 25-07 for AI supervision), 5270, 5280; SEC Exchange Act §15(g);
 SEC Regulation Best Interest; SEC Regulation S-P; MSRB Rules G-23 and G-37;
-OCC 2011-12; and Fed SR 11-7. It does not, on its own, evidence compliance
+OCC 2026-13 (formerly OCC 2011-12); and Fed SR 26-2 (formerly SR 11-7). It does not, on its own, evidence compliance
 with any single regulation.
 
 **Compliance Officer Signature:** _______________________

--- a/docs/playbooks/control-implementations/1.29/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.29/powershell-setup.md
@@ -517,7 +517,7 @@ Files Included:
 Regulatory References:
   GLBA 501(b) — Safeguards Rule: system security controls
   FINRA 4511  — General requirements: system security records
-  OCC 2011-12 — Technology Risk Management
+  OCC 2026-13 (formerly OCC 2011-12) — Technology Risk Management
   SOX 302/404 — IT General Controls evidence
 
 Notes:

--- a/docs/playbooks/control-implementations/1.6/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.6/verification-testing.md
@@ -118,7 +118,7 @@ in this attestation supports — but does not by itself establish — the firm's
   • SEC 17a-4(f) / FINRA 4511 record-preservation expectations (paired with Audit Premium / Control 1.7)
   • SEC Reg S-P §248.30(a)(4) detection support for events that may trigger customer notification
   • GLBA 501(b) safeguards expectations for customer information processed by AI
-  • OCC 2011-12 / Fed SR 11-7 model risk management ongoing-monitoring expectations
+  • OCC 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly SR 11-7) model risk management ongoing-monitoring expectations
   • Interagency Guidance on Third-Party Relationships (OCC/FRB/FDIC) for ongoing monitoring of third-party AI
 
 This evidence does not constitute a legal determination. Reportability decisions remain with

--- a/docs/playbooks/control-implementations/1.7/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.7/verification-testing.md
@@ -934,7 +934,7 @@ Statements (sovereign / tamper / join):
 This attestation is intended to support — but does not by itself ensure — compliance with
 FINRA 4511, FINRA 3110, FINRA 25-07 (RFC), SEC 17a-3, SEC 17a-4 (including 17a-4(f)
 October 2022 amendments and 3 May 2023 compliance date), SOX 302/404, GLBA 501(b),
-OCC 2011-12, Federal Reserve SR 11-7, and CFTC 1.31. This attestation does not by itself
+OCC 2026-13 (formerly OCC 2011-12), Federal Reserve SR 26-2 (formerly SR 11-7), and CFTC 1.31. This attestation does not by itself
 constitute the 17a-4(f) attestation that the firm's electronic recordkeeping system is
 non-rewriteable / non-erasable; that attestation is the role of an independent third party
 (e.g., Cohasset Associates) and is referenced in this cycle's preservation evidence rather

--- a/docs/playbooks/control-implementations/1.8/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.8/verification-testing.md
@@ -666,7 +666,7 @@ For Zone 2 and Zone 3 agents this control requires content moderation **High**, 
 1. As **AI Governance Lead**, compile the prior 12 months of evidence: PSX-01..03 results, all 16 CM matrix tests, all DEF tests, WEB-01..04, ERR-01.
 2. Sample 5% of webhook ``block`` decisions and 5% of moderation blocks; review for false-positive impact on firm productivity.
 3. Sample 5% of allowed prompts that should have been blocked (escalations from end users).
-4. Produce a written validation memo per the firm's model-risk standard (aligned to [Fed SR 11-7](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) and [OCC 2011-12](https://www.occ.treas.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)).
+4. Produce a written validation memo per the firm's model-risk standard (aligned to [Fed SR 26-2 (formerly SR 11-7)](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm) and [OCC 2026-13 (formerly OCC 2011-12)](https://www.occ.treas.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)).
 
 **Pass criterion.** Validation memo signed by AI Governance Lead, Security Operations lead, and Compliance / Audit Admin.
 

--- a/docs/playbooks/control-implementations/2.11/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/2.11/portal-walkthrough.md
@@ -137,7 +137,7 @@ Capture the agent's scope decision in a one-page memo signed by the Compliance O
 ```yaml
 Agent: Retail Banking Account-Opening Assistant
 Zone: 3 (Enterprise — customer-facing, influences account-opening decisions)
-Regulatory Scope: ECOA / Reg B, FINRA 3110, SR 11-7, CFPB Circular 2023-03
+Regulatory Scope: ECOA / Reg B, FINRA 3110, Fed SR 26-2 (formerly SR 11-7), CFPB Circular 2023-03
 
 Protected Classes (in scope):
   - Race (5 categories per Census)
@@ -162,7 +162,7 @@ Metrics & Thresholds:
 Cadence:
   Pre-deployment:    Required (gate in release pipeline)
   Quarterly:         Q-end + 30 days
-  On material change: Re-validation under SR 11-7
+  On material change: Re-validation under Fed SR 26-2 (formerly SR 11-7)
 
 Evidence:
   Library: SharePoint > FSI-AIGov > Bias-Testing-Evidence

--- a/docs/playbooks/control-implementations/2.11/verification-testing.md
+++ b/docs/playbooks/control-implementations/2.11/verification-testing.md
@@ -184,7 +184,7 @@ I attest that, for the period indicated:
    All were tracked, [n_closed] closed with re-test evidence, [n_open] open within SLA.
 
 5. Material model changes during the period [were / were not] triggered;
-   if triggered, SR 11-7 re-validation [is / is not] complete.
+   if triggered, Fed SR 26-2 (formerly SR 11-7) re-validation [is / is not] complete.
 
 6. Evidence is retained in [SharePoint library URL] with Purview WORM retention
    label `[label name]` and SHA-256 integrity manifest.

--- a/docs/playbooks/control-implementations/2.13/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.13/powershell-setup.md
@@ -256,7 +256,7 @@ Ensure-SiteColumn -DisplayName 'Classification Date'-InternalName 'Classificatio
 
 # Extended columns (Zone 2+)
 Ensure-SiteColumn -DisplayName 'Regulatory Reference' -InternalName 'RegReference'    -Type Choice `
-    -Choices @('FINRA 4511','FINRA 3110','SEC 17a-3','SEC 17a-4','SOX 302','SOX 404','GLBA 501(b)','OCC 2011-12','Fed SR 11-7','CFTC 1.31')
+    -Choices @('FINRA 4511','FINRA 3110','SEC 17a-3','SEC 17a-4','SOX 302','SOX 404','GLBA 501(b)','OCC 2026-13 (formerly OCC 2011-12)','Fed SR 26-2 (formerly SR 11-7)','CFTC 1.31')
 Ensure-SiteColumn -DisplayName 'Retention Period'    -InternalName 'RetentionPeriod'  -Type Choice `
     -Choices @('3 years','5 years','6 years','7 years','10 years','Permanent')
 Ensure-SiteColumn -DisplayName 'Governance Zone'     -InternalName 'GovZone'          -Type Choice `
@@ -383,9 +383,9 @@ Ensure-RetentionLabel -Name 'FSI-Agent-CFTC-5Year' `
     -Regulatory $true `
     -ReviewerEmail $ReviewerStage2
 
-# Model risk documentation (6 years per OCC 2011-12 / Fed SR 11-7)
+# Model risk documentation (6 years per OCC 2026-13 / Fed SR 26-2 — formerly OCC 2011-12 / SR 11-7)
 Ensure-RetentionLabel -Name 'FSI-Agent-ModelRisk-6Year' `
-    -Comment 'OCC 2011-12 / Fed SR 11-7 model risk documentation. 6-year retention.' `
+    -Comment 'OCC 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly SR 11-7) model risk documentation. 6-year retention.' `
     -RetentionDurationDays 2190 `
     -RetentionAction KeepAndDelete `
     -IsRecordLabel $true `
@@ -463,7 +463,7 @@ $Zone3Labels = @(
 Ensure-RetentionPolicy -PolicyName 'FSI-AI-Governance-Retention-Zone3' `
     -LabelNames $Zone3Labels `
     -SharePointLocation $SiteUrl `
-    -Comment 'Zone 3 regulatory record labels per SEC 17a-4(f) / CFTC 1.31 / OCC 2011-12'
+    -Comment 'Zone 3 regulatory record labels per SEC 17a-4(f) / CFTC 1.31 / OCC 2026-13 (formerly OCC 2011-12)'
 ```
 
 !!! note "Propagation delay"
@@ -576,7 +576,7 @@ function Export-AgentDocumentation {
         Exports Copilot Studio agent metadata for governance documentation.
     .DESCRIPTION
         Retrieves agent metadata from Power Platform Admin Center and exports
-        to the evidence directory for record-keeping per FINRA 4511 / OCC 2011-12.
+        to the evidence directory for record-keeping per FINRA 4511 / OCC 2026-13 (formerly OCC 2011-12).
     .PARAMETER EnvironmentId
         The Power Platform environment ID containing the agents.
     .PARAMETER EvidenceRoot

--- a/docs/playbooks/control-implementations/2.24/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.24/powershell-setup.md
@@ -1133,7 +1133,7 @@ function Compare-Feat224ZoneCompliance {
             $findings.Add([pscustomobject]@{
                 Status      = 'Anomaly'
                 FeatureName = $name
-                Reason      = 'F15: feature enabled tenant-wide but no agent uses it (latent attack surface; SR 11-7 inventory expectation)'
+                Reason      = 'F15: feature enabled tenant-wide but no agent uses it (latent attack surface; Fed SR 26-2 (formerly SR 11-7) inventory expectation)'
             })
         }
     }

--- a/docs/playbooks/control-implementations/2.24/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.24/troubleshooting.md
@@ -36,7 +36,7 @@ Symptom reported
   ├─► Voice / image / multimodal feature enabled
   │   without comms-compliance recording path?        → §11 VOICE-IMAGE-GAP
   ├─► Feature change made without MRM change record
-  │   (SR 11-7) or without model re-validation?       → §12 MRM-CASCADE-BROKEN
+  │   (Fed SR 26-2 — formerly SR 11-7) or without model re-validation?       → §12 MRM-CASCADE-BROKEN
   └─► Supervisors unaware that a feature changed,
       WSP / supervision queue not updated?            → §13 SUPERVISOR-UNAWARE
 ```
@@ -963,7 +963,7 @@ An incident under this playbook may be closed only when **all** of the following
 <which §N pillar(s); upstream contributing factors; was this a recurrence>
 
 ## 3. Cascades engaged
-- [ ] Control 2.6 (MRM / SR 11-7) — record ID:
+- [ ] Control 2.6 (MRM / Fed SR 26-2 — formerly SR 11-7) — record ID:
 - [ ] Control 2.12 (Supervision / FINRA 3110) — WSP ref:
 - [ ] Control 1.4 (ACP) — policy IDs touched:
 - [ ] Control 1.10 (CC) — policy IDs touched:
@@ -986,7 +986,7 @@ An incident under this playbook may be closed only when **all** of the following
 
 ## 7. Hedged-language confirmation
 This attestation **supports** examiner response and post-incident review. It does not substitute for:
-- the SR 11-7 model-risk record (Control 2.6),
+- the Fed SR 26-2 (formerly SR 11-7) model-risk record (Control 2.6),
 - the FINRA Rule 3110 written supervisory procedure update (Control 2.12),
 - or the AI guardrail framework (Control 1.1).
 

--- a/docs/playbooks/control-implementations/2.26/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.26/powershell-setup.md
@@ -1549,7 +1549,7 @@ function New-Agt226AttestationPack {
         regulatory_anchors  = @(
             'FINRA 4511 (6-year recordkeeping)',
             'SEC 17a-4 (records preservation)',
-            'OCC 2013-29 / SR 11-7 (model risk)',
+            'OCC 2013-29 / Fed SR 26-2 (formerly SR 11-7) (model risk)',
             'GLBA Safeguards Rule (access review)'
         )
         generated_at        = (Get-Date).ToUniversalTime()

--- a/docs/playbooks/control-implementations/2.6/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.6/powershell-setup.md
@@ -841,7 +841,7 @@ $dispositionLog = $feed.Findings | Where-Object Status -in @('Anomaly','Pending'
         @{n='DispositionDecision';e={''}},
         @{n='DecisionDateUtc';e={''}}
 
-$dispositionLog | Export-Csv -Path '.\sr11-7-vendor-model-disposition.csv' -NoTypeInformation
+$dispositionLog | Export-Csv -Path '.\sr26-2-vendor-model-disposition.csv' -NoTypeInformation
 # DispositionDecision and DecisionDateUtc are filled in by the MRM Committee,
 # NOT by this script. The script produces the queue; people produce the decisions.
 ```

--- a/docs/playbooks/control-implementations/3.3/powershell-setup.md
+++ b/docs/playbooks/control-implementations/3.3/powershell-setup.md
@@ -226,7 +226,7 @@ function New-ExaminationManifest {
             '02-Technology-Risk-Controls.pdf'    = 'IT control documentation'
             '03-Business-Continuity-Plans.pdf'   = 'BCP documentation'
             '04-Change-Management-Evidence.xlsx' = 'Change control records'
-            '05-Model-Risk-Validation.pdf'       = 'OCC 2011-12 / Fed SR 11-7 model validation evidence'
+            '05-Model-Risk-Validation.pdf'       = 'OCC 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly SR 11-7) model validation evidence'
         }
         'State' = @{
             '01-State-AI-Law-Mapping.pdf' = 'Mapping of state AI laws (e.g., NYDFS, CO SB205)'

--- a/docs/playbooks/control-implementations/3.6/verification-testing.md
+++ b/docs/playbooks/control-implementations/3.6/verification-testing.md
@@ -1577,7 +1577,7 @@ The quarterly attestation is the pack's cover document. It restates the hedged l
 
 ## Statement
 
-This attestation supports compliance with FINRA 3110, 4511, and Notice 25-07, SEC Rules 17a-3 / 17a-4, SOX 302 / 404, GLBA §501(b), OCC Bulletin 2011-12, Fed SR 11-7, CFTC 1.31, and NYDFS Part 500. A clean attestation **does not guarantee** compliance, **does not replace** the firm's written supervisory procedures, and **supports — does not replace — registered-principal supervisory review under FINRA Rule 3110**.
+This attestation supports compliance with FINRA 3110, 4511, and Notice 25-07, SEC Rules 17a-3 / 17a-4, SOX 302 / 404, GLBA §501(b), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), Fed SR 26-2 (formerly SR 11-7), CFTC 1.31, and NYDFS Part 500. A clean attestation **does not guarantee** compliance, **does not replace** the firm's written supervisory procedures, and **supports — does not replace — registered-principal supervisory review under FINRA Rule 3110**.
 
 ## Namespace Summary
 

--- a/docs/playbooks/control-implementations/4.6/troubleshooting.md
+++ b/docs/playbooks/control-implementations/4.6/troubleshooting.md
@@ -625,7 +625,7 @@ Subject: Microsoft 365 Copilot grounding-scope event — [date]
    - GLBA 501(b) / SEC Reg S-P §248.30(a)(4): [if customer NPI in scope; 30-day customer-notification timeline]
    - SOX §302 / §404 ICFR: [if financial-disclosure-adjacent]
    - NY DFS 23 NYCRR 500 §500.17(a) 72-hour cybersecurity-event clock: [pending Legal | not applicable | clock running since UTC X]
-   - OCC 2011-12 / Fed SR 11-7 model risk: [if the agent surface itself produced a model-risk-adjacent failure]
+   - OCC 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly SR 11-7) model risk: [if the agent surface itself produced a model-risk-adjacent failure]
    - CFTC Rule 1.31: [if covered swap / trading content]
    - FINRA Rule 4530: [if firm misconduct in scope]
 

--- a/docs/playbooks/control-implementations/4.6/verification-testing.md
+++ b/docs/playbooks/control-implementations/4.6/verification-testing.md
@@ -815,7 +815,7 @@ Regulatory drivers attested against this cycle:
   - SEC Rule 17a-3 / 17a-4 / 17a-4(b) (record retention; WORM)
   - SOX 302 / 404 (internal control over financial reporting)
   - GLBA 501(b) (safeguards)
-  - OCC 2011-12 / Federal Reserve SR 11-7 (model risk management)
+  - OCC 2026-13 (formerly OCC 2011-12) / Federal Reserve SR 26-2 (formerly SR 11-7) (model risk management)
   - NYDFS 23 NYCRR 500 (Parts 500.6 audit trail; 500.11 third-party; 500.16 incident response)
 
 Caveats (this attestation is bounded by):

--- a/docs/playbooks/control-implementations/4.7/troubleshooting.md
+++ b/docs/playbooks/control-implementations/4.7/troubleshooting.md
@@ -765,7 +765,7 @@ Reportability tree (initial assessment):
   Q3 (NYDFS 72hr): YES/NO/UNKNOWN
   Q4 (FINRA 4530): YES/NO/UNKNOWN
   Q5 (FTC Safeguards): YES/NO/UNKNOWN
-  Q6 (SR 11-7): YES/NO/UNKNOWN
+  Q6 (Fed SR 26-2 — formerly SR 11-7): YES/NO/UNKNOWN
   Q7 (state privacy): YES/NO/UNKNOWN
 
 Compensating controls applied: <list>


### PR DESCRIPTION
## Summary
Closes U-002 (P3) and U-009 (P2). Verification sweep on 2026-05-18 called out 3 known files, and a wider `docs/**/*.md` sweep found additional standalone OCC/SR references across controls and playbooks. The current tree does not contain `docs/javascripts/assessment-data.json`, so this PR closes the remaining shipped docs surfaces that still emitted the rescinded codes without `(formerly ...)` wrappers.

## Pattern applied
- `OCC Bulletin 2011-12` → `OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12)`
- `OCC 2011-12` → `OCC 2026-13 (formerly OCC 2011-12)`
- `SR 11-7` → `Fed SR 26-2 (formerly SR 11-7)`
- `Federal Reserve SR 11-7` → `Federal Reserve SR 26-2 (formerly SR 11-7)`

## Validation
- JSON parse check on `docs/javascripts/assessment-data.json` skipped because the file is not present in the current tree
- `python scripts/verify_language_rules.py` ✅
- `python scripts/verify_controls.py` ✅
- `python scripts/check_manifest_doc_drift.py --check` ✅
- `python scripts/verify_xref_graph.py` ✅
- `mkdocs build --strict` ✅
- Wider grep re-run: zero unwrapped occurrences remain

Closes findings U-002, U-009.