### PR TITLE
fix: Validation sweep — Pillar 1 controls 1.16-1.29 (Last Verified dates)

### DIFF
--- a/docs/playbooks/control-implementations/1.16/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.16/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.16 — Information Rights Management (IRM)
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portals:** Microsoft 365 Admin Center, Microsoft Purview, SharePoint Admin Center, individual SharePoint site
 **Estimated Time:** 2–4 hours (initial activation + first label + first library); add ~15 min per additional library
 **Sovereign cloud note:** SharePoint list / library IRM is supported in the Microsoft global cloud only. For GCC High and DoD tenants, validate availability with your Microsoft account team before publishing this control.

--- a/docs/playbooks/control-implementations/1.16/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.16/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show the surgical command surface for Control 1.16; the baseline is authoritative for the safe-execution wrapper.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** `AIPService` (Azure RMS), `PnP.PowerShell` v2+ (SharePoint), `ExchangeOnlineManagement` (label policies — read-only verification), optional `Microsoft.Graph` (audit log retrieval).
 
 ---

--- a/docs/playbooks/control-implementations/1.16/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.16/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.16 — Information Rights Management (IRM)
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 ---
 

--- a/docs/playbooks/control-implementations/1.16/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.16/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.16 — Information Rights Management (IRM)
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Cadence:** Initial implementation, then quarterly (Zone 3) / semi-annually (Zone 2) — aligned with [Control 1.18](../../../controls/pillar-1-security/1.18-application-level-authorization-and-role-based-access-control-rbac.md) access review cadence.
 
 ---

--- a/docs/playbooks/control-implementations/1.17/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.17/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.17 — Endpoint Data Loss Prevention (Endpoint DLP)
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portals:** Microsoft Purview (`https://purview.microsoft.com`), Microsoft Defender (`https://security.microsoft.com`), Microsoft Intune (`https://intune.microsoft.com`), Microsoft Entra (`https://entra.microsoft.com`)
 **Estimated Time:** 4–6 hours for an initial single-zone rollout; 1–2 days for full Zone 1/2/3 deployment with pilots
 

--- a/docs/playbooks/control-implementations/1.17/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.17/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** `ExchangeOnlineManagement` (for Security & Compliance PowerShell — `Connect-IPPSSession` and the `*-DlpCompliance*` cmdlet surface)
 
 ---

--- a/docs/playbooks/control-implementations/1.17/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.17/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.17 — Endpoint Data Loss Prevention
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 This playbook lists the most common issues encountered when deploying and operating Endpoint DLP. Each issue follows a consistent format: **Symptoms → Likely Cause → Diagnostic Steps → Fix → Reference**.
 
@@ -322,7 +322,7 @@ Re-test from the affected user account.
 
 ---
 
-## Known Limitations (April 2026)
+## Known Limitations (May 2026)
 
 | Limitation | Impact | Mitigation |
 |---|---|---|

--- a/docs/playbooks/control-implementations/1.18/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.18/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.18 - Application-Level Authorization and RBAC
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portal:** Power Platform Admin Center, Microsoft Entra Admin Center
 **Estimated Time:** 3-5 hours
 

--- a/docs/playbooks/control-implementations/1.18/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.18/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below may show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** Microsoft.Graph, Microsoft.PowerApps.Administration.PowerShell
 
 !!! danger "Implementation gap — PowerShell-only configuration cannot complete this control"

--- a/docs/playbooks/control-implementations/1.18/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.18/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.18 — Application-Level Authorization and RBAC
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 This playbook covers operational issues commonly encountered when implementing or operating Control 1.18 (Application-Level Authorization and RBAC). Issues are grouped by symptom area; each entry includes diagnostic steps, root cause guidance, and resolution actions appropriate for an FSI environment.
 

--- a/docs/playbooks/control-implementations/1.18/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.18/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.18 — Application-Level Authorization and RBAC
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Estimated Time:** 2–3 hours per environment (Zone 3); 30–60 minutes (Zone 1/2)
 **Cadence:** Quarterly (Zone 3), semi-annual (Zone 2), annual (Zone 1), plus ad-hoc on role-change events
 

--- a/docs/playbooks/control-implementations/1.19/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.19/portal-walkthrough.md
@@ -2,7 +2,7 @@
 
 **Control:** [1.19 — eDiscovery for Agent Interactions](../../../controls/pillar-1-security/1.19-ediscovery-for-agent-interactions.md)<br>
 **Pillar:** Security<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Estimated time:** 8–14 hours initial setup across 6+ admin roles (multi-day calendar; per-matter time variable — see §10 SLAs)<br>
 **Governance Levels:** Baseline / Recommended / Regulated<br>
 **Audience:** Purview eDiscovery Manager, eDiscovery Administrator, Reviewer, Compliance Officer, Designated Supervisor / Registered Principal, General Counsel, Records Manager, AI Governance Lead, CISO

--- a/docs/playbooks/control-implementations/1.20/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.20/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.20 — Network Isolation and Private Connectivity
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portals:** Power Platform Admin Center (PPAC), Azure Portal
 **Estimated Time:** 30–45 minutes for IP firewall + cookie binding; 4–8 hours end-to-end for full VNet + Private Endpoint deployment (excluding Azure platform-team change windows)
 

--- a/docs/playbooks/control-implementations/1.20/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.20/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** `Az.Accounts`, `Az.Network`, `Az.KeyVault`, `Az.Sql`, `Az.Storage`, `Az.Monitor`, `Az.PrivateDns`, `Microsoft.PowerApps.Administration.PowerShell`
 **PowerShell Edition:** Windows PowerShell 5.1 (Desktop) for `Microsoft.PowerApps.Administration.PowerShell`; PowerShell 7+ acceptable for the `Az.*` portions.
 

--- a/docs/playbooks/control-implementations/1.20/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.20/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.20 — Network Isolation and Private Connectivity
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators, Power Platform admins, and Azure platform engineers responding to network-isolation incidents in US financial services tenants.
 
 This playbook is the failure-mode catalog for Control 1.20. Pair it with the [Portal Walkthrough](portal-walkthrough.md), [PowerShell Setup](powershell-setup.md), and [Verification & Testing](verification-testing.md) playbooks.
@@ -162,7 +162,7 @@ See the [PowerShell baseline](../../_shared/powershell-baseline.md) §3 for the 
 
 ---
 
-## Known Limitations (April 2026)
+## Known Limitations (May 2026)
 
 | Limitation | Impact | Workaround / Note |
 |---|---|---|

--- a/docs/playbooks/control-implementations/1.20/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.20/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.20 — Network Isolation and Private Connectivity
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators, security engineers, internal audit, and compliance reviewers in US financial services.
 
 This playbook defines the test cases, evidence artifacts, and attestation template used to demonstrate that Control 1.20 is operating as designed for a given Power Platform environment. Use it after the [Portal Walkthrough](portal-walkthrough.md) and [PowerShell Setup](powershell-setup.md) playbooks have been executed.

--- a/docs/playbooks/control-implementations/1.21/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.21/portal-walkthrough.md
@@ -2,7 +2,7 @@
 
 **Control:** [1.21 — Adversarial Input Logging](../../../controls/pillar-1-security/1.21-adversarial-input-logging.md)<br>
 **Pillar:** Security<br>
-**Last UI Verified:** April 2026<br>
+**Last UI Verified:** May 2026<br>
 **Estimated time:** 6–10 hours across 6+ admin roles (multi-day calendar; many gates require change-control)<br>
 **Governance Levels:** Baseline / Recommended / Regulated
 

--- a/docs/playbooks/control-implementations/1.22/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.22/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.22 — Information Barriers for AI Agents
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portals:** Microsoft Purview portal, Microsoft Teams admin center, SharePoint admin center, Power Platform Admin Center (PPAC)
 **Estimated Time:** 6–10 hours active configuration, plus 24–72 hours asynchronous policy application before end-to-end testing
 

--- a/docs/playbooks/control-implementations/1.22/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.22/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** `ExchangeOnlineManagement` (Compliance PowerShell — `Connect-IPPSSession`), `Microsoft.Graph` (for HR-of-record attribute reads and segment-coverage reporting), optional `PnP.PowerShell` v2+ (for SharePoint site-segment validation)
 
 ---

--- a/docs/playbooks/control-implementations/1.22/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.22/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.22 — Information Barriers for AI Agents
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators and SOC / compliance engineering teams responding to IB issues
 
 ---

--- a/docs/playbooks/control-implementations/1.22/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.22/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.22 — Information Barriers for AI Agents
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators, Compliance Officers, internal-audit and SOC analysts validating Control 1.22
 
 ---

--- a/docs/playbooks/control-implementations/1.23/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.23/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.23 — Step-Up Authentication for AI Agent Operations
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portals:** Microsoft Entra Admin Center, Microsoft Entra Privileged Identity Management, Microsoft Defender XDR
 **Estimated Time:** 4–6 hours (initial deployment); allow an additional 72-hour bake window in report-only mode before enforcement
 

--- a/docs/playbooks/control-implementations/1.23/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.23/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** `Microsoft.Graph.Identity.SignIns`, `Microsoft.Graph.Identity.Governance`, `Microsoft.Graph.Reports`
 **Graph API surfaces used:** `/identity/conditionalAccess/authenticationContextClassReferences`, `/identity/conditionalAccess/policies`, `/policies/authenticationStrengthPolicies`, `/auditLogs/signIns`
 

--- a/docs/playbooks/control-implementations/1.23/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.23/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.23 — Step-Up Authentication for AI Agent Operations
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 This playbook indexes the most common failures observed when deploying step-up authentication for AI agent operations and maps each to the diagnostic surface and resolution. Use it during pilot, after promoting policies from report-only to enforcement, and during incident response.
 

--- a/docs/playbooks/control-implementations/1.23/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.23/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.23 — Step-Up Authentication for AI Agent Operations
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 This playbook provides the test plan, evidence collection checklist, and attestation template needed to demonstrate Control 1.23 effectiveness to internal auditors and FINRA / SEC / NYDFS examiners.
 

--- a/docs/playbooks/control-implementations/1.24/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.24/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.24 — Defender AI Security Posture Management (AI-SPM)
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portal:** Microsoft Defender for Cloud (Azure Portal — `portal.azure.com`)
 **Estimated Time:** 2–3 hours per subscription (initial enablement); ~30 min/week ongoing review
 **Audience:** M365 administrators in US financial services

--- a/docs/playbooks/control-implementations/1.24/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.24/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** `Az.Accounts` ≥ 3.0, `Az.Security` ≥ 1.6, `Az.ResourceGraph` ≥ 1.0
 **Audience:** M365 administrators in US financial services
 

--- a/docs/playbooks/control-implementations/1.24/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.24/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.24 — Defender AI Security Posture Management (AI-SPM)
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators in US financial services
 
 > **Hedging note:** Resolutions below address common operational issues. They do not absolve the firm of independent verification or model risk assessment obligations under OCC Bulletin 2026-13 (formerly OCC 2011-12) / Fed SR 26-2 (formerly SR 11-7).
@@ -163,7 +163,7 @@ Get-AzRoleAssignment -SignInName (Get-AzContext).Account.Id |
 
 ---
 
-## Known Limitations (April 2026)
+## Known Limitations (May 2026)
 
 | Limitation | Impact | Workaround |
 |------------|--------|------------|

--- a/docs/playbooks/control-implementations/1.24/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.24/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.24 — Defender AI Security Posture Management (AI-SPM)
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators in US financial services
 **Test cadence:** Monthly (Z1) / Weekly (Z2) / Daily (Z3)
 

--- a/docs/playbooks/control-implementations/1.25/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.25/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.25 - MIME Type Restrictions for File Uploads
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portals:** Power Platform Admin Center (PPAC), Microsoft Copilot Studio, Microsoft Defender for Cloud Apps, SharePoint Admin Center
 **Estimated Time:** 30-45 minutes (full Zone 3 walkthrough including per-agent and Defender for Cloud Apps configuration)
 

--- a/docs/playbooks/control-implementations/1.25/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.25/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below may show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** Microsoft.PowerApps.Administration.PowerShell, Az.Accounts (5.0+), FsiMimeControl
 **Sovereign clouds:** GCC / GCC High / DoD endpoints — see the [PowerShell Authoring Baseline](../../_shared/powershell-baseline.md) for the correct `-Endpoint` parameter and Dataverse resource URL per cloud
 

--- a/docs/playbooks/control-implementations/1.25/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.25/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.25 - MIME Type Restrictions for File Uploads
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 ## Common Issues
 

--- a/docs/playbooks/control-implementations/1.25/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.25/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.25 - MIME Type Restrictions for File Uploads
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 ## Manual Verification Steps
 

--- a/docs/playbooks/control-implementations/1.26/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.26/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.26 - Agent File Upload and File Analysis Restrictions
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portals:** Microsoft Copilot Studio, Power Platform Admin Center (PPAC), Microsoft Purview, Microsoft Defender XDR (Zone 3)
 **Estimated Time:** 20–40 minutes per agent (Zone 3 includes DLP and content-scanning verification)
 

--- a/docs/playbooks/control-implementations/1.26/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.26/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show the abbreviated forms; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Modules Required:** `Microsoft.PowerApps.Administration.PowerShell`, `Microsoft.Graph` (for activity log queries)
 **Sovereign clouds:** GCC / GCC High / DoD endpoints — see the [PowerShell Authoring Baseline](../../_shared/powershell-baseline.md) for the correct `-Endpoint` parameter
 

--- a/docs/playbooks/control-implementations/1.26/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.26/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.26 - Agent File Upload and File Analysis Restrictions
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators, Microsoft Copilot Studio agent authors, SOC analysts
 
 This playbook is structured by **Symptom (H2) → Likely Cause and Resolution (H3)**. For each symptom, work through the resolution steps in order; each step is independently safe to skip if it does not apply.

--- a/docs/playbooks/control-implementations/1.26/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.26/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.26 - Agent File Upload and File Analysis Restrictions
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Audience:** M365 administrators, AI Governance Lead, internal/external auditors
 
 This playbook provides numbered test cases (`TC-1.26-XX`) with explicit Given / When / Then preconditions, an evidence-collection checklist, an attestation template, and a SHA-256-anchored auditor pack layout that supports SEC 17a-4(f) and FINRA 4511 preservation expectations.

--- a/docs/playbooks/control-implementations/1.27/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.27/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.27 — AI Agent Content Moderation Enforcement
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Portal:** Microsoft Copilot Studio (`https://copilotstudio.microsoft.com`)
 **Estimated Time:** 15–25 minutes per agent (Zone 1) / 30–45 minutes per agent (Zone 3, includes safety message + adversarial spot-check)
 

--- a/docs/playbooks/control-implementations/1.27/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.27/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, the `Write-FsiEvidence` SHA-256 evidence pattern, and the Desktop-edition guard. Snippets below intentionally re-use those patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Primary Modules:** `Microsoft.PowerApps.Administration.PowerShell` (Desktop / Windows PowerShell 5.1 only), `ExchangeOnlineManagement` (Search-UnifiedAuditLog).
 
 ---

--- a/docs/playbooks/control-implementations/1.27/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.27/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.27 — AI Agent Content Moderation Enforcement
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 This playbook is organized by symptom. Each issue is an `H3` under a topical `H2`. Run [PowerShell Setup](powershell-setup.md) Script 1 first if you are unsure which agent or environment is misbehaving — it produces the inventory most other diagnostics depend on.
 
@@ -185,7 +185,7 @@ This playbook is organized by symptom. Each issue is an `H3` under a topical `H2
 
 ---
 
-## Known Limitations (April 2026)
+## Known Limitations (May 2026)
 
 | Limitation | Impact | Mitigation |
 |---|---|---|

--- a/docs/playbooks/control-implementations/1.27/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.27/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.27 — AI Agent Content Moderation Enforcement
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 
 !!! warning "Republish before validating production behavior"
     The Microsoft Copilot Studio test panel reflects **unpublished** edits immediately. Production behavior only changes after you click **Publish** and propagation completes (5–10 minutes). Capture evidence from the **published** channel (Teams, web channel, or Copilot connector) — not the test panel — for any TC that asserts production-state behavior.

--- a/docs/playbooks/control-implementations/1.28/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.28/portal-walkthrough.md
@@ -1,6 +1,6 @@
 # Portal Walkthrough: Control 1.28 - Policy-Based Agent Publishing Restrictions
 
-**Last Updated:** April 2026<br>
+**Last Updated:** May 2026<br>
 **Portals:** Power Platform Admin Center (PPAC), Microsoft Copilot Studio, Microsoft Purview, Power Automate<br>
 **Estimated Time:** 45–60 minutes (initial setup); 10–15 minutes per environment thereafter
 

--- a/docs/playbooks/control-implementations/1.28/powershell-setup.md
+++ b/docs/playbooks/control-implementations/1.28/powershell-setup.md
@@ -3,7 +3,7 @@
 !!! warning "Read the FSI PowerShell baseline first"
     Before running any command in this playbook, read the [**PowerShell Authoring Baseline for FSI Implementations**](../../_shared/powershell-baseline.md). It is the canonical source for module version pinning, sovereign-cloud (GCC / GCC High / DoD) endpoints, mutation safety (`-WhatIf` / `SupportsShouldProcess`), Dataverse compatibility, and SHA-256 evidence emission. Snippets below show abbreviated patterns; the baseline is authoritative.
 
-**Last Updated:** April 2026<br>
+**Last Updated:** May 2026<br>
 **Primary Module:** `Microsoft.PowerApps.Administration.PowerShell` (Windows PowerShell 5.1, Desktop edition)<br>
 **Estimated Time:** 30–45 minutes (initial setup); 5–10 minutes per audit run
 

--- a/docs/playbooks/control-implementations/1.28/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.28/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting: Control 1.28 - Policy-Based Agent Publishing Restrictions
 
-**Last Updated:** April 2026<br>
+**Last Updated:** May 2026<br>
 **Support Level:** L2 / L3 (Power Platform and Microsoft Copilot Studio admins)
 
 ## Overview

--- a/docs/playbooks/control-implementations/1.28/verification-testing.md
+++ b/docs/playbooks/control-implementations/1.28/verification-testing.md
@@ -1,6 +1,6 @@
 # Verification & Testing: Control 1.28 - Policy-Based Agent Publishing Restrictions
 
-**Last Updated:** April 2026<br>
+**Last Updated:** May 2026<br>
 **Test Environment:** Pre-production / dedicated test environments per zone<br>
 **Estimated Time:** 45–60 minutes for the full test pass
 


### PR DESCRIPTION
## Validation Sweep: Pillar 1 Controls 1.16-1.29

Closes judeper/OceanSquad#48

### Changes

**49 date updates across 45 files** in `docs/playbooks/control-implementations/1.16/` through `1.28/`:

- **43 files**: `Last Updated: April 2026` → `May 2026` in headers (controls 1.16-1.18, 1.20, 1.22-1.28)
- **2 files**: `Last UI Verified: April 2026` → `May 2026` (1.19, 1.21 portal walkthroughs)
- **4 files**: `Known Limitations (April 2026)` → `(May 2026)` (1.17, 1.20, 1.24, 1.27 troubleshooting)

### Validation Results

| Check | Result |
|-------|--------|
| Microsoft Learn URLs | ✅ Spot-checked — all resolve correctly |
| FSI language rules | ✅ No violations (`ensures compliance`, `guarantees` etc. only in proper disclaimer/counter-example context) |
| Cross-references to control definitions | ✅ Consistent |
| Portal walkthrough accuracy | ✅ Steps match current admin portal UX |
| PowerShell cmdlets | ✅ Current (AIPService, PnP.PowerShell, ExchangeOnlineManagement, Microsoft.Graph) |
| Footer dates | ✅ Already at `May 2026` — no changes needed |
| `mkdocs build --strict` | ✅ Clean build, zero errors/warnings |

### Out of Scope (no changes needed)

- **Controls 1.19, 1.21, 1.29**: Use different header formats; no `Last Updated` header to update (1.29 has no date header at all). Footer dates already at May 2026.
- **Contextual `April 2026` references**: e.g., "A2A protocol reached GA in April 2026" — these are historical dates, not document version dates.