### PR TITLE
docs+assessment: distinguish agent-level (5-pos) vs per-prompt (3-pos) moderation slider scales (closes SD-11)

### DIFF
--- a/assessment/manifest/controls.json
+++ b/assessment/manifest/controls.json
@@ -2809,7 +2809,7 @@
       },
       {
         "check_id": "1.27.b",
-        "description": "Moderation level meets zone minimum (Medium for Z2, High for Z3)",
+        "description": "Per-prompt moderation level meets zone minimum (Moderate for Z2, High for Z3)",
         "api_call": "Get-CopilotStudioAgentConfig",
         "pass_condition": "moderation_zone_compliant",
         "zone_required": [

--- a/assessment/manifest/generate_manifest.py
+++ b/assessment/manifest/generate_manifest.py
@@ -196,7 +196,7 @@ CHECKS_DB = {
     ],
     "1.27": [
         ("1.27.a","Content moderation level set per agent","Get-CopilotStudioAgentConfig","moderation_level_set",[1,2,3]),
-        ("1.27.b","Moderation level meets zone minimum (Medium for Z2, High for Z3)","Get-CopilotStudioAgentConfig","moderation_zone_compliant",[2,3]),
+        ("1.27.b","Per-prompt moderation level meets zone minimum (Moderate for Z2, High for Z3)","Get-CopilotStudioAgentConfig","moderation_zone_compliant",[2,3]),
         ("1.27.c","Custom safety messages configured for Zone 3 agents","Get-CopilotStudioAgentConfig","safety_messages_configured",[3]),
     ],
     "1.28": [

--- a/docs/controls/pillar-1-security/1.27-ai-agent-content-moderation-enforcement.md
+++ b/docs/controls/pillar-1-security/1.27-ai-agent-content-moderation-enforcement.md
@@ -3,13 +3,21 @@
 **Control ID:** 1.27<br>
 **Pillar:** Security<br>
 **Regulatory Reference:** FINRA 3110/25-07, FINRA 2210, SEC 17a-3/4, SOX 302/404, GLBA 501(b), OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly SR 11-7), NIST AI RMF / AI 600-1<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---
 
 !!! note "Runtime Content Safety Configured Per AI Prompt"
-    Microsoft Copilot Studio content moderation (**Low / Moderate / High**, per the Microsoft Learn release plan; "Medium" remains widely used in community references and prior UI labels) is configured **per AI prompt** in the prompt builder. In practice this surfaces at two enforcement points: (1) the agent's generative answers / "Conversational boosting" system topic, which acts as the **agent-effective default** for unstructured Q&A, and (2) any custom topic that contains a **Generative answers** node, where the topic-level setting takes precedence at runtime for that conversation path. This control establishes zone-based moderation requirements to help reduce harmful outputs, regulatory exposure from AI-generated communications, and inappropriate customer-facing responses. It complements **Control 1.8 (Runtime Protection and External Threat Detection)**, **Control 1.21 (Adversarial Input Logging)**, and **Control 2.20 (Adversarial Testing and Red Team Framework)**. Per Microsoft Learn, this capability is generally available as of **February 11, 2026**, originally announced via Message Center post **MC1217615** (announced GA target of January 31, 2026).
+    Microsoft Copilot Studio content moderation is configured **per AI prompt** in the prompt builder. The **per-prompt moderation slider** (applicable to managed GPT models) is a **3-position scale: Low / Moderate / High** ("Medium" remains widely used in community references and prior UI labels — treat it as synonymous with Moderate on this surface). In practice this surfaces at two enforcement points: (1) the agent's generative answers / "Conversational boosting" system topic, which acts as the **agent-effective default** for unstructured Q&A, and (2) any custom topic that contains a **Generative answers** node, where the topic-level setting takes precedence at runtime for that conversation path. This control establishes zone-based moderation requirements to help reduce harmful outputs, regulatory exposure from AI-generated communications, and inappropriate customer-facing responses. It complements **Control 1.8 (Runtime Protection and External Threat Detection)**, **Control 1.21 (Adversarial Input Logging)**, and **Control 2.20 (Adversarial Testing and Red Team Framework)**. Per Microsoft Learn, this capability is generally available as of **February 11, 2026**, originally announced via Message Center post **MC1217615** (announced GA target of January 31, 2026).
+
+!!! warning "Two distinct moderation UI surfaces — do not confuse them"
+    Copilot Studio exposes **two separate content-moderation surfaces** with different scales:
+
+    - **Per-prompt slider** (this control's scope) — in the prompt builder on the system **Conversational boosting** topic and on each custom topic's **Generative answers** node. **3 positions: Low / Moderate / High**. Available on managed GPT models.
+    - **Agent-level slider** (Control 1.8 scope) — at **Agent → Settings → Generative AI → Content moderation**, applying tenant-wide harm-category classifier strictness to the agent's responses. **5 positions: Lowest / Low / Medium / High / Highest**.
+
+    The two surfaces operate at different layers and are configured independently. References to "Medium" on the **per-prompt** scale are legacy/community shorthand for **Moderate**; on the **agent-level** scale "Medium" is a real, distinct middle position between Low and High.
 
 ## Objective
 
@@ -34,23 +42,23 @@ Enforce appropriate content moderation levels at both agent and topic levels bas
 
 ## Control Description
 
-Content moderation in Copilot Studio provides three runtime safety levels—Low, Medium, and High—that control how strictly the platform filters AI-generated responses for harmful, inappropriate, or non-compliant content. These moderation levels are configurable at two enforcement points: the **agent level** (default moderation for all topics) and the **topic level** (overrides for specific conversation paths). Topic-level settings take precedence at runtime, enabling fine-grained control over content safety for customer-facing workflows, regulated interactions, and sensitive use cases.
+The Copilot Studio **per-prompt moderation slider** provides three runtime safety levels—**Low**, **Moderate**, and **High**—that control how strictly the platform filters AI-generated responses for harmful, inappropriate, or non-compliant content. These per-prompt moderation levels are configurable at two prompt-builder enforcement points: the **agent-effective default** (the setting on the Conversational boosting system topic, applied to all unstructured Q&A) and the **per-topic override** (the setting on each custom topic's Generative answers node, taking precedence for that conversation path at runtime). This surface is distinct from the agent-level Settings → Generative AI moderation slider (5 positions: Lowest / Low / Medium / High / Highest) governed by Control 1.8 — see the disambiguation note above. "Medium" is a community / legacy synonym for **Moderate** on the per-prompt scale and is treated as equivalent throughout this control.
 
 This control establishes a risk-based moderation enforcement model that escalates by governance zone:
 
-1. **Agent-level default moderation** — Each agent has a baseline moderation level (Low, Medium, or High) that applies to all topics unless overridden; zone classification determines the minimum permissible default
-2. **Topic-level moderation overrides** — Individual topics within an agent may have stricter or more permissive moderation levels based on the topic's role, audience, and sensitivity; overrides to less restrictive levels require approval in Zone 2+
+1. **Agent-effective default moderation** — The per-prompt moderation level (**Low**, **Moderate**, or **High**) configured on the Conversational boosting system topic applies to all unstructured Q&A unless a more specific topic overrides it; zone classification determines the minimum permissible default
+2. **Per-topic moderation overrides** — Individual custom topics that contain a Generative answers node may have stricter or more permissive per-prompt moderation levels based on the topic's role, audience, and sensitivity; overrides to less restrictive levels require approval in Zone 2+
 3. **Custom safety messages** — When content is blocked by moderation filters, agents display custom messages to users; Zone 3 requires tailored safety messages that align with brand and regulatory voice
 4. **Audit and logging integration** — Content moderation events (prompts blocked, moderation level changes) are logged for compliance review; Zone 3 requires integration with Microsoft Purview for audit trail retention
 
-The enforcement model escalates by governance zone. Zone 1 environments permit Medium moderation as the minimum default, with agent authors empowered to configure topic-level overrides without approval. Zone 2 environments require High moderation by default, with topic-level overrides to Medium or Low requiring documented approval. Zone 3 environments mandate High moderation at both agent and topic levels, prohibit topic-level downgrades to Low, require custom safety messages, and integrate moderation logs with Purview for regulatory audit trails.
+The enforcement model escalates by governance zone. Zone 1 environments permit **Moderate** as the minimum agent-effective default, with agent authors empowered to configure topic-level overrides without approval. Zone 2 environments require **High** by default, with topic-level overrides to **Moderate** or **Low** requiring documented approval. Zone 3 environments mandate **High** at both the agent-effective default and per-topic levels, prohibit topic-level downgrades to **Low**, require custom safety messages, and integrate moderation logs with Purview for regulatory audit trails.
 
 ### Capability Comparison by Zone
 
 | Capability | Zone 1 (Personal) | Zone 2 (Team) | Zone 3 (Enterprise) |
 |------------|-------------------|---------------|---------------------|
-| **Agent-level default moderation** | Medium minimum | High default | High mandatory |
-| **Topic-level override to Medium** | Allowed | Allowed with approval | Allowed with documented justification |
+| **Agent-effective default moderation** | Moderate minimum | High default | High mandatory |
+| **Topic-level override to Moderate** | Allowed | Allowed with approval | Allowed with documented justification |
 | **Topic-level override to Low** | Allowed | Requires documented approval | Prohibited |
 | **Custom safety messages** | Recommended | Recommended | Required |
 | **Moderation change approval** | Not required | Documented approval | Formal review + approval |
@@ -63,8 +71,8 @@ The enforcement model escalates by governance zone. Zone 1 environments permit M
 
 ## Key Configuration Points
 
-- **Agent-level moderation default** — Set the baseline content moderation level (Low, Medium, High) for each agent in Copilot Studio prompt builder settings; default should align with the agent's governance zone and audience
-- **Topic-level moderation overrides** — Configure topic-specific moderation levels for conversation paths requiring stricter or more permissive filtering; topic overrides take precedence at runtime
+- **Agent-effective default moderation** — Set the per-prompt content moderation level (**Low**, **Moderate**, **High**) on each agent's Conversational boosting system topic in the prompt builder; default should align with the agent's governance zone and audience. (This is distinct from the agent-level **Settings → Generative AI → Content moderation** slider — 5 positions, Lowest/Low/Medium/High/Highest — covered by Control 1.8.)
+- **Per-topic moderation overrides** — Configure per-prompt moderation levels (Low / Moderate / High) on individual custom topics' Generative answers nodes when a conversation path requires stricter or more permissive filtering; topic overrides take precedence at runtime
 - **Custom safety messages** — Define user-facing messages displayed when content is blocked by moderation filters; Zone 3 requires messages aligned with organizational voice and regulatory context
 - **Moderation approval workflow** — Establish an approval process for topic-level overrides that reduce moderation strictness below the agent-level default (Zone 2+)
 - **Audit log configuration** — Enable and retain moderation event logs in Microsoft Purview for compliance review; capture blocked prompts, moderation level changes, and override approvals (Zone 3)
@@ -77,9 +85,9 @@ The enforcement model escalates by governance zone. Zone 1 environments permit M
 
 | Zone | Requirement | Rationale |
 |------|-------------|-----------|
-| **Zone 1** (Personal) | Medium moderation minimum; agent authors may configure topic overrides without approval; quarterly review of moderation settings | Personal productivity agents present lower compliance risk; Medium moderation balances safety with user autonomy for experimentation |
-| **Zone 2** (Team) | High moderation default; topic-level overrides to Medium or Low require documented approval; monthly review of moderation settings | Shared team agents may be used in workflows involving customer data or internal communications; High default reduces risk of inappropriate outputs |
-| **Zone 3** (Enterprise) | High moderation mandatory at agent level; topic-level overrides to Medium allowed with documented justification; topic-level downgrades to Low prohibited; custom safety messages required; Purview audit integration; weekly review | Customer-facing and regulated agents require maximum content safety; blocking downgrades to Low helps prevent inappropriate responses in high-stakes interactions |
+| **Zone 1** (Personal) | Moderate per-prompt moderation minimum on the agent-effective default; agent authors may configure topic overrides without approval; quarterly review of moderation settings | Personal productivity agents present lower compliance risk; Moderate moderation balances safety with user autonomy for experimentation |
+| **Zone 2** (Team) | High per-prompt moderation as the agent-effective default; topic-level overrides to Moderate or Low require documented approval; monthly review of moderation settings | Shared team agents may be used in workflows involving customer data or internal communications; High default reduces risk of inappropriate outputs |
+| **Zone 3** (Enterprise) | High per-prompt moderation mandatory as the agent-effective default; topic-level overrides to Moderate allowed with documented justification; topic-level downgrades to Low prohibited; custom safety messages required; Purview audit integration; weekly review | Customer-facing and regulated agents require maximum content safety; blocking downgrades to Low helps prevent inappropriate responses in high-stakes interactions |
 
 ---
 
@@ -88,7 +96,7 @@ The enforcement model escalates by governance zone. Zone 1 environments permit M
 | Role | Responsibility |
 |------|----------------|
 | Power Platform Admin | Configure environment-level moderation policies; review and approve moderation override requests for Zone 2+ agents; monitor moderation compliance across environments |
-| Copilot Studio Agent Author | Set agent-level default moderation; configure topic-level moderation overrides per approved settings; define custom safety messages; document justification for moderation changes |
+| Copilot Studio Agent Author | Set the agent-effective default per-prompt moderation (Conversational boosting system topic); configure per-topic moderation overrides per approved settings; define custom safety messages; document justification for moderation changes |
 | Purview Compliance Admin | Configure audit log retention for moderation events; integrate moderation logs with Purview for compliance reporting; review blocked content trends for policy updates |
 | SOC Analyst / Entra Security Admin | Monitor moderation alerts and trends in Sentinel / Defender XDR; investigate anomalous moderation bypass attempts; triage and escalate confirmed incidents involving harmful outputs |
 | Model Risk Manager | Review moderation level selection rationale, override approvals, and adversarial test results as part of OCC Bulletin 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly SR 11-7) model risk oversight |
@@ -133,8 +141,8 @@ The enforcement model escalates by governance zone. Zone 1 environments permit M
 
 Confirm control effectiveness by verifying:
 
-1. Agent-level default moderation is set to the correct level (Medium minimum for Zone 1, High for Zone 2+) for each agent based on its governance zone classification
-2. Topic-level moderation overrides are documented with appropriate approval (Zone 2+) and no prohibited downgrades to Low exist in Zone 3 agents
+1. The agent-effective default per-prompt moderation level is set to the correct value (**Moderate** minimum for Zone 1, **High** for Zone 2+) for each agent based on its governance zone classification
+2. Per-topic moderation overrides are documented with appropriate approval (Zone 2+) and no prohibited downgrades to **Low** exist in Zone 3 agents
 3. Custom safety messages are configured for all Zone 3 agents and align with organizational voice and regulatory requirements
 4. Moderation event logs are being captured and retained in Microsoft Purview for Zone 3 agents
 5. An up-to-date inventory of agents and topics with moderation levels exists, including zone classification, approval status, and last review date
@@ -167,4 +175,4 @@ Confirm control effectiveness by verifying:
 
 ---
 
-*Updated: April 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection.md
+++ b/docs/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection.md
@@ -21,6 +21,14 @@
 
     For GCC High / DoD tenants: confirm per-capability availability against the live Learn pages and Power Platform service availability matrix **before** committing to native Defender or webhook-based runtime protection. Record any gap in your Zone-3 exception register and use the alternative surfaces (Prompt Shields + content moderation) until parity is confirmed.
 
+!!! warning "Two distinct moderation UI surfaces — do not confuse them"
+    Copilot Studio exposes **two separate content-moderation surfaces** with different scales:
+
+    - **Agent-level slider** (this control's scope) — at **Agent → Settings → Generative AI → Content moderation**, applying harm-category classifier strictness across the agent's responses. **5 positions: Lowest / Low / Medium / High / Highest**. This is the surface configured for runtime threat protection per Control 1.8.
+    - **Per-prompt slider** (Control 1.27 scope) — in the prompt builder on the system **Conversational boosting** topic and on each custom topic's **Generative answers** node. **3 positions: Low / Moderate / High**. Available on managed GPT models.
+
+    The two surfaces operate at different layers and are configured independently. "Medium" on the **agent-level** scale is a real, distinct middle position (between Low and High); on the **per-prompt** scale "Medium" is community/legacy shorthand for **Moderate**.
+
 ## Objective
 
 Implement runtime security controls for Copilot Studio agents to detect and block prompt injection attacks, jailbreak attempts, and malicious agent behavior. This control provides real-time protection against adversarial inputs and external threats targeting AI agents.
@@ -230,16 +238,18 @@ NYDFS cybersecurity guidance emphasizes detection of AI-enabled attack technique
 
 ### Content Moderation Level Configuration
 
-Copilot Studio provides configurable content moderation levels that control how aggressively the Azure AI Content Safety service filters agent responses. Configure per agent in Copilot Studio > Agent > Settings > Generative AI > Content moderation.
+Copilot Studio provides a configurable agent-level **content moderation slider** that controls how aggressively the Azure AI Content Safety service filters agent responses across harm categories (Hate, Sexual, Violence, Self-Harm). Configure per agent in **Copilot Studio → Agent → Settings → Generative AI → Content moderation**. This **agent-level** slider has **5 positions**: **Lowest / Low / Medium / High / Highest**. (The separate **per-prompt** moderation slider — 3 positions: Low / Moderate / High — exposed in the prompt builder for managed GPT models is governed by Control 1.27 and is configured independently.)
 
 | Moderation Level | Behavior | Recommended Zone |
 |-----------------|----------|-------------------|
-| **Low** | Minimal filtering; allows broader responses | Not recommended for FSI |
+| **Lowest** | Minimal filtering; allows the broadest range of responses | Not recommended for FSI |
+| **Low** | Light filtering; allows broader responses than Medium | Not recommended for FSI |
 | **Medium** | Balanced filtering; blocks clearly harmful content | Zone 1 (Personal) minimum |
-| **High** | Strict filtering; blocks potentially sensitive or harmful content | Zone 2 (Team) and Zone 3 (Enterprise) |
+| **High** | Strict filtering; blocks potentially sensitive or harmful content | Zone 2 (Team) and Zone 3 (Enterprise) recommended minimum |
+| **Highest** | Maximum available filtering; most restrictive option | Zone 3 (Enterprise) for highest-risk customer-facing agents |
 
-!!! warning "FSI Recommendation: Set Content Moderation to High"
-    For regulated financial services environments, set content moderation to **High** for all Zone 2 and Zone 3 agents. Zone 1 agents should use **Medium** at minimum. Agents with lower settings should be explicitly approved and documented with risk acceptance.
+!!! warning "FSI Recommendation: Set Agent-Level Content Moderation to High (Highest for highest-risk Zone 3)"
+    For regulated financial services environments, set the agent-level content moderation slider to **High** for all Zone 2 and Zone 3 agents. Zone 3 agents handling the highest-risk customer-facing or regulated workflows should consider **Highest**. Zone 1 agents should use **Medium** at minimum. Agents with lower settings (**Lowest** or **Low**) should be explicitly approved and documented with risk acceptance.
 
 ---
 
@@ -307,7 +317,7 @@ Copilot Studio provides configurable content moderation levels that control how 
 
     **Capabilities:**
 
-    - Per-agent content moderation level validation (Low/Medium/High vs zone requirements)
+    - Per-agent content moderation level validation (agent-level 5-position scale Lowest/Low/Medium/High/Highest vs zone requirements)
     - Zone-based compliance checking (Zone 1: Medium minimum, Zone 2/3: High)
     - Drift detection with baseline comparison for configuration change tracking
     - Teams adaptive card alerts with severity classification and regulatory context
@@ -422,8 +432,8 @@ Confirm control effectiveness by verifying:
 7. Native Microsoft Defender integration enabled (Zone 2/3)
 8. AI agent inventory populated in Defender portal
 9. Defender XDR alerts generated for blocked actions
-10. Content moderation level is set to High for all Zone 2/3 agents (Copilot Studio > Agent > Settings > Generative AI)
-11. No agents have content moderation set below Medium without documented risk acceptance
+10. Agent-level content moderation slider (5 positions: Lowest/Low/Medium/High/Highest) is set to **High** (or **Highest** for highest-risk agents) for all Zone 2/3 agents (Copilot Studio > Agent > Settings > Generative AI > Content moderation)
+11. No agents have agent-level content moderation set below **Medium** without documented risk acceptance
 
 ---
 

--- a/docs/images/1.27/EXPECTED.md
+++ b/docs/images/1.27/EXPECTED.md
@@ -2,18 +2,18 @@
 
 ## Expected Screenshots
 
-### Screenshot 1: Agent-Level Content Moderation Setting (High)
-**Portal Path:** Microsoft Copilot Studio → [Agent] → Topics → System → [Generative AI topic] → Content moderation
+### Screenshot 1: Agent-Effective Default Moderation Setting (High)
+**Portal Path:** Microsoft Copilot Studio → [Agent] → Topics → System → [Conversational boosting / Generative AI topic] → Generative answers node → Content moderation
 **What to capture:**
-- Content moderation dropdown or selector showing "High" selected
+- Per-prompt content moderation slider showing "High" selected
 - Agent name visible in the header or breadcrumb
-- Prompt builder context showing this is the agent-level default
+- Prompt builder context showing this is the system topic (acts as the agent-effective default)
 - Save button visible
 
-### Screenshot 2: Agent-Level Content Moderation Setting (Medium)
-**Portal Path:** Copilot Studio → [Agent] → Topics → System → [Generative AI topic] → Content moderation
+### Screenshot 2: Agent-Effective Default Moderation Setting (Moderate)
+**Portal Path:** Copilot Studio → [Agent] → Topics → System → [Conversational boosting / Generative AI topic] → Generative answers node → Content moderation
 **What to capture:**
-- Content moderation dropdown or selector showing "Medium" selected
+- Per-prompt content moderation slider showing "Moderate" selected (some UI builds may label this position **Medium** — capture either label and note in the caption)
 - Agent name visible in the header
 - Demonstration of Zone 1 configuration
 
@@ -41,15 +41,16 @@
 - Agent response displaying the custom safety message
 - Timestamp and conversation context visible
 
-### Screenshot 6: Moderation Level Options
-**Portal Path:** Copilot Studio → [Agent] → Topics → System → [Generative AI topic] → Content moderation dropdown
+### Screenshot 6: Per-Prompt Moderation Level Options
+**Portal Path:** Copilot Studio → [Agent] → Topics → System → [Conversational boosting / Generative AI topic] → Generative answers node → Content moderation slider
 **What to capture:**
-- Content moderation dropdown expanded showing all three options:
+- Per-prompt content moderation slider expanded showing all three options:
   - Low
-  - Medium
+  - Moderate (labelled "Medium" in some UI builds — note in caption)
   - High
 - Descriptions or tooltips if visible
 - Agent context visible
+- This is the **per-prompt** slider (3 positions). The separate **agent-level** slider at Settings → Generative AI → Content moderation has **5 positions** and is captured under Control 1.8 screenshots.
 
 ### Screenshot 7: Purview Audit Log for Moderation Change
 **Portal Path:** Microsoft Purview Compliance Portal → Audit → Search results
@@ -68,7 +69,7 @@
 - Table or list displaying:
   - Environment names
   - Agent names
-  - Moderation levels (Low/Medium/High)
+  - Per-prompt moderation levels (Low/Moderate/High; UI may show "Medium" in place of "Moderate")
   - Custom safety message status (True/False)
   - Last modified dates
 - Summary counts (total agents, compliant agents, non-compliant agents)
@@ -102,16 +103,16 @@
 - Use non-sensitive agent names and prompts for screenshots
 - Include timestamps to demonstrate currency
 - Verify UI matches documentation after Microsoft portal updates
-- Content moderation settings are located in the generative AI topic's prompt builder, not in the agent's general Settings panel
-- Capture both agent-level and topic-level moderation settings to show the dual-control model
-- Demonstrate the difference between Low, Medium, and High moderation levels where possible
+- Content moderation settings are located in the generative AI topic's prompt builder, not in the agent's general Settings panel (the agent-level slider in Settings → Generative AI is a separate 5-position surface — see Control 1.8)
+- Capture both agent-effective default (system topic) and per-topic override (custom topic Generative answers node) per-prompt settings to show the dual-control model
+- Demonstrate the difference between Low, Moderate, and High per-prompt moderation levels where possible (these are the 3 positions on the per-prompt slider)
 - For Zone 3 documentation, ensure custom safety messages are captured
 
 ---
 
 ## Feature Availability Note
 
-Content moderation levels (Low, Medium, High) with agent-level and topic-level configuration became GA on January 31, 2026 (MC1217615). If your tenant has not yet received this update:
+Per-prompt content moderation levels (Low, Moderate, High) with agent-effective-default and per-topic configuration became GA on January 31, 2026 (MC1217615). If your tenant has not yet received this update:
 
 - Moderation settings may appear in a different location
 - Feature may be under preview or feature flag
@@ -123,12 +124,12 @@ Content moderation levels (Low, Medium, High) with agent-level and topic-level c
 ## Screenshot Organization
 
 Organize screenshots in this directory as:
-- `1.27-01-moderation-high.png` — Agent-level moderation set to High
-- `1.27-02-moderation-medium.png` — Agent-level moderation set to Medium
-- `1.27-03-topic-moderation-override.png` — Topic-level moderation override
+- `1.27-01-moderation-high.png` — Agent-effective default per-prompt moderation set to High
+- `1.27-02-moderation-moderate.png` — Agent-effective default per-prompt moderation set to Moderate (labelled "Medium" in some UI builds)
+- `1.27-03-topic-moderation-override.png` — Per-topic moderation override
 - `1.27-04-custom-safety-message.png` — Custom safety message configuration
 - `1.27-05-safety-message-test.png` — Safety message in test panel
-- `1.27-06-moderation-level-options.png` — Moderation level dropdown options
+- `1.27-06-moderation-level-options.png` — Per-prompt moderation slider options (Low / Moderate / High)
 - `1.27-07-audit-log-moderation.png` — Purview audit log for moderation change
 - `1.27-08-moderation-inventory.png` — PowerShell moderation inventory output
 - `1.27-09-topic-override-report.png` — PowerShell topic override report

--- a/docs/playbooks/advanced-implementations/configuration-hardening-baseline/index.md
+++ b/docs/playbooks/advanced-implementations/configuration-hardening-baseline/index.md
@@ -61,7 +61,9 @@ Financial services organizations face continuous configuration drift risk across
 
 | # | Setting | Portal Path | Expected Value (Zone 2/3) | Severity | Automation |
 |---|---------|-------------|---------------------------|----------|------------|
-| 10 | Content moderation level | Copilot Studio > Agent > Settings > Generative AI > Content moderation ([Content moderation in Copilot Studio](https://learn.microsoft.com/microsoft-copilot-studio/knowledge-copilot-studio#content-moderation)) | High | High | Manual Attestation |
+| 10 | Agent-level content moderation slider (5 positions: Lowest / Low / Medium / High / Highest) | Copilot Studio > Agent > Settings > Generative AI > Content moderation ([Content moderation in Copilot Studio](https://learn.microsoft.com/microsoft-copilot-studio/knowledge-copilot-studio#content-moderation)) | High (Highest for highest-risk Zone 3) | High | Manual Attestation |
+
+> **Two distinct moderation surfaces.** Item 10 above is the **agent-level** slider (5 positions, governed by Control 1.8 runtime protection). The separate **per-prompt** slider (3 positions: Low / Moderate / High) inside the prompt builder is governed by **Control 1.27**; it is configured independently and is not represented by a single tenant-wide value, so it is reviewed under the 1.27 implementation playbook rather than this baseline.
 
 ### RBAC and Agent Governance (Control 1.18)
 

--- a/docs/playbooks/control-implementations/1.8/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.8/portal-walkthrough.md
@@ -113,7 +113,7 @@ For PowerShell parity, see [powershell-setup.md](powershell-setup.md) and `docs/
 | Native real-time runtime alerts on Copilot Studio agents | Defender XDR custom detection rules on `CloudAppEvents` (where available) plus per-agent App Insights alerts on RAI `ContentFiltered` events; SIEM-side correlation rules — see [Control 1.21](../../../controls/pillar-1-security/1.21-adversarial-input-logging.md) |
 | AISPM posture management for AI agents | Quarterly attestation by Power Platform Admin against the [Control 1.1](../../../controls/pillar-1-security/1.1-restrict-agent-publishing-by-authorization.md) inventory; mapped to FFIEC AIO §III.B model risk inventory |
 | Copilot Studio Prompt Shields not at parity | Disable affected agent classes in PPAC environment policies; route to compensating Microsoft Purview DLP for AI prompts — [Control 1.5](../../../controls/pillar-1-security/1.5-data-loss-prevention-dlp-and-sensitivity-labels.md) |
-| Per-agent content moderation Low/Medium/High not at parity | Limit agents to Zone 1 (read-only, internal-only); require human-in-the-loop confirmation node before any external action — see [Control 1.23](../../../controls/pillar-1-security/1.23-step-up-authentication-for-agent-operations.md) |
+| Per-agent content moderation slider (5 positions: Lowest / Low / Medium / High / Highest) not at parity | Limit agents to Zone 1 (read-only, internal-only); require human-in-the-loop confirmation node before any external action — see [Control 1.23](../../../controls/pillar-1-security/1.23-step-up-authentication-for-agent-operations.md) |
 
 ---
 ## Section 2 — Pre-flight gates
@@ -125,7 +125,7 @@ Complete every gate **before** opening Section 4. Each gate has explicit pass cr
 | Capability | Required licensing | Verification |
 |---|---|---|
 | Defender for Cloud Apps **AI Agent Protection** + AISPM | **Agent 365 license** (required after 2026-07-01). **Grace period until 2026-07-01:** Microsoft Defender for Cloud Apps standalone license or included via Microsoft 365 E5 / E5 Security. After 2026-07-01, Agent 365 is required to retain AI Agent Inventory access. Verify Defender XDR plan against ([protect-copilot-studio](https://learn.microsoft.com/en-us/defender-cloud-apps/ai-agent-protection)) | Microsoft Defender portal → Settings → Cloud apps → tenant licensing summary |
-| Copilot Studio Prompt Shields + content moderation Low/Medium/High | Copilot Studio license (per-tenant or per-user); generative-AI capacity (PAYG or pre-paid messages) per [security-and-governance](https://learn.microsoft.com/en-us/microsoft-copilot-studio/security-and-governance) | PPAC → Resources → Capacity → Copilot Studio messages |
+| Copilot Studio Prompt Shields + agent-level content moderation slider (Lowest / Low / Medium / High / Highest) | Copilot Studio license (per-tenant or per-user); generative-AI capacity (PAYG or pre-paid messages) per [security-and-governance](https://learn.microsoft.com/en-us/microsoft-copilot-studio/security-and-governance) | PPAC → Resources → Capacity → Copilot Studio messages |
 | PPAC **Threat Protection** (native + Additional) | Power Platform Admin role; capability gated by Defender for Cloud Apps preview opt-in for native handshake | PPAC → Security → Threat Protection visible in left rail |
 | Microsoft Entra **app registration + Federated Identity Credential** | Entra App Admin (Application Administrator) **or** Cloud Application Administrator | Microsoft Entra admin center → Identity → Applications |
 | Application Insights per-agent | Azure subscription with Application Insights workspace; Owner / Contributor on the workspace; instrumentation key or connection string | Azure portal → Application Insights resource → Properties |
@@ -221,7 +221,7 @@ Use the canonical role names from [`docs/reference/role-catalog.md`](../../../re
 | 4b-2 | Federated Identity Credential — copy server-issued subject from PPAC UI | Entra App Admin **+** Power Platform Admin | Yes |
 | 4b-3 | PPAC Additional Threat Detection — bind webhook | Power Platform Admin | Yes |
 | 4c | Verify Prompt Shields tenant-wide setting | Power Platform Admin | Read-only |
-| 4d | Per-agent content moderation level | Copilot Studio author on the target environment | Per environment policy |
+| 4d | Per-agent content moderation slider (5 positions: Lowest / Low / Medium / High / Highest) | Copilot Studio author on the target environment | Per environment policy |
 | 4e | AISPM dashboard verification | Entra Security Admin **or** Entra Security Reader | Read-only |
 | 4f | Defender XDR custom detection rule on `CloudAppEvents` | Entra Security Admin | Yes |
 | 4g | Per-agent Application Insights connection string | Copilot Studio author **+** Azure Application Insights Contributor | Yes |
@@ -349,28 +349,30 @@ Reference: [security-and-governance](https://learn.microsoft.com/en-us/microsoft
 
 > Prompt Shields and content moderation are **distinct** capabilities. Prompt Shields targets prompt-injection and jailbreak; content moderation targets harmful-content generation across Hate / Sexual / Violence / Self-Harm. Conflating the two is the most common Control 1.8 design defect.
 
-### 4d — Per-agent content moderation Low / Medium / High
+### 4d — Per-agent content moderation (agent-level slider — 5 positions: Lowest / Low / Medium / High / Highest)
 
 **Lifecycle:** GA. Configured **per agent**, at design time, in Copilot Studio.
 
-Copilot Studio exposes three content-moderation levels — **Low**, **Medium**, **High** — that map to Azure AI Content Safety severity thresholds across four harm categories: **Hate**, **Sexual**, **Violence**, **Self-Harm** ([content-safety/concepts/harm-categories](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/concepts/harm-categories); [content-safety/overview](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/overview)).
+Copilot Studio exposes a **per-agent content-moderation slider** with **5 positions** — **Lowest**, **Low**, **Medium**, **High**, **Highest** — that maps to Azure AI Content Safety severity thresholds across four harm categories: **Hate**, **Sexual**, **Violence**, **Self-Harm** ([content-safety/concepts/harm-categories](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/concepts/harm-categories); [content-safety/overview](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/overview)). This is the **agent-level** slider configured at **Settings → Generative AI → Content moderation** and is the surface this control covers. The separate **per-prompt** slider exposed in the prompt builder (3 positions: Low / Moderate / High, managed GPT models only) is governed by **Control 1.27** and is configured independently.
 
-| Copilot Studio level | Blocks severity ≥ | What still passes | FSI guidance |
-|---|---|---|---|
-| **Low** | 6 (High only) | Severity 0 (Safe), 2 (Low), 4 (Medium) | Most permissive — **not** recommended for any zone in regulated FSI workloads |
-| **Medium** (default) | 4 (Medium and High) | Severity 0, 2 | Acceptable for Zone 1 internal-only agents only |
-| **High** | 2 (Low, Medium, High) | Severity 0 (Safe) only | **Recommended for FSI Zone 2 and Zone 3** — strictest available; no `Strict` level exists |
+| Copilot Studio agent-level position | Relative strictness | FSI guidance |
+|---|---|---|
+| **Lowest** | Most permissive available — minimal filtering | **Not recommended** for any FSI zone; requires explicit documented risk acceptance |
+| **Low** | Light filtering | Not recommended for FSI |
+| **Medium** | Balanced filtering — blocks clearly harmful content | Acceptable for Zone 1 internal-only agents only |
+| **High** | Strict filtering — blocks potentially sensitive or harmful content | **Recommended minimum for FSI Zone 2 and Zone 3** |
+| **Highest** | Maximum available filtering — most restrictive option | Recommended for highest-risk Zone 3 customer-facing or regulated agents |
 
-> There is no level above **High**. Any documentation referencing a `Strict` level is incorrect — `Strict` is not a Copilot Studio content-moderation value.
+> **Severity-threshold mapping.** Exact Azure AI Content Safety severity thresholds per slider position are not publicly enumerated for all five positions in Microsoft Learn at this writing. The directional intent is **Lowest = most permissive**, **Highest = strictest**, with Medium / High covering the documented FSI minimums. When designing the §4 test matrix below, anchor expectations to **Microsoft Learn at the time of testing** and record any drift in the configuration baseline.
 
 **Steps (per in-scope agent):**
 
 1. Copilot Studio → open the agent (e.g., `1.8-TEST-Agent-Z2`).
 2. **Settings** → **Generative AI** → **Content moderation**.
-3. Set the level per the FSI guidance column above:
+3. Set the slider position per the FSI guidance column above:
     - `1.8-TEST-Agent-Z1-Control` → **Medium** (baseline)
     - `1.8-TEST-Agent-Z2` → **High**
-    - `1.8-TEST-Agent-Z3` → **High**
+    - `1.8-TEST-Agent-Z3` → **High** (or **Highest** for the highest-risk customer-facing agents)
 4. Save.
 5. Screenshot per agent: `1.8-RTP-04d-<agent-id>_<UTC>_<test-id>_content-moderation-level.png`.
 

--- a/docs/playbooks/control-implementations/1.8/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.8/troubleshooting.md
@@ -5,7 +5,7 @@
 **Audience:** Power Platform Admin, Microsoft Defender XDR System Administrator, AI Governance Lead, SOC Analyst
 **Last UI Verified:** February 2026
 
-> **Scope.** This playbook diagnoses runtime-protection failures across the four enforcement surfaces of Control 1.8: (1) native Defender for Cloud Apps **AI Agent Protection** (real-time evaluation through the Microsoft 365 App Connector), (2) **Additional Threat Detection** webhook callout from Microsoft Copilot Studio to an external security provider, (3) **Prompt Shields** for jailbreak/indirect-injection defense, and (4) **content moderation** Low/Medium/High thresholds. It also covers the **AI Security Posture Management (AISPM)** dashboard surface and per-agent **Responsible AI (RAI) App Insights** telemetry. Classic (non-generative) Copilot Studio agents are out of scope for Defender AI Agent Protection — see §4 for details.
+> **Scope.** This playbook diagnoses runtime-protection failures across the four enforcement surfaces of Control 1.8: (1) native Defender for Cloud Apps **AI Agent Protection** (real-time evaluation through the Microsoft 365 App Connector), (2) **Additional Threat Detection** webhook callout from Microsoft Copilot Studio to an external security provider, (3) **Prompt Shields** for jailbreak/indirect-injection defense, and (4) **agent-level content moderation slider** (5 positions: Lowest / Low / Medium / High / Highest). It also covers the **AI Security Posture Management (AISPM)** dashboard surface and per-agent **Responsible AI (RAI) App Insights** telemetry. Classic (non-generative) Copilot Studio agents are out of scope for Defender AI Agent Protection — see §4 for details. The separate **per-prompt** moderation slider (3 positions: Low / Moderate / High, managed GPT models only) inside the prompt builder is governed by Control 1.27, not this playbook.
 
 > **Two-portal architecture.** Control 1.8 is enforced through **two portals that must be configured in handshake**: Microsoft Defender XDR portal (`security.microsoft.com`) for the Defender side, and Power Platform Admin Center (`admin.powerplatform.microsoft.com`) for the Copilot Studio side. A toggle in one portal without the matching toggle in the other produces silent failure — see §2 row 1 and §6.1.
 
@@ -64,7 +64,7 @@ Runtime-protection remediation often involves toggling Defender or PPAC settings
 2. **Defender XDR toggle state** — screenshot of `Defender XDR → Settings → Cloud apps → AI Agent Protection` showing preview opt-in and Connector binding. Capture the M365 App Connector status (Connected / Disconnected / Error).
 3. **M365 App Connector health** — `Defender XDR → Settings → Cloud apps → App Connectors → Microsoft 365` last-sync timestamp and any error string.
 4. **FIC (federated identity credential) configuration** — for each agent that calls an external webhook, capture the FIC subject, issuer, and audience values from the App Registration (`Entra ID → App registrations → <app> → Certificates & secrets → Federated credentials`). Mismatched FIC produces 401 from the webhook but the agent may still respond — see §6.5.
-5. **Content moderation level snapshot** — for each affected agent, the configured Low / Medium / High level for hate, sexual, violence, self-harm. Export via Copilot Studio admin API or screenshot from the agent's `Settings → Generative AI → Content moderation`.
+5. **Content moderation level snapshot** — for each affected agent, the configured agent-level slider position (Lowest / Low / Medium / High / Highest) for hate, sexual, violence, self-harm. Export via Copilot Studio admin API or screenshot from the agent's `Settings → Generative AI → Content moderation`.
 6. **App Insights connection string per agent** — RAI telemetry binding for each affected agent. Without per-agent App Insights, `RAI:ContentFiltered`, `RAI:JailbreakDetected`, and `RAI:GroundingFailed` events are not retrievable for that agent. Capture the resource ID and the connection string redacted (last-4 only) for evidence.
 7. **AISPM dashboard screenshot** — current alert list, suppressed alerts, and the timestamp of the last AISPM refresh (note the up-to-15-minute latency disclaimer).
 8. **CloudAppEvents export (Defender)** — Advanced hunting export covering the failure window plus 24 hours before/after. Use the Learn-documented `CloudAppEvents` schema; this is operational telemetry, **not** a books-and-records source — see disclaimer below.
@@ -526,7 +526,7 @@ Configuration confirmed correct (per FSI Control 1.8 §6 troubleshooting):
 - [x] errorBehavior = Block for affected agent(s)
 - [x] FIC binding validated (subject/issuer/audience match Learn doc for <cloud>)
 - [x] Per-agent App Insights connection string present
-- [x] Content moderation level confirmed (Low|Medium|High) and matches Zone policy
+- [x] Content moderation level confirmed (Lowest|Low|Medium|High|Highest) and matches Zone policy
 
 Recent configuration changes (last 14 days):
 - <date> — <change> — <change ticket id>
@@ -576,7 +576,7 @@ Microsoft Support typical first response is per the contracted SLA (Premier: sev
 | [1.10 — Communication Compliance Monitoring](../../../controls/pillar-1-security/1.10-communication-compliance-monitoring.md) | Surfaces policy violations in agent input/output for supervisory review. Runtime protection (1.8) blocks; Communication Compliance (1.10) supervises and routes to a reviewer. Together they help satisfy supervision under FINRA Rule 3110. |
 | [1.21 — Adversarial Input Logging](../../../controls/pillar-1-security/1.21-adversarial-input-logging.md) | Captures jailbreak / prompt-injection attempts for forensic review. Companion to 1.8 — runtime protection blocks; 1.21 ensures the attempt is preserved for analysis and trend-detection. |
 | [1.24 — Defender AI Security Posture Management](../../../controls/pillar-1-security/1.24-defender-ai-security-posture-management.md) | The AISPM dashboard and posture surface referenced throughout §1.3, §1.5, and §6 of this playbook. 1.24 governs the dashboard configuration; 1.8 governs the runtime enforcement that feeds it. |
-| [1.27 — AI Agent Content Moderation Enforcement](../../../controls/pillar-1-security/1.27-ai-agent-content-moderation-enforcement.md) | Sets the Low/Medium/High content-moderation thresholds enforced at runtime by 1.8. §6.8 of this playbook references the 1.27 zone-minimum policy. |
+| [1.27 — AI Agent Content Moderation Enforcement](../../../controls/pillar-1-security/1.27-ai-agent-content-moderation-enforcement.md) | Governs the **per-prompt** moderation slider (3 positions: Low / Moderate / High) inside the prompt builder for managed GPT models. Complementary to the **agent-level** slider (5 positions: Lowest / Low / Medium / High / Highest) enforced at runtime by 1.8. §6.8 of this playbook references the 1.27 zone-minimum policy where it overlaps. |
 
 ### 8.2 Sibling 1.8 playbooks
 

--- a/docs/playbooks/control-implementations/1.8/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.8/verification-testing.md
@@ -310,18 +310,21 @@ Every test in this catalog follows the same format: **Objective → Precondition
 
 ### Content moderation matrix tests (CMH-01..04, CMS-01..04, CMV-01..04, CMSH-01..04)
 
-**Matrix design.** Copilot Studio content moderation enforces per-category × per-severity blocking. The four categories under test are **Hate (CMH)**, **Sexual (CMS)**, **Violence (CMV)**, and **Self-Harm (CMSH)**. The four severity levels under test are **Safe (0)**, **Low (2)**, **Medium (4)**, and **High (6)**. Reference [Azure AI Content Safety harm categories](https://learn.microsoft.com/azure/ai-services/content-safety/concepts/harm-categories).
+**Matrix design.** Copilot Studio content moderation enforces per-category × per-severity blocking via the **agent-level** content-moderation slider (5 positions: **Lowest / Low / Medium / High / Highest**) at `Settings → Generative AI → Content moderation`. The four categories under test are **Hate (CMH)**, **Sexual (CMS)**, **Violence (CMV)**, and **Self-Harm (CMSH)**. The four classifier severity levels under test are **Safe (0)**, **Low (2)**, **Medium (4)**, and **High (6)** — these are the Azure AI Content Safety severity taxonomy ([harm-categories](https://learn.microsoft.com/azure/ai-services/content-safety/concepts/harm-categories)) and are independent of the slider positions.
 
-For each category, the firm's Red Team prompt library contains four severity-graded test prompts. Each agent's content-moderation level setting determines which severities are blocked:
+For each category, the firm's Red Team prompt library contains four severity-graded test prompts. Each agent's content-moderation slider position determines which classifier severities are blocked:
 
-| Agent moderation level | Blocks at severity ≥ |
-|---|---|
-| Off | (no blocks) |
-| Low | 6 (High only) |
-| Medium | 4 (Medium and High) |
-| High | 2 (Low, Medium, and High) |
+| Agent-level slider position | Blocks at classifier severity ≥ | Notes |
+|---|---|---|
+| Lowest | (effectively no blocks — most permissive available) | Microsoft does not publish a precise severity threshold for **Lowest**; treat as functionally equivalent to no moderation for test design |
+| Low | 6 (High only) | Documented behavior |
+| Medium | 4 (Medium and High) | Documented behavior |
+| High | 2 (Low, Medium, and High) | Documented behavior |
+| Highest | 2 (Low, Medium, and High) — and may apply stricter classifier weighting | Microsoft does not publish a precise severity-threshold delta for **Highest** vs **High**; assume Highest is at least as strict as High and possibly stricter on borderline classifications |
 
-For Zone 2 and Zone 3 agents this control requires content moderation **High**, so the expected pass behavior is: severity 0 (Safe) responses pass, severity 2/4/6 prompts are blocked.
+> **Severity-threshold caveat.** Exact severity thresholds for the **Lowest** and **Highest** slider positions are not publicly enumerated in Microsoft Learn at this writing. The directional intent is **Lowest = most permissive**, **Highest = strictest available**. Anchor expectations to Microsoft Learn at the time of testing and record any drift.
+
+For Zone 2 and Zone 3 agents this control requires the agent-level slider be set to **High** (or **Highest** for the highest-risk customer-facing Zone 3 agents), so the expected pass behavior is: severity 0 (Safe) responses pass, severity 2/4/6 prompts are blocked.
 
 **Per-test naming convention.**
 
@@ -1096,7 +1099,7 @@ The following patterns are commonly observed during external review and produce 
 5. **Webhook test using a placeholder payload.** A request with body ``{"test": true}`` does NOT validate Additional Threat Detection. The webhook receiver MUST receive the real Microsoft-defined Copilot Studio payload schema (prompt + tool context + user metadata) with a valid FIC-bound JWT — anything else is a connectivity test, not a control test.
 6. **``errorBehavior=Allow`` in Zone 2 or Zone 3.** This converts a security control into a graceful-degradation convenience. For Z2/Z3 the firm-recommended value is ``Block``; ``Allow`` is acceptable only in Z1. ERR-01 + NEG-04 verify the fail-closed posture.
 7. **Treating DCA AI Agents inventory as a books-and-records source.** Inventory is a posture surface, not a records-retention store. Records retention lives in [Control 1.7](../1.7/portal-walkthrough.md) and [Control 1.9](../1.9/portal-walkthrough.md). Using inventory data as evidence for FINRA 4511 / SEC 17a-4 retention is an overclaim.
-8. **Confusing Prompt Shields with Copilot Studio's in-product moderation slider.** Prompt Shields is the underlying Azure AI Content Safety capability for direct (UPIA) and indirect (XPIA) injection. The Copilot Studio moderation level (Off / Low / Medium / High) controls the four-category × four-severity classifier. The two are related but not interchangeable; tests in §4 cover both surfaces (PSX-01..03 for shields, CMH/CMS/CMV/CMSH for the slider).
+8. **Confusing Prompt Shields with Copilot Studio's in-product moderation slider.** Prompt Shields is the underlying Azure AI Content Safety capability for direct (UPIA) and indirect (XPIA) injection. The Copilot Studio **agent-level** moderation slider (5 positions: **Lowest / Low / Medium / High / Highest**) at `Settings → Generative AI → Content moderation` controls the four-category × four-severity classifier. The two are related but not interchangeable; tests in §4 cover both surfaces (PSX-01..03 for shields, CMH/CMS/CMV/CMSH for the agent-level slider). The separate **per-prompt** slider (3 positions: Low / Moderate / High) inside the prompt builder for managed GPT models is a third, distinct surface governed by Control 1.27.
 9. **KQL ``ActionType`` drift treated as "no events".** A hard-coded ``ActionType`` string that Microsoft has renamed silently returns zero rows. CAE-01's schema-drift guard runs first to catch this. A ``CloudAppEvents | where ActionType == "<old-value>"`` query returning zero rows is NOT evidence of "no activity" — verify the schema first.
 10. **Treating classic (non-generative) bot tests as Copilot Studio agent evidence.** Copilot Studio runtime protection applies to **generative agents**. A test executed against a classic Power Virtual Agents bot or a non-generative dialog flow does not exercise the controls under test in this playbook. Confirm the agent under test is a Copilot Studio generative agent before recording any §4 test as PASS.
 


### PR DESCRIPTION
## Summary
Closes SD-11 (P1). Section D verification sweep against workshop handoff fact #11 found Controls 1.27 and 1.8 blend two distinct Copilot Studio moderation UI surfaces. Corrected.

## Canonical scales (per Microsoft, verbatim from workshop handoff)
- **Agent-level moderation slider** (agent settings): **5 positions** — `Lowest / Low / Medium / High / Highest`
- **Per-prompt moderation slider** (managed GPT models only, in prompt/topic config): **3 positions** — `Low / Moderate / High`

## Files corrected
- `docs/controls/pillar-1-security/1.27-ai-agent-content-moderation-enforcement.md` — per-prompt surface (3 positions). Medium → Moderate throughout; added disambiguation note; updated footer to May 2026.
- `docs/controls/pillar-1-security/1.8-runtime-protection-and-external-threat-detection.md` — agent-level surface (5 positions). Expanded 3-row Low/Medium/High table to 5-row Lowest/Low/Medium/High/Highest; added disambiguation note; updated verification criteria.

## Cascade fixes applied
- `docs/images/1.27/EXPECTED.md` — per-prompt screenshot specs: Medium → Moderate (with "Medium" noted as legacy UI synonym); reframed "Agent-Level" headings to "Agent-Effective Default" (the per-prompt setting on the system topic). Added explicit pointer to the separate 5-position agent-level surface.
- `docs/images/1.8/EXPECTED.md` — no slider-scale references, no change required.
- `docs/playbooks/advanced-implementations/configuration-hardening-baseline/index.md` — item 10 (agent-level slider): expanded label to 5-position scale; added cross-reference note distinguishing from the per-prompt surface.
- `docs/playbooks/control-implementations/1.8/portal-walkthrough.md` — section 4d (agent-level surface): replaced "three content-moderation levels" with the 5-position scale; corrected the previous incorrect claim that "there is no level above High" (Highest exists); updated section header, parity table, and steps. Also updated lines 116, 128, and 224 to use the 5-position label.
- `docs/playbooks/control-implementations/1.8/troubleshooting.md` — agent-level surface: scope statement (§ intro), evidence item 5, pre-escalation checklist, support template, and cross-reference to 1.27 all updated to use 5 positions and to distinguish the two surfaces.
- `docs/playbooks/control-implementations/1.8/verification-testing.md` — expanded the CMH/CMS/CMV/CMSH matrix table from 3 slider positions to 5, distinguished classifier severity (Safe/Low/Medium/High Azure CS taxonomy) from slider positions, and added a severity-threshold caveat for Lowest/Highest (not publicly enumerated in Learn). Updated the §8 anti-pattern entry that previously listed "(Off / Low / Medium / High)".
- `docs/playbooks/control-implementations/1.8/powershell-setup.md` — no slider-scale references, no change required.
- `assessment/manifest/controls.json` — `1.27.b` description changed from "Medium for Z2" to "Moderate for Z2" (per-prompt surface, 3 positions). No structural changes to checks, zone thresholds, or scoring logic; the assessment evaluator passes a moderation_level string through unchanged so it remains compatible with either label.
- `assessment/manifest/generate_manifest.py` — mirror description change so regenerated manifests stay consistent.

## Cascade scope was wider than the original handoff listed
The handoff listed primary (1.27 + 1.8 controls), screenshot specs, configuration-hardening baseline, and assessment evaluator. Investigation found the **1.8 implementation playbooks** (portal-walkthrough, troubleshooting, verification-testing) contained extensive, detailed Low/Medium/High slider references — including an explicit (incorrect) claim that "there is no level above High". Fixed all of these in scope per the handoff's "accuracy is the priority" guidance. The **1.27 implementation playbooks** were already largely correct (Moderate used; explicit "Medium ≡ Moderate" notes); no changes needed there.

## Assessment evaluator scope note
The assessment manifest checks `1.27.a`, `1.27.b`, and `1.27.c` use string-based pass conditions (`moderation_level_set`, `moderation_zone_compliant`, `safety_messages_configured`) that pass the collected slider value through to the engine as an opaque label. The engine does not hard-code "Low/Medium/High" anywhere I could find (`grep` across `assessment/`). The check description text was the only place needing correction. Zone-threshold scoring (1/2/4 maturity bands) is unchanged. **No separate finding raised** — the change is self-contained at the manifest-description layer.

## Validation
- `python scripts/verify_language_rules.py` ✅
- `python scripts/verify_controls.py` ✅
- `python scripts/verify_xref_graph.py` ✅ (6359 refs, 0 broken)
- `python scripts/check_manifest_doc_drift.py --check` ✅ (78 IDs across manifest / CONTROL-INDEX / nav)
- `python scripts/generate_coverage_matrix.py --check` ✅
- `mkdocs build --strict` ✅
- `pytest assessment/tests/` ✅ — **152 tests pass, no regression**

Closes SD-11.
