### PR TITLE
docs(1.8): correct NYDFS subsection for ERR-01 verification row

### DIFF
--- a/docs/playbooks/control-implementations/1.8/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.8/verification-testing.md
@@ -46,7 +46,7 @@ All timestamps in this playbook are **UTC**. Local-time timestamps are not accep
 | DEF-01 to DEF-04 | Monthly | Security Operations | 7 years | NY DFS 500.16 incident response; SEC Reg S-P §248.30 |
 | CAE-01 | Quarterly | Security Operations | 7 years | NY DFS 500.06; FINRA 4530 |
 | WEB-01 to WEB-04 | Monthly | Security Operations + Application Administrator | 7 years | NY DFS 500.11 third-party; FFIEC AIO booklet |
-| ERR-01 | Monthly + on-change | Security Operations | 7 years | NY DFS 500.11; FFIEC AIO booklet |
+| ERR-01 | Monthly + on-change | Security Operations | 7 years | NY DFS 500.16; FFIEC AIO booklet |
 | AGT-01 | Quarterly | Power Platform Admin | 7 years | OCC Bulletin 2026-13 (formerly OCC 2011-12) (inventory) |
 | CFG-01 to CFG-02 | Quarterly | Power Platform Admin + Application Administrator | 7 years | NY DFS 500.07; SEC Reg S-P §248.30 |
 | VRA-01 | Annually | AI Governance Lead | 7 years | Fed SR 26-2 (formerly SR 11-7) (model risk validation) |


### PR DESCRIPTION
## Summary
Surfaced by review of a workshop handoff doc (parallel session). The ERR-01 verification row in `docs/playbooks/control-implementations/1.8/verification-testing.md:49` cited NY DFS §500.11 (Third-Party Service Provider Security Policy), but ERR-01 is monthly error-investigation by Security Operations — wrong subsection.

## Fix
Replaced `NY DFS 500.11` with `NY DFS 500.16` (Incident Response Plan / Cybersecurity Event Reporting) — matching the file's existing convention for DEF-01 (L46) and IR-01 (L55). The adjacent WEB-01 row (L48) correctly retains §500.11 because that row IS about third-party web checks.

## Validation
- All scripts ✅
- `mkdocs build --strict` ✅

## Source
Workshop handoff Section E trap pattern #10 ("NYDFS §500.11 for direct-to-production change governance — wrong subsection; use §500.07 + §500.08").
