### PR TITLE
docs: canonicalize MCP custom servers GA date to April 2026 (closes SD-9)

### DIFF
--- a/docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md
+++ b/docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md
@@ -142,7 +142,7 @@ Microsoft 365 Copilot and Copilot Studio support various extension mechanisms. U
 
 ### Custom MCP Servers and Advanced Connector Policies
 
-> ⚠️ **Preview feature:** Copilot Studio MCP tool integration entered public preview in **April 2026** and is scheduled for **October 2026** general availability. Delivery timelines may change before release.
+> ⚠️ **GA feature:** Copilot Studio custom MCP server integration entered public preview in **March 2026** and reached general availability in **April 2026**. Configuration options, authentication flows, and administrative controls may continue to evolve after GA — verify capabilities against current Microsoft Learn documentation.
 
 Microsoft's release-plan guidance states that custom MCP servers can be built or cloned from existing MCP servers and can assemble connector actions, tools from other MCP servers, and custom APIs into a reusable governed integration surface. ACP supports **MCP server-level blocking** and **DLP policy enforcement**. Note: granular control over individual MCP tools within ACP is not yet available — only server-level blocking is supported. Copilot Studio allows makers and admins to toggle individual MCP tools at the agent level, which is separate from ACP/DLP enforcement.
 
@@ -189,4 +189,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/playbooks/advanced-implementations/mcp-server-governance/index.md
+++ b/docs/playbooks/advanced-implementations/mcp-server-governance/index.md
@@ -1,6 +1,6 @@
 # MCP Server Governance for FSI
 
-**Last Updated:** March 2026
+**Last Updated:** May 2026
 **Version:** v1.6.2
 
 ---
@@ -11,8 +11,8 @@ The **Model Context Protocol (MCP)** is an open standard that enables Microsoft 
 
 MCP servers surface as **custom connectors** within the Power Platform connector framework. This means they inherit the same DLP policy controls, environment scoping, and governance mechanisms that apply to any Power Platform connector — but they also introduce new risks specific to regulated environments.
 
-!!! warning "Preview Feature — Custom MCP Servers"
-    Custom MCP Servers in Copilot Studio are in **Preview** as of April 2026, with general availability planned for **October 2026**. Configuration options, authentication flows, and administrative controls may change before GA. Organizations should verify current capabilities against [Microsoft Learn documentation](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-create-new-server) before production deployment.
+!!! info "GA Feature — Custom MCP Servers"
+    Custom MCP Servers in Copilot Studio entered **public preview in March 2026** and reached **general availability in April 2026**. Configuration options, authentication flows, and administrative controls may continue to evolve after GA. Organizations should verify current capabilities against [Microsoft Learn documentation](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-create-new-server) before production deployment.
 
 This playbook provides FSI-specific governance guidance for MCP server integration, covering DLP connector policy scoping, authentication governance, network isolation, and audit requirements.
 

--- a/docs/playbooks/control-implementations/2.17/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.17/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 2.17 — Multi-Agent Orchestration Limits
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 This guide covers the high-frequency failure modes observed when implementing the orchestration controls. The emphasis is on **false-clean** patterns — situations where the control *appears* to be working but is silently failing — because those are the highest-risk failures for FSI audit defensibility.
 
@@ -144,7 +144,7 @@ Treat any drift event as a Control 3.4 incident and document in the quarterly at
 | No native circuit breaker | Custom Power Automate flow required | Documented in *Portal Walkthrough* Step 4 |
 | Limited cross-environment orchestration visibility | Reconstructing chains spanning environments requires manual correlation | Use Pattern B + correlation-ID propagation; consider keeping Zone 3 chains within a single environment |
 | HITL via adaptive cards uses polling | Latency between approval and resume | Use Microsoft Agent Framework HITL primitives where available — they integrate with checkpoint persistence |
-| Custom MCP servers in preview (April 2026) | Behavior may change before GA | Do not promote custom MCP servers to Zone 3 production until GA confirmed on Microsoft Learn |
+| Custom MCP servers reached GA in April 2026 (post-preview) | Post-GA behavior may continue to evolve | Verify capabilities against current Microsoft Learn before promoting custom MCP servers to Zone 3 production |
 | 128-tool-per-agent ceiling | Large delegation trees can hit ceiling silently | Run Section 4 of *PowerShell Setup* monthly to track headroom |
 
 ---


### PR DESCRIPTION
## Summary
Closes SD-9 (P1). Section D verification sweep against workshop handoff fact #9 found internal corpus split on MCP custom servers GA date:
- 2.17 + 3.8 correctly say April 2026
- 1.4 + mcp-server-governance/index.md incorrectly say October 2026
- 2.17/troubleshooting.md ambiguous

Canonical date per Microsoft (workshop handoff): **April 2026**.

## Files corrected
- `docs/controls/pillar-1-security/1.4-advanced-connector-policies-acp.md:145`
- `docs/playbooks/advanced-implementations/mcp-server-governance/index.md:14-15`
- `docs/playbooks/control-implementations/2.17/troubleshooting.md:147`

## Source
Workshop handoff Section D fact #9: "MCP custom servers GA date: April 2026."

## Validation
- All scripts ✅ (`verify_language_rules`, `verify_controls`, `verify_xref_graph`, `check_manifest_doc_drift`)
- `mkdocs build --strict` ✅
- Post-fix grep: zero remaining "October 2026" matches anywhere in `docs/`

Closes SD-9.
