### PR TITLE
docs(1.7): restore Control Description intro paragraph (closes CR-297-002)

### DIFF
--- a/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
+++ b/docs/controls/pillar-1-security/1.7-comprehensive-audit-logging-and-compliance.md
@@ -48,6 +48,8 @@ Implement comprehensive audit logging to capture Microsoft 365 Copilot and Micro
 
 ## Control Description
 
+Microsoft Purview Audit provides the activity-capture foundation for Copilot and agent recordkeeping, but Control 1.7 governs the broader architecture required to capture, retrieve, and preserve those records for FSI obligations. The sections below distinguish capture in Microsoft 365 Audit from content retrieval tooling and the separate preservation layer that should follow the applicable record-class retention schedule.
+
 !!! danger "Capture vs Preservation — read first"
     Control 1.7 governs the capture, search, export, and preservation architecture for Copilot and agent records. Retention should be set by record class, not by a blanket zone default: use 3 years for communications records under SEC Rule 17a-4(b)(4), 6 years for financial/accounting or governance records under SEC Rule 17a-4(a) and FINRA Rule 4511(b), 5 years for CFTC Rule 1.31 records, and longer periods only when a specific rule or the firm's records schedule requires it. Microsoft 365 Audit, including the 10-Year Audit Log Retention add-on, extends the capture window but is not, by itself, the SEC Rule 17a-4(f) preservation layer. For broker-dealers, preservation requires one documented path: Azure immutable blob storage with a locked time-based policy, a 17a-4-attested archive vendor, or the post-October 2022 audit-trail alternative with DEO/DTP documentation and an annual independent records-management assessment.
 


### PR DESCRIPTION
## Summary
Closes CR-297-002 (P3, cosmetic). Code review of PR #297 (WORM Option C synthesis) noted that the intro paragraph of Control 1.7's `## Control Description` was shortened. Adds a 1-2 sentence bridging intro to help readers orient before diving into the capture-vs-preservation architecture.

## Validation
- `python scripts/verify_language_rules.py` ✅
- `python scripts/verify_controls.py` ✅
- `python scripts/verify_xref_graph.py` ✅
- `mkdocs build --strict` ✅

Closes CR-297-002.