### PR TITLE
docs: fix homepage icon shortcode rendering on GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!--start-->
 
+## [Unreleased]
+
+### Fixed
+- Replaced non-rendering Material shortcode markup on the homepage quick-start cards (`docs/index.md`) with plain text labels so GitHub Pages no longer displays literal `:material-*:` tokens.
+
+### Changed
+- Added explicit Markdown authoring guidance in `README.md` and `CONTRIBUTING.md` to avoid `:material-*:` shortcodes in page content under the current CSP-safe MkDocs emoji configuration.
+
 ## [1.6.2] — May 11, 2026 (Frontier Readiness auto-evaluator wave)
 
 **Release theme:** Six-PR wave wiring telemetry-driven auto-scoring for the Frontier Readiness assessment, taking auto-evaluable coverage from **0/25 (0%)** to **6/25 (24%)**. After this release, the Frontier auto-evaluable backlog is **structurally exhausted** — the remaining 19 questions (76%) are facilitator-only by design (board attestation, written policy text, executive interviews, regulatory committee minutes, business strategy alignment) and cannot be honestly derived from M365/PPAC/Sentinel/SharePoint telemetry.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ Thank you for your interest in contributing to the FSI Agent Governance Framewor
 - Use Markdown with consistent formatting
 - Include version footer on all pages
 - Reference control IDs where applicable
+- Avoid Material icon shortcodes (`:material-*:`) in page content; with the current MkDocs emoji/CSP configuration they may render as literal text on GitHub Pages
+- Prefer plain text labels (for example `Start Here ->`) or standard Unicode symbols in Markdown content
 
 ### Control Files
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ Run these from the repo root (`FSI-AgentGov/`):
 - `python scripts/verify_excel_templates.py`
 - `mkdocs build --strict`
 
+### Markdown Icon Rendering Guidance
+
+- Do not use Material icon shortcodes such as `:material-*:` inside docs page content.
+- This repository uses `pymdownx.emoji.to_alt` in `mkdocs.yml` for CSP-safe output, so Material shortcodes can render as literal text on GitHub Pages.
+- Use plain text labels (for example `Start Here ->`) or standard Unicode symbols when icon emphasis is needed in Markdown content.
+
 ### Quick Reference Resources
 
 | Resource | Description | Location |

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,50 +44,50 @@ agent deployments.
 
 <div class="grid cards" markdown>
 
--   :material-shield-check:{ .lg .middle } **Compliance Officer**
+-   **Compliance Officer**
 
     ---
 
     Map controls to FINRA, SEC, SOX, and GLBA requirements.
     Build examination-ready evidence packs.
 
-    [:material-arrow-right: Start Here](framework/executive-summary.md)
+    [Start Here ->](framework/executive-summary.md)
 
--   :material-cog:{ .lg .middle } **Power Platform Admin**
+-   **Power Platform Admin**
 
     ---
 
     Deploy controls, run playbooks, and configure
     governance across your M365 tenant.
 
-    [:material-arrow-right: Start Here](controls/index.md)
+    [Start Here ->](controls/index.md)
 
--   :material-security:{ .lg .middle } **IT Security / InfoSec**
+-   **IT Security / InfoSec**
 
     ---
 
     Implement DLP, audit logging, encryption, MFA,
     and 29 security controls across your tenant.
 
-    [:material-arrow-right: Start Here](controls/pillar-1-security/index.md)
+    [Start Here ->](controls/pillar-1-security/index.md)
 
--   :material-file-document-check:{ .lg .middle } **Examination Readiness**
+-   **Examination Readiness**
 
     ---
 
     Prepare for FINRA/SEC examinations with
     evidence standards and audit checklists.
 
-    [:material-arrow-right: Start Here](playbooks/compliance-and-audit/audit-readiness-checklist.md)
+    [Start Here ->](playbooks/compliance-and-audit/audit-readiness-checklist.md)
 
--   :material-account-tie:{ .lg .middle } **Business Owner**
+-   **Business Owner**
 
     ---
 
     Understand zone requirements and the agent
     approval lifecycle for your team.
 
-    [:material-arrow-right: Start Here](framework/zones-and-tiers.md)
+    [Start Here ->](framework/zones-and-tiers.md)
 
 </div>
 


### PR DESCRIPTION
## Summary
- replace non-rendering :material-*: shortcodes in docs/index.md quick-start cards with plain text labels
- add README and CONTRIBUTING guidance to avoid Material shortcodes in page content under current MkDocs emoji/CSP settings
- add changelog entry under Unreleased

## Why
GitHub Pages was rendering :material-*: tokens literally on the home page.

## Validation
- python scripts/verify_language_rules.py passes
- mkdocs build --strict still reports existing pre-existing warning about docs/images/README.md and docs/images/VERIFY.md not in nav