### PR TITLE
fix(assessment): close TODO placeholder leakage from manifest to SPA (closes U-022)

### DIFF
--- a/assessment/tests/test_copy_assessment_data_hook.py
+++ b/assessment/tests/test_copy_assessment_data_hook.py
@@ -1,0 +1,127 @@
+"""Tests for ``scripts/hooks/copy_assessment_data.py``.
+
+The mkdocs hook publishes the manifest to ``site/assessment/data/controls.json``.
+Manifest ``TODO:`` authoring placeholders must be stripped before the file
+reaches the customer-facing SPA (finding U-022).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK_PATH = REPO_ROOT / "scripts" / "hooks" / "copy_assessment_data.py"
+MANIFEST_PATH = REPO_ROOT / "assessment" / "manifest" / "controls.json"
+
+
+def _load_hook_module():
+    spec = importlib.util.spec_from_file_location("copy_assessment_data_hook", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def hook():
+    return _load_hook_module()
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_scrub_drops_todo_priority(hook):
+    controls = [
+        {
+            "id": "X.1",
+            "priority": "TODO: critical|high|medium|low",
+            "yesBar": "TODO: concise pass criteria",
+            "partialBar": "TODO: partial coverage criteria",
+            "noBar": "TODO: fail criteria",
+            "facilitatorNotes": {
+                "ask": "TODO: facilitator question",
+                "followUp": "TODO: follow-up hint",
+                "timeBudgetMinutes": 5,
+            },
+        }
+    ]
+    cleaned, count = hook.scrub_manifest_todos(controls)
+    assert count == 6
+    c = cleaned[0]
+    assert "priority" not in c
+    assert c["yesBar"] == ""
+    assert c["partialBar"] == ""
+    assert c["noBar"] == ""
+    assert c["facilitatorNotes"]["ask"] == ""
+    assert c["facilitatorNotes"]["followUp"] == ""
+    # timeBudgetMinutes is structural, not a placeholder.
+    assert c["facilitatorNotes"]["timeBudgetMinutes"] == 5
+
+
+def test_scrub_preserves_authored_values(hook):
+    controls = [
+        {
+            "id": "1.1",
+            "priority": "critical",
+            "yesBar": "Environment Maker role removed from All Users.",
+            "partialBar": "Publisher group exists but Environment Maker still open.",
+            "noBar": "Environment Maker is open to All Users.",
+            "facilitatorNotes": {
+                "ask": "Is publishing restricted to a named publisher group?",
+                "followUp": "Open Power Platform admin center > Environments.",
+                "timeBudgetMinutes": 6,
+            },
+        }
+    ]
+    cleaned, count = hook.scrub_manifest_todos(controls)
+    assert count == 0
+    c = cleaned[0]
+    assert c["priority"] == "critical"
+    assert c["yesBar"].startswith("Environment Maker")
+    assert c["facilitatorNotes"]["ask"].startswith("Is publishing")
+
+
+def test_scrub_does_not_mutate_input(hook):
+    original = {
+        "id": "X.1",
+        "priority": "TODO: critical",
+        "facilitatorNotes": {"ask": "TODO: q", "followUp": "TODO: f", "timeBudgetMinutes": 5},
+    }
+    snapshot = json.loads(json.dumps(original))
+    hook.scrub_manifest_todos([original])
+    assert original == snapshot
+
+
+def test_scrub_handles_missing_facilitator_notes(hook):
+    controls = [{"id": "X.1", "priority": "high"}]
+    cleaned, count = hook.scrub_manifest_todos(controls)
+    assert count == 0
+    assert cleaned[0] == {"id": "X.1", "priority": "high"}
+
+
+def test_real_manifest_produces_zero_todo_leakage(hook, manifest):
+    """Whatever TODOs exist in the committed manifest, none survive scrubbing."""
+    cleaned, _ = hook.scrub_manifest_todos(manifest)
+    serialized = json.dumps(cleaned)
+    # No literal "TODO:" substring should survive in the published payload.
+    assert "TODO:" not in serialized, "TODO placeholder leaked through scrubber"
+    # And the scrubbed payload is still a list of 78 controls.
+    assert len(cleaned) == 78
+
+
+def test_write_manifest_scrubbed_emits_clean_file(hook, tmp_path):
+    dest = tmp_path / "assessment" / "data" / "controls.json"
+    scrubbed_count = hook._write_manifest_scrubbed(dest)
+    assert dest.exists()
+    payload = dest.read_text(encoding="utf-8")
+    assert "TODO:" not in payload, "published manifest still contains TODO placeholders"
+    parsed = json.loads(payload)
+    assert isinstance(parsed, list)
+    assert len(parsed) == 78
+    # The scrubbed count is non-negative and bounded by 6 fields × 78 controls.
+    assert 0 <= scrubbed_count <= 6 * 78

--- a/docs/javascripts/assessment-app.js
+++ b/docs/javascripts/assessment-app.js
@@ -713,11 +713,43 @@
   };
 
   /**
+   * Strip TODO authoring placeholders from a manifest string field. Returns ""
+   * for unauthored values so downstream UI guards (e.g. `if (ctrl.yesBar)`)
+   * skip rendering rather than leaking the literal "TODO: ..." text to the
+   * customer-facing surface. See finding U-022.
+   */
+  function _scrubManifestTodo(s) {
+    if (typeof s !== "string") return "";
+    var trimmed = s.trim();
+    if (!trimmed) return "";
+    if (trimmed.indexOf("TODO:") === 0) return "";
+    return s;
+  }
+
+  /**
+   * Scrub TODO placeholders from a facilitatorNotes object. Returns a new
+   * object with the same shape, replacing TODO-valued `ask` / `followUp`
+   * strings with "". `timeBudgetMinutes` is preserved verbatim.
+   */
+  function _scrubFacilitatorNotes(fn) {
+    if (!fn || typeof fn !== "object") return {};
+    var out = {};
+    for (var k in fn) {
+      if (!Object.prototype.hasOwnProperty.call(fn, k)) continue;
+      var v = fn[k];
+      out[k] = (typeof v === "string") ? _scrubManifestTodo(v) : v;
+    }
+    return out;
+  }
+
+  /**
    * Merge v1.4 manifest fields (yesBar/partialBar/noBar/sectorYesBar/verifyIn/
    * verifyPowerShell/evidenceExpected/controlDocUrl/portalPlaybookUrl/solutions/
    * facilitatorNotes/zonesApplicable) onto the legacy control objects loaded
-   * from assessment-data.json. Existing fields are preserved when the manifest
-   * value is missing or a TODO placeholder.
+   * from assessment-data.json. TODO: placeholder values in priority, yesBar,
+   * partialBar, noBar, and facilitatorNotes.ask/followUp are scrubbed to ""
+   * here so they never reach the SPA drawer or agenda exports (finding U-022).
+   * The manifest itself retains the TODO markers as an authoring backlog.
    */
   AssessmentApp.prototype.mergeManifestIntoControls = function () {
     if (!this.data || !Array.isArray(this.data.controls)) return;
@@ -727,17 +759,23 @@
     this.data.controls.forEach(function (c) {
       var m = byId[c.id];
       if (!m) return;
-      // Manifest is authoritative for these new fields.
-      c.yesBar = m.yesBar || "";
-      c.partialBar = m.partialBar || "";
-      c.noBar = m.noBar || "";
+      // Manifest is authoritative for these new fields. TODO placeholders are
+      // scrubbed to empty strings — the SPA already guards on truthy values.
+      c.yesBar = _scrubManifestTodo(m.yesBar);
+      c.partialBar = _scrubManifestTodo(m.partialBar);
+      c.noBar = _scrubManifestTodo(m.noBar);
       c.sectorYesBar = m.sectorYesBar || {};
       c.verifyIn = Array.isArray(m.verifyIn) ? m.verifyIn : [];
       c.verifyPowerShell = m.verifyPowerShell || "";
       c.evidenceExpected = Array.isArray(m.evidenceExpected) ? m.evidenceExpected : [];
       c.controlDocUrl = withBasePath(m.controlDocUrl || "");
       c.portalPlaybookUrl = withBasePath(m.portalPlaybookUrl || "");
-      c.facilitatorNotes = m.facilitatorNotes || {};
+      c.facilitatorNotes = _scrubFacilitatorNotes(m.facilitatorNotes);
+      // priority — surface only authored values so badges/sorts skip placeholders.
+      if (typeof m.priority === "string") {
+        var pri = _scrubManifestTodo(m.priority);
+        if (pri) c.manifestPriority = pri;
+      }
       c.zonesApplicable = Array.isArray(m.zonesApplicable) && m.zonesApplicable.length
         ? m.zonesApplicable.slice() : (c.zones || [1, 2, 3]);
       // Prefer manifest solutions IDs (v1.4 source of truth) when non-empty.

--- a/scripts/hooks/copy_assessment_data.py
+++ b/scripts/hooks/copy_assessment_data.py
@@ -9,6 +9,18 @@ This is the v1.4 plumbing that lets the SPA fetch the manifest at
 runtime as a static asset (``/assessment/data/controls.json``), keeping
 the engine and the SPA bound to a single source of truth.
 
+Authoring-placeholder gating (finding U-022)
+---------------------------------------------
+The manifest intentionally carries ``TODO:`` placeholders in
+``priority`` / ``yesBar`` / ``partialBar`` / ``noBar`` and in
+``facilitatorNotes.{ask,followUp}`` for controls whose facilitator
+content has not yet been authored. We strip those placeholders out of
+the **published** manifest copy so they cannot leak into the
+customer-facing SPA drawer, agenda exports, or any other consumer of
+``/assessment/data/controls.json``. The source manifest under
+``assessment/manifest/`` is left untouched and continues to serve as
+the authoring backlog.
+
 Wire-up in ``mkdocs.yml``::
 
     hooks:
@@ -16,6 +28,7 @@ Wire-up in ``mkdocs.yml``::
 """
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 from pathlib import Path
@@ -23,17 +36,92 @@ from pathlib import Path
 log = logging.getLogger("mkdocs.copy_assessment_data")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_SRC = REPO_ROOT / "assessment" / "manifest" / "controls.json"
+MANIFEST_REL = "assessment/data/controls.json"
 SOURCES = {
-    REPO_ROOT / "assessment" / "manifest" / "controls.json": "assessment/data/controls.json",
     REPO_ROOT / "assessment" / "data" / "solutions-lock.json": "assessment/data/solutions-lock.json",
     REPO_ROOT / "assessment" / "data" / "README.md": "assessment/data/README.md",
 }
+
+# Manifest fields whose TODO placeholders must NOT reach the SPA. Keep this
+# list aligned with `assessment-app.js::mergeManifestIntoControls`.
+_SCRUB_STRING_FIELDS = ("priority", "yesBar", "partialBar", "noBar")
+_SCRUB_FACILITATOR_FIELDS = ("ask", "followUp")
+
+
+def _is_todo(value: object) -> bool:
+    return isinstance(value, str) and value.strip().startswith("TODO:")
+
+
+def scrub_manifest_todos(controls: list[dict]) -> tuple[list[dict], int]:
+    """Return (scrubbed_controls, count_of_fields_scrubbed).
+
+    ``priority`` is dropped when it is a TODO so downstream consumers see a
+    missing key rather than a placeholder value. The string content fields
+    (``yesBar`` / ``partialBar`` / ``noBar``) are replaced with empty strings
+    so SPA truthy guards (``if (ctrl.yesBar)``) skip rendering. Facilitator
+    notes ``ask`` / ``followUp`` get the same empty-string treatment.
+
+    The source list is not mutated.
+    """
+    scrubbed = 0
+    cleaned: list[dict] = []
+    for ctrl in controls:
+        c = dict(ctrl)  # shallow copy is enough — we only rewrite top-level fields
+        for field in _SCRUB_STRING_FIELDS:
+            v = c.get(field)
+            if _is_todo(v):
+                scrubbed += 1
+                if field == "priority":
+                    c.pop(field, None)
+                else:
+                    c[field] = ""
+        fn = c.get("facilitatorNotes")
+        if isinstance(fn, dict):
+            new_fn = dict(fn)
+            for sub in _SCRUB_FACILITATOR_FIELDS:
+                if _is_todo(new_fn.get(sub)):
+                    scrubbed += 1
+                    new_fn[sub] = ""
+            c["facilitatorNotes"] = new_fn
+        cleaned.append(c)
+    return cleaned, scrubbed
+
+
+def _write_manifest_scrubbed(dest: Path) -> int:
+    """Write the manifest to ``dest`` with TODO placeholders stripped.
+
+    Returns the number of TODO fields that were scrubbed.
+    """
+    if not MANIFEST_SRC.exists():
+        log.warning("copy_assessment_data: manifest source missing: %s", MANIFEST_SRC)
+        return 0
+    controls = json.loads(MANIFEST_SRC.read_text(encoding="utf-8"))
+    if not isinstance(controls, list):
+        log.error("copy_assessment_data: manifest is not a list; copying verbatim")
+        shutil.copyfile(MANIFEST_SRC, dest)
+        return 0
+    cleaned, scrubbed = scrub_manifest_todos(controls)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(cleaned, indent=2) + "\n", encoding="utf-8")
+    return scrubbed
 
 
 def on_post_build(config, **_kwargs):
     """Copy assessment data assets into the built site after MkDocs finishes."""
     site_dir = Path(config["site_dir"])
     copied = 0
+
+    # Scrub-and-copy the manifest separately so we never publish TODO leakage.
+    manifest_dest = site_dir / MANIFEST_REL
+    scrubbed = _write_manifest_scrubbed(manifest_dest)
+    if manifest_dest.exists():
+        copied += 1
+        log.info(
+            "copy_assessment_data: published manifest with %d TODO field(s) scrubbed",
+            scrubbed,
+        )
+
     for src, rel in SOURCES.items():
         if not src.exists():
             log.warning("copy_assessment_data: source missing: %s", src)

--- a/tests/spa/manifest-todo-scrub.test.mjs
+++ b/tests/spa/manifest-todo-scrub.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * U-022 regression — manifest TODO placeholders must not leak into the
+ * customer-facing SPA after mergeManifestIntoControls().
+ *
+ * The manifest at assessment/manifest/controls.json carries "TODO:"
+ * authoring placeholders in priority / yesBar / partialBar / noBar and in
+ * facilitatorNotes.{ask,followUp} for controls whose facilitator content
+ * has not yet been authored. The SPA must scrub those placeholders at
+ * merge time so the drawer, agenda exports, and any other consumer never
+ * render the literal "TODO:" text to customers.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { bootApp } from "./_bootSpa.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = join(here, "..", "..", "assessment", "manifest", "controls.json");
+
+function isTodo(value) {
+  return typeof value === "string" && value.trim().startsWith("TODO:");
+}
+
+describe("U-022 — manifest TODO placeholders are scrubbed before reaching the SPA", () => {
+  it("source manifest still carries TODO placeholders (authoring backlog intact)", () => {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    const anyTodo = manifest.some(
+      (c) =>
+        isTodo(c.priority) ||
+        isTodo(c.yesBar) ||
+        isTodo(c.partialBar) ||
+        isTodo(c.noBar) ||
+        (c.facilitatorNotes && (isTodo(c.facilitatorNotes.ask) || isTodo(c.facilitatorNotes.followUp)))
+    );
+    // If this assertion ever flips to false it means the authoring backlog
+    // has been fully drained — at that point this whole spec can be retired.
+    expect(anyTodo).toBe(true);
+  });
+
+  it("merged controls expose no TODO text in yesBar/partialBar/noBar", async () => {
+    const { app } = await bootApp({});
+    expect(Array.isArray(app.data.controls)).toBe(true);
+    for (const c of app.data.controls) {
+      expect(isTodo(c.yesBar), `yesBar leaked TODO for ${c.id}: ${c.yesBar}`).toBe(false);
+      expect(isTodo(c.partialBar), `partialBar leaked TODO for ${c.id}: ${c.partialBar}`).toBe(false);
+      expect(isTodo(c.noBar), `noBar leaked TODO for ${c.id}: ${c.noBar}`).toBe(false);
+    }
+  });
+
+  it("merged controls expose no TODO text in facilitatorNotes.ask / followUp", async () => {
+    const { app } = await bootApp({});
+    for (const c of app.data.controls) {
+      const fn = c.facilitatorNotes || {};
+      expect(isTodo(fn.ask), `facilitatorNotes.ask leaked TODO for ${c.id}: ${fn.ask}`).toBe(false);
+      expect(isTodo(fn.followUp), `facilitatorNotes.followUp leaked TODO for ${c.id}: ${fn.followUp}`).toBe(false);
+    }
+  });
+
+  it("merged controls never expose a TODO priority", async () => {
+    const { app } = await bootApp({});
+    for (const c of app.data.controls) {
+      expect(isTodo(c.manifestPriority), `manifestPriority leaked TODO for ${c.id}`).toBe(false);
+      // Authored priorities (when present) must match the documented vocabulary.
+      if (typeof c.manifestPriority === "string" && c.manifestPriority) {
+        expect(["critical", "high", "medium", "low"]).toContain(c.manifestPriority);
+      }
+    }
+  });
+
+  it("unauthored bar fields collapse to empty strings (SPA truthy guards skip them)", async () => {
+    const { app, manifest } = await bootApp({});
+    const todoByIdField = new Map();
+    for (const m of manifest) {
+      todoByIdField.set(m.id, {
+        yesBar: isTodo(m.yesBar),
+        partialBar: isTodo(m.partialBar),
+        noBar: isTodo(m.noBar),
+      });
+    }
+    for (const c of app.data.controls) {
+      const flags = todoByIdField.get(c.id) || {};
+      if (flags.yesBar) expect(c.yesBar).toBe("");
+      if (flags.partialBar) expect(c.partialBar).toBe("");
+      if (flags.noBar) expect(c.noBar).toBe("");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes finding **U-022** (P1): `assessment/manifest/controls.json` ships `TODO:` placeholders for facilitator-question fields (`priority`, `yesBar`, `partialBar`, `noBar`, `ask`, `followUp`). The manifest is published as `site/assessment/data/controls.json` and merged at runtime into the customer-facing assessment SPA — so without gating, customers see literal strings like `"TODO: concise pass criteria"` in the drawer.

## Decision: Option B — gate TODO fields out of shipped artifacts

**Investigation findings:**

| Question | Answer |
|---|---|
| TODO occurrences in source manifest | **318** across 53 of 78 controls |
| Controls with at least one TODO field | 53 (1.9, 1.15–1.16, 1.18–1.20, 1.22–1.29, 2.3, 2.5, 2.7–2.11, 2.13–2.16, 2.18–2.23, 2.25–2.26, 3.1–3.3, 3.5–3.8, 3.10–3.12, 3.14, 4.1–4.9) |
| TODOs in `docs/javascripts/assessment-data.json` (markdown-derived) | 0 — already clean |
| TODOs leaking into `site/assessment/data/controls.json` before fix | 318 |
| TODOs after fix | **0** |
| SPA TODO-skip patterns already present | 3 (`sectorYesBar` at L845; `facilitatorNotes.ask/followUp` at L2898/2901; `_agendaSkipTodo` at L4378) |
| SPA TODO-skip patterns **missing** before this PR | drawer rendering of `yesBar` / `partialBar` / `noBar` at L825–836 (the leak) |

**Why not Option A (author real content):** 53 controls × 4–6 fields each = ~200–300 specific value insertions that include "concise pass criteria" and "facilitator question" content. Writing those autonomously risks inventing FSI-facilitation criteria that could mislead customers or undermine trust with examiners. Real authoring belongs with the SME / Microsoft researcher track.

**Why not Option C (hybrid):** Even Pillar 4 (SharePoint) — the most tractable subset — would benefit from external review. Compromising both directions seemed worse than cleanly gating now and authoring later.

**Why Option B:** Aligns with three existing TODO-skip patterns already in the codebase. The manifest validator already supports `--allow-todo` mode, formally recognizing TODOs as a deliberate authoring backlog. SPA truthy guards on these fields already exist; we just need to convert TODOs to empty strings at one merge point.

## Changes

| File | Change |
|---|---|
| `docs/javascripts/assessment-app.js` | Centralized TODO scrubbing in `mergeManifestIntoControls` via new `_scrubManifestTodo` and `_scrubFacilitatorNotes` helpers. `yesBar`/`partialBar`/`noBar` TODOs collapse to `""`; `facilitatorNotes.ask/followUp` likewise; `priority` TODOs aren't surfaced as `manifestPriority`. |
| `scripts/hooks/copy_assessment_data.py` | Defense-in-depth: the mkdocs `on_post_build` hook now scrubs TODO placeholders during the copy. Logs `"published manifest with N TODO field(s) scrubbed"` so the gating is observable. |
| `assessment/tests/test_copy_assessment_data_hook.py` (new) | 6 pytest cases covering `scrub_manifest_todos` and `_write_manifest_scrubbed`; asserts the real committed manifest produces zero `"TODO:"` substring in the scrubbed payload. |
| `tests/spa/manifest-todo-scrub.test.mjs` (new) | 5 Vitest cases asserting `mergeManifestIntoControls` produces no TODO-valued fields on any of the 78 controls, and that unauthored bars collapse to empty strings. Includes a sanity check that the source manifest still carries TODOs (authoring backlog intact). |

The source manifest at `assessment/manifest/controls.json` is intentionally **untouched** — TODOs remain as the authoring backlog and `scripts/validate_manifest.py --allow-todo` continues to recognize them.

## Validation

```
pytest (assessment/tests):            152 passed (was 146; added 6)
npm test (Vitest contracts):          183 passed | 1 skipped (added 5 new specs)
mkdocs build --strict:                clean; logs "318 TODO field(s) scrubbed"
verify_language_rules.py:             clean
check_manifest_doc_drift.py --check:  clean
verify_xref_graph.py:                 clean
ruff check scripts assessment:        clean
Select-String site/**/*.json TODO:    0 matches
```

## Follow-up

`u-022-author-content-followup` filed to author real facilitator content for the 53 gated controls. Requires SME / Microsoft researcher input — not autonomous work.

---

Source: `maintainers-local/audits/2026-05-18/close-out/verification-sweep-results.md`
