### PR TITLE
docs(pillar-2): validate management controls — update dates and fix stale URL

### DIFF
--- a/docs/controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md
+++ b/docs/controls/pillar-2-management/2.11-bias-testing-and-fairness-assessment.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.11<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** Fed SR 26-2 (formerly SR 11-7), OCC Bulletin 2026-13 (formerly OCC 2011-12), ECOA / Reg B (15 U.S.C. § 1691, 12 CFR Part 1002), FINRA Rule 3110, FINRA 2026 Annual Regulatory Oversight Report (AI focus), CFPB Circular 2023-03 (adverse action notices using AI), NIST AI RMF (MEASURE-2.11)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md
+++ b/docs/controls/pillar-2-management/2.12-supervision-and-oversight-finra-rule-3110.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.12<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** FINRA Rule 3110 (Supervision), FINRA Rule 3120 (Supervisory Control System), FINRA Rule 2210 (Communications with the Public), FINRA Rule 4511 (Books and Records), FINRA Regulatory Notice 24-09 (Gen AI / LLM Guidance), SEC Rules 17a-3 / 17a-4 (Recordkeeping and WORM), SOX Sections 302 / 404 (Internal Controls), NYDFS 23 NYCRR 500 (Supervisory Review Analogue)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.13-documentation-and-record-keeping.md
+++ b/docs/controls/pillar-2-management/2.13-documentation-and-record-keeping.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.13<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** FINRA 4511, FINRA 3110, FINRA RN 24-09, SEC 17a-3, SEC 17a-4, SOX 302/404, GLBA 501(b), OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly SR 11-7), CFTC 1.31<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.14-training-and-awareness-program.md
+++ b/docs/controls/pillar-2-management/2.14-training-and-awareness-program.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.14<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** FINRA Rule 3110(a)(7), FINRA RN 24-09, SOX Section 404, GLBA Section 501(b), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.15-environment-routing.md
+++ b/docs/controls/pillar-2-management/2.15-environment-routing.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.15<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** OCC Bulletin 2026-13 (formerly OCC 2011-12), FINRA 3110, FINRA RN 24-09, GLBA 501(b), SOX 302/404<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.16-rag-source-integrity-validation.md
+++ b/docs/controls/pillar-2-management/2.16-rag-source-integrity-validation.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.16<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** Fed SR 26-2 (formerly SR 11-7), OCC Bulletin 2026-13 (formerly OCC 2011-12), Interagency Third-Party Guidance (2023), FINRA 4511, FINRA RN 24-09, FINRA Rule 3110<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.18-automated-conflict-of-interest-testing.md
+++ b/docs/controls/pillar-2-management/2.18-automated-conflict-of-interest-testing.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.18<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** SEC Reg BI, SEC Rule 10b-5, FINRA 2111, FINRA RN 24-09, FINRA Rule 3110<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.19-customer-ai-disclosure-and-transparency.md
+++ b/docs/controls/pillar-2-management/2.19-customer-ai-disclosure-and-transparency.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.19<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** SEC Reg BI, CFPB UDAAP, FINRA Rule 2210, FINRA Regulatory Notice 24-09 (Gen AI), SEC Rule 17a-4 / FINRA Rule 4511 (recordkeeping of AI communications), GLBA Section 501(b), State AI Laws (CA SB 1001, CA SB 243, CA AB 853, Utah AI Policy Act / SB 149, Colorado AI Act)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.20-adversarial-testing-and-red-team-framework.md
+++ b/docs/controls/pillar-2-management/2.20-adversarial-testing-and-red-team-framework.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.20<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12), Federal Reserve SR 26-2 (formerly SR 11-7), FINRA Rule 3110, FINRA RN 24-09, NIST AI RMF (with Generative AI Profile, NIST AI 600-1), MITRE ATLAS, OWASP Top 10 for LLM Applications (2025)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.21-ai-marketing-claims-and-substantiation.md
+++ b/docs/controls/pillar-2-management/2.21-ai-marketing-claims-and-substantiation.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.21<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** SEC Marketing Rule (Investment Advisers Act Rule 206(4)-1), FINRA Rule 2210, FINRA Regulatory Notice 24-09, FTC Act Section 5, State Unfair Trade Practices Laws<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.22-inactivity-timeout-enforcement.md
+++ b/docs/controls/pillar-2-management/2.22-inactivity-timeout-enforcement.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.22<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** GLBA 501(b), SOX 302, FINRA 4511, FINRA RN 24-09, SEC 17a-4(f), NIST 800-53 AC-11/AC-12<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.23-user-consent-and-ai-disclosure-enforcement.md
+++ b/docs/controls/pillar-2-management/2.23-user-consent-and-ai-disclosure-enforcement.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.23<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** FINRA Rule 3110, FINRA Rule 2210, FINRA RN 24-09, SEC 17a-4, GLBA Section 501(b), SOX Section 302/404, CFPB UDAAP guidance<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.4-business-continuity-and-disaster-recovery.md
+++ b/docs/controls/pillar-2-management/2.4-business-continuity-and-disaster-recovery.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.4<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** FFIEC Business Continuity Management (BCM) Handbook (Nov 2019); FINRA Rule 4370 (Business Continuity Plans); FINRA Rule 4511 / RN 24-09; SEC 17a-3 / 17a-4 (record retention and reconstruction); SOX 404 (internal controls); GLBA 501(b) (Safeguards Rule – availability); OCC Heightened Standards (12 CFR 30 Appendix D – risk governance); Interagency Paper on Sound Practices to Strengthen Operational Resilience (Oct 2020 – OCC / Fed / FDIC)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md
+++ b/docs/controls/pillar-2-management/2.5-testing-validation-and-quality-assurance.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.5<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** SOX Sections 302/404, FINRA Rule 4511, FINRA Rule 3110, FINRA RN 24-09, GLBA 501(b), SEC 17a-4(b)(4), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7), and NIST AI RMF 1.0 + Generative AI Profile (testing, measurement, and ongoing monitoring expectations)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md
+++ b/docs/controls/pillar-2-management/2.6-model-risk-management-sr-26-2.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.6<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) (Sound Practices for Model Risk Management), Federal Reserve SR 26-2 (formerly SR 11-7) (Supervisory Guidance on Model Risk Management), FDIC FIL-22-2017 (FDIC adoption of OCC Bulletin 2026-13 (formerly OCC 2011-12)), FFIEC IT Examination Handbook (Management; Information Security), FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), FINRA RN 24-09, SEC Rules 17a-3 / 17a-4 (Recordkeeping for model artifacts and validation evidence), SOX Sections 302 / 404 (Internal Controls over Financial Reporting), GLBA 501(b) (Safeguards Rule), NYDFS 23 NYCRR 500 (where AI agents touch covered customer information)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.7-vendor-and-third-party-risk-management.md
+++ b/docs/controls/pillar-2-management/2.7-vendor-and-third-party-risk-management.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.7<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** GLBA Section 501(b), SOX Section 404, FINRA Rule 4511, FINRA Rule 3110, FINRA Regulatory Notice 24-09, SEC Rule 17a-4(f), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) / Fed SR 26-2 (formerly SR 11-7), OCC Bulletin 2013-29, Interagency Guidance on Third-Party Relationships (FRB/FDIC/OCC, June 2023), OWASP LLM Top 10 (2025)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 
 ---

--- a/docs/controls/pillar-2-management/2.8-access-control-and-segregation-of-duties.md
+++ b/docs/controls/pillar-2-management/2.8-access-control-and-segregation-of-duties.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.8<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** SOX 302/404 (SoD over financially relevant systems), FINRA 3110 (supervisory separation), FINRA 4511, FINRA RN 24-09, GLBA 501(b), SEC 17a-4, OCC Heightened Standards (12 CFR 30 Appendix D), NIST SP 800-53 AC-5 (Separation of Duties) and AC-6 (Least Privilege)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---

--- a/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md
+++ b/docs/controls/pillar-2-management/2.9-agent-performance-monitoring-and-optimization.md
@@ -3,7 +3,7 @@
 **Control ID:** 2.9<br>
 **Pillar:** Management<br>
 **Regulatory Reference:** FINRA 4511, FINRA RN 24-09, FINRA Rule 3110, GLBA 501(b), SEC 17a-3/4, SOX 404, OCC Bulletin 2026-13 (formerly OCC 2011-12), Fed SR 26-2 (formerly SR 11-7)<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 
 ---
@@ -180,7 +180,7 @@ Confirm control effectiveness by verifying:
 - [Microsoft Learn: Power Platform Analytics](https://learn.microsoft.com/en-us/power-platform/admin/analytics-common-data-service)
 - [Microsoft Learn: Export Analytics to Azure (self-service analytics)](https://learn.microsoft.com/en-us/power-platform/admin/self-service-analytics)
 - [Microsoft Learn: Azure Monitor Alerts](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview)
-- [Microsoft Learn: Azure AI Evaluation SDK](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/evaluate-sdk)
+- [Microsoft Learn: Azure AI Evaluation SDK](https://learn.microsoft.com/en-us/azure/ai-foundry/how-to/develop/evaluate-sdk)
 - [Federal Reserve SR 26-2 (formerly SR 11-7): Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/SR2602.htm)
 - [OCC Bulletin 2026-13: Sound Practices for Model Risk Management (formerly OCC Bulletin 2011-12)](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12.html)
 


### PR DESCRIPTION
## Pillar 2 Management Controls — Validation Sweep

Closes judeper/OceanSquad#49

### Changes

**18 control files updated:**

- **Last UI Verified date**: Updated from `April 2026` to `May 2026` on 18 controls (2.4–2.9, 2.11–2.16, 2.18–2.23)
- **Stale URL fix**: Control 2.9 — Azure AI Evaluation SDK link updated from `azure/ai-studio/` to `azure/ai-foundry/` path

### Validation Summary

| Check | Result |
|-------|--------|
| Microsoft Learn URLs (36 spot-checked) | All 200 OK |
| Playbook completeness (104 files) | All present |
| FSI language rules | No violations |
| 10-section control structure | All valid |
| Footer dates/versions | All at May 2026 / v1.6.2 |
| `mkdocs build --strict` | Pass |
| `verify_controls.py` | Pass |
| `check_manifest_doc_drift.py` | Pass |
| `verify_language_rules.py` | Pass |

### Scope

- 26 control docs in `docs/controls/pillar-2-management/`
- 104 playbook files in `docs/playbooks/control-implementations/2.*/`
- Controls already at May 2026: 2.1, 2.2, 2.3, 2.10, 2.17, 2.24, 2.25, 2.26 (no changes needed)
