### PR TITLE
fix(docs): repair 9 broken external URLs across controls and playbooks

### DIFF
--- a/docs/controls/pillar-1-security/1.23-step-up-authentication-for-agent-operations.md
+++ b/docs/controls/pillar-1-security/1.23-step-up-authentication-for-agent-operations.md
@@ -194,7 +194,7 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Privileged Identity Management — configure role settings](https://learn.microsoft.com/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings)
 - [Microsoft Learn: Conditional Access for workload identities](https://learn.microsoft.com/entra/identity/conditional-access/workload-identity)
 - [NIST SP 800-63B: Digital Identity Guidelines (Authentication)](https://pages.nist.gov/800-63-3/sp800-63b.html)
-- [NIST SP 800-53 Rev. 5: IA-2 Identification and Authentication](https://csrc.nist.gov/projects/risk-management/sp800-53-controls/release-search#!/control?version=5.1&number=IA-2)
+- [NIST SP 800-53 Rev. 5: IA-2 Identification and Authentication](https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_2_0/home?element=IA-2)
 - [NYDFS 23 NYCRR 500.12: Multi-Factor Authentication](https://www.dfs.ny.gov/industry_guidance/cybersecurity)
 
 ---

--- a/docs/controls/pillar-2-management/2.8-access-control-and-segregation-of-duties.md
+++ b/docs/controls/pillar-2-management/2.8-access-control-and-segregation-of-duties.md
@@ -187,7 +187,7 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Implement a zoned governance strategy (Copilot Studio)](https://learn.microsoft.com/en-us/microsoft-copilot-studio/guidance/sec-gov-phase2)
 - [Microsoft Learn: Control maker-provided credentials in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/configure-no-maker-authentication)
 - [Microsoft Learn: Continuous Access Evaluation](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-continuous-access-evaluation)
-- [NIST SP 800-53 Rev. 5 — AC-5 Separation of Duties](https://csrc.nist.gov/projects/risk-management/sp800-53-controls/release-search#!/control?version=5.1&number=AC-5)
+- [NIST SP 800-53 Rev. 5 — AC-5 Separation of Duties](https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_2_0/home?element=AC-5)
 - [Microsoft Learn: Enhanced admin controls for agent security (Preview)](https://learn.microsoft.com/en-us/power-platform/release-plan/2026wave1/power-platform-governance-administration/manage-copilot-security-enhanced-admin-controls)
 - [Microsoft Learn: Safe sharing by detecting credential oversharing (Preview)](https://learn.microsoft.com/en-us/power-platform/release-plan/2026wave1/microsoft-copilot-studio/enforce-safe-sharing-detecting-credential-oversharing)
 

--- a/docs/controls/pillar-3-reporting/3.11-centralized-agent-inventory-enforcement.md
+++ b/docs/controls/pillar-3-reporting/3.11-centralized-agent-inventory-enforcement.md
@@ -169,7 +169,7 @@ Microsoft's PL-900 certification (Microsoft Certified: Power Platform Fundamenta
     - Dataverse-persisted enforcement history for audit trail
     - SHA-256 integrity-hashed evidence export for regulatory examination
 
-    **Deployable Solution:** [agent-inventory-enforcement-monitor](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/agent-inventory-enforcement-monitor) provides PowerShell validation scripts, Power Automate flow definitions, Dataverse schema, and compliance reporting templates.
+    **Deployable Solution:** [agent-registry-automation](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/agent-registry-automation) provides PowerShell validation scripts, Power Automate flow definitions, Dataverse schema, and compliance reporting templates.
 
 ---
 

--- a/docs/controls/pillar-3-reporting/3.8-copilot-hub-and-governance-dashboard.md
+++ b/docs/controls/pillar-3-reporting/3.8-copilot-hub-and-governance-dashboard.md
@@ -460,7 +460,7 @@ To support SEC 17a-4(f) WORM (Write Once, Read Many) requirements and audit inte
 
 !!! tip "Governance Script: Zone Access Validation"
 
-    `Test-ZoneAgentAccess.ps1` validates M365 Admin Center agent access settings against zone-based governance policies. Checks agent access policy alignment (Zone 1: all agents, Zone 2: Org + Microsoft verified, Zone 3: Org only), admin exclusion group membership, staged deployment group configuration, and web search controls — with drift detection and adaptive card alerting via `adaptive-card-zone-access-alert.json` (in [FSI-AgentGov-Solutions](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/agent-access-monitor/src)).
+    `Test-ZoneAgentAccess.ps1` validates M365 Admin Center agent access settings against zone-based governance policies. Checks agent access policy alignment (Zone 1: all agents, Zone 2: Org + Microsoft verified, Zone 3: Org only), admin exclusion group membership, staged deployment group configuration, and web search controls — with drift detection and adaptive card alerting via `adaptive-card-zone-access-alert.json` (in [FSI-AgentGov-Solutions](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/agent-access-monitor/scripts)).
 
     **Script Location:** `scripts/governance/Test-ZoneAgentAccess.ps1`
 

--- a/docs/playbooks/advanced-implementations/deny-event-correlation-report/index.md
+++ b/docs/playbooks/advanced-implementations/deny-event-correlation-report/index.md
@@ -185,9 +185,8 @@ The FSI-AgentGov-Solutions repository provides deployable components:
 **Solution Documentation:**
 
 - [prerequisites.md](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/deny-event-correlation-report/docs/prerequisites.md) — Licensing, permissions, infrastructure requirements
-- [SCHEMA.md](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/deny-event-correlation-report/docs/SCHEMA.md) — Dataverse table definitions and relationships
-- [FLOW_SETUP.md](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/deny-event-correlation-report/docs/FLOW_SETUP.md) — Power Automate orchestration configuration
-- [EVIDENCE_EXPORT.md](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/deny-event-correlation-report/docs/EVIDENCE_EXPORT.md) — SHA-256 evidence package setup
+- [architecture.md](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/deny-event-correlation-report/docs/architecture.md) — Solution architecture, data flow, and Dataverse schema
+- [README.md](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/deny-event-correlation-report/README.md) — Solution overview, Power Automate orchestration, and evidence export configuration
 - [troubleshooting.md](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/deny-event-correlation-report/docs/troubleshooting.md) — Common issues and resolution steps
 
 ---
@@ -203,7 +202,7 @@ The v2.0.0 solution uses a 4-table Dataverse schema for persistent storage of de
 | **fsi_DenyAlert** | Generated alerts with routing metadata | fsi_deny_alert_id, fsi_alert_severity, fsi_alert_type, fsi_acknowledged |
 | **fsi_DenyValidationHistory** | Validation and extraction audit trail | fsi_deny_validation_id, fsi_run_timestamp, fsi_records_processed, fsi_export_status |
 
-> **Note:** Key fields shown are primary columns. See [SCHEMA.md](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/deny-event-correlation-report/docs/SCHEMA.md) for canonical column definitions and data types.
+> **Note:** Key fields shown are primary columns. See [architecture.md](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/deny-event-correlation-report/docs/architecture.md) for canonical column definitions and data types.
 
 **Relationships:** fsi_DenyEvent → fsi_DenyCorrelation (many-to-one), fsi_DenyCorrelation → fsi_DenyAlert (one-to-many), evidence exports reference fsi_DenyCorrelation records.
 
@@ -357,7 +356,7 @@ For complete scalability guidance, see the [Solutions Architecture Guide](../../
 1. **Read [Purview Audit Extraction](purview-audit-extraction.md)** to understand CopilotInteraction deny events
 2. **Configure [App Insights RAI Telemetry](app-insights-rai-telemetry.md)** for Copilot Studio agents
 3. **Deploy Dataverse schema** from the FSI-AgentGov-Solutions repository
-4. **Configure Power Automate flow** using [FLOW_SETUP.md](https://github.com/judeper/FSI-AgentGov-Solutions/tree/main/deny-event-correlation-report/docs/FLOW_SETUP.md)
+4. **Configure Power Automate flow** using the [solution README](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/deny-event-correlation-report/README.md)
 5. **Set up Teams alerting** and configure severity routing
 6. **Schedule daily extraction** and verify correlation results in Compliance Dashboard
 

--- a/docs/playbooks/control-implementations/1.8/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.8/verification-testing.md
@@ -1131,7 +1131,7 @@ The following patterns are commonly observed during external review and produce 
 
 ### Regulatory windows referenced in §1 and §7
 
-- **NY DFS 23 NYCRR 500.17** — 72-hour cybersecurity event notification ([text](https://www.dfs.ny.gov/industry_guidance/cyber_faqs))
+- **NY DFS 23 NYCRR 500.17** — 72-hour cybersecurity event notification ([text](https://www.dfs.ny.gov/industry_guidance/cybersecurity))
 - **SEC Reg S-P §248.30(a)(4)** — incident response and customer notification ([text](https://www.sec.gov/files/rules/final/2024/34-100155.pdf))
 - **FINRA Rule 4530** — reporting requirements ([text](https://www.finra.org/rules-guidance/rulebooks/finra-rules/4530))
 - **FINRA Rule 4511** / **SEC 17a-4(b)(4)** — books-and-records retention (verified under Controls 1.7 and 1.9, not this control)

--- a/docs/playbooks/control-implementations/2.22/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.22/troubleshooting.md
@@ -378,7 +378,7 @@
 
 4. **If the format appears valid but still fails:**
    - Check for leading/trailing whitespace or null characters in `fsi_errorraw`
-   - Verify the flow's `Parse_Duration_Minutes` compose expression matches the current supported formats in [SOLUTION-DOCUMENTATION.md Appendix: ISO 8601 Duration Parsing](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/inactivity-timeout-enforcement/SOLUTION-DOCUMENTATION.md)
+   - Verify the flow's `Parse_Duration_Minutes` compose expression matches the current supported formats in [Inactivity Timeout Enforcement README — ISO 8601 Duration Parsing](https://github.com/judeper/FSI-AgentGov-Solutions/blob/main/inactivity-timeout-enforcement/README.md)
 
 **Root Cause:** The BAP Admin API returned an inactivity timeout duration in a format not handled by the flow's ISO 8601 parser (e.g., `P1D` for 1 day instead of `PT1440M`). This is a platform behavior — the flow cannot automatically handle all possible ISO 8601 variants.
 


### PR DESCRIPTION
## Comprehensive Documentation & URL Review — Issue #38

### Summary
Full scan of 625 markdown docs and 78 control files in FSI-AgentGov. Checked 972 external URLs (704 Microsoft Learn + 268 others) and all internal link references.

### Findings

**URLs checked:**
- ✅ 704 Microsoft Learn URLs — all valid, none stale
- ✅ 259 non-Microsoft URLs — valid
- ❌ 9 broken external URLs — **fixed in this PR**

**Broken URLs fixed:**

| File | Issue | Fix |
|------|-------|-----|
| deny-event-correlation-report/index.md | 3 refs to renamed docs (SCHEMA.md, FLOW_SETUP.md, EVIDENCE_EXPORT.md) | Updated to current filenames (architecture.md, README.md) |
| 3.8 Copilot Hub & Governance Dashboard | `agent-access-monitor/src` → 404 | Changed to `/scripts` |
| 3.11 Centralized Agent Inventory | `agent-inventory-enforcement-monitor` → 404 | Changed to `agent-registry-automation` |
| 2.22 troubleshooting playbook | `SOLUTION-DOCUMENTATION.md` → 404 | Changed to `README.md` |
| 1.8 verification-testing playbook | NY DFS `cyber_faqs` → 404 | Changed to `cybersecurity` |
| 1.23 Step-up Authentication | CSRC old search URL → redirect to generic page | Updated to new CPRT catalog URL with element anchor |
| 2.8 Access Control & SoD | CSRC old search URL → redirect to generic page | Updated to new CPRT catalog URL with element anchor |

**Other validations — all passing:**
- ✅ `mkdocs build --strict` — zero errors/warnings
- ✅ `verify_controls.py` — all 78 controls have required 10-section structure
- ✅ `verify_language_rules.py` — no prohibited FSI language found
- ✅ All control footers at v1.6.2
- ✅ No stale `docs.microsoft.com` references (all already `learn.microsoft.com`)
- ✅ Regulatory references (OCC, FINRA, SEC, NIST) current and correctly cited

### What was NOT changed
- No content rewrites (only URL fixes)
- No structural changes to controls
- No navigation changes

Closes judeper/OceanSquad#38