### PR TITLE
docs(framework): rewrite v1.5.0 current-state claims as historical (closes PD-004)

### DIFF
--- a/docs/framework/governance-fundamentals.md
+++ b/docs/framework/governance-fundamentals.md
@@ -125,7 +125,7 @@ The framework organizes 78 controls across four pillars:
 
 The framework's 78 controls describe *what to implement and how to verify it*. [Capability Drivers](../reference/glossary.md) describe *whether your organization is capable of implementing and operating it at scale*.
 
-Microsoft's Copilot Acceleration Engineering (CAPE) materials introduced five **Capability Drivers** as organizational readiness dimensions whose collective maturity determines an enterprise's capacity to deploy AI agents sustainably. FSI-AgentGov v1.5.0 adopts Capability Drivers as a first-class framework concept, complementing — not replacing — the control-by-control governance lens. The five drivers are:
+Microsoft's Copilot Acceleration Engineering (CAPE) materials introduced five **Capability Drivers** as organizational readiness dimensions whose collective maturity determines an enterprise's capacity to deploy AI agents sustainably. FSI-AgentGov adopted Capability Drivers as a first-class framework concept in v1.5.0 (current at v1.6.2), complementing — not replacing — the control-by-control governance lens. The five drivers are:
 
 | Capability Driver | What It Measures |
 |-------------------|------------------|

--- a/docs/framework/operating-model.md
+++ b/docs/framework/operating-model.md
@@ -446,7 +446,7 @@ This document defines the organizational structure, roles, and accountability fo
 
 ## Agentic Center of Excellence
 
-The operating model defined above — roles, RACI, and decision rights — is the canonical FSI governance structure for this framework. FSI-AgentGov v1.5.0 introduces a **Center of Excellence (CoE) blueprint** specifically for AI agent governance, adapted from Microsoft's Frontier CoE materials with FSI guardrails. The CoE blueprint complements the FSI operating model: it is a specialized operational structure for the AI program, not a replacement for the firm's overall governance architecture. The RACI assignments and role accountabilities above remain load-bearing for examiner workpapers (FFIEC IT examination, FINRA WSP supervisory documentation). The CoE blueprint adds a vocabulary for *organizing the work* above the RACI spine.
+The operating model defined above — roles, RACI, and decision rights — is the canonical FSI governance structure for this framework. FSI-AgentGov introduced a **Center of Excellence (CoE) blueprint** in v1.5.0 (current at v1.6.2), specifically for AI agent governance, adapted from Microsoft's Frontier CoE materials with FSI guardrails. The CoE blueprint complements the FSI operating model: it is a specialized operational structure for the AI program, not a replacement for the firm's overall governance architecture. The RACI assignments and role accountabilities above remain load-bearing for examiner workpapers (FFIEC IT examination, FINRA WSP supervisory documentation). The CoE blueprint adds a vocabulary for *organizing the work* above the RACI spine.
 
 ### Four CoE Functions and Three Shapes
 

--- a/docs/framework/regulatory-framework.md
+++ b/docs/framework/regulatory-framework.md
@@ -492,7 +492,7 @@ Organizations should conduct separate analysis for state-specific requirements.
 
 ## Microsoft CAPE alignment cross-reference
 
-FSI-AgentGov v1.5.0 includes a Microsoft CAPE alignment layer that maps Microsoft's six Frontier Transformation Patterns onto FSI zones, controls, and regulatory exposure. This alignment does not modify the underlying 78-control framework, which remains the definitive governance structure for US financial services AI deployments. CAPE is a Microsoft business-strategy framework designed to accelerate enterprise AI transformation, not a regulatory framework. Any deployment using CAPE Patterns 4–6 sits inside the FSI regulatory perimeter and triggers the same regulatory obligations as any other AI deployment subject to FINRA, SEC, OCC, Fed, GLBA, SOX, and state regulatory oversight.
+FSI-AgentGov has included a Microsoft CAPE alignment layer since v1.5.0 (current at v1.6.2) that maps Microsoft's six Frontier Transformation Patterns onto FSI zones, controls, and regulatory exposure. This alignment does not modify the underlying 78-control framework, which remains the definitive governance structure for US financial services AI deployments. CAPE is a Microsoft business-strategy framework designed to accelerate enterprise AI transformation, not a regulatory framework. Any deployment using CAPE Patterns 4–6 sits inside the FSI regulatory perimeter and triggers the same regulatory obligations as any other AI deployment subject to FINRA, SEC, OCC, Fed, GLBA, SOX, and state regulatory oversight.
 
 The [Microsoft CAPE crosswalk](../reference/microsoft-cape-crosswalk.md) provides the canonical mapping between CAPE vocabulary and FSI governance requirements. For each CAPE pattern, the crosswalk identifies:
 

--- a/docs/version.json
+++ b/docs/version.json
@@ -1,5 +1,5 @@
 {
   "version": "1.6.2",
-  "sha": "b56b9a2cbbf4aab1b8a0bd2191d4bcd484256493",
-  "builtAt": "2026-05-17T05:38:07Z"
+  "sha": "dc3d4d64c220808b1ec8572e76a6ed4ec0168b61",
+  "builtAt": "2026-05-18T18:02:57Z"
 }


### PR DESCRIPTION
## Summary
Closes PD-004 (P2). 3 framework body-text claims of "FSI-AgentGov v1.5.0 introduces X" rewritten so they don't imply v1.5.0 is the current release (current is v1.6.2).

## Changes per file

All three lines used **Option 1** (preserve historical context with a "current at v1.6.2" qualifier), because the surrounding paragraphs explicitly position the feature as a CAPE/Frontier adaptation introduced into the framework — dropping the version reference entirely would lose useful provenance for customers tracking when capabilities arrived.

- `docs/framework/governance-fundamentals.md:128` — **Option 1**
  - Before: `FSI-AgentGov v1.5.0 adopts Capability Drivers as a first-class framework concept, complementing — not replacing — the control-by-control governance lens.`
  - After: `FSI-AgentGov adopted Capability Drivers as a first-class framework concept in v1.5.0 (current at v1.6.2), complementing — not replacing — the control-by-control governance lens.`

- `docs/framework/operating-model.md:449` — **Option 1**
  - Before: `FSI-AgentGov v1.5.0 introduces a **Center of Excellence (CoE) blueprint** specifically for AI agent governance, adapted from Microsoft's Frontier CoE materials with FSI guardrails.`
  - After: `FSI-AgentGov introduced a **Center of Excellence (CoE) blueprint** in v1.5.0 (current at v1.6.2), specifically for AI agent governance, adapted from Microsoft's Frontier CoE materials with FSI guardrails.`

- `docs/framework/regulatory-framework.md:495` — **Option 1**
  - Before: `FSI-AgentGov v1.5.0 includes a Microsoft CAPE alignment layer that maps Microsoft's six Frontier Transformation Patterns onto FSI zones, controls, and regulatory exposure.`
  - After: `FSI-AgentGov has included a Microsoft CAPE alignment layer since v1.5.0 (current at v1.6.2) that maps Microsoft's six Frontier Transformation Patterns onto FSI zones, controls, and regulatory exposure.`

## Validation
- `python scripts/verify_language_rules.py` ✅
- `python scripts/verify_controls.py` ✅
- `python scripts/verify_xref_graph.py` ✅
- `mkdocs build --strict` ✅

## Notes
- Footers on these 3 files intentionally untouched — that's PD-001/002/003/006's scope.
- `docs/version.json` updated automatically by the local mkdocs build hook (SHA + builtAt timestamp only; version remains 1.6.2).

Closes PD-004.
