### PR TITLE
ci: add .github/instructions/** to python-quality paths filter

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -48,6 +48,13 @@ on:
       # Required-check coverage gate (mirrors pull_request paths above): see
       # comment on tests/** under pull_request.paths.
       - 'tests/**'
+      # Instruction files (.github/instructions/**) are governance tooling that
+      # do not trigger e2e-smoke or docs-validation but DO need the python-quality
+      # gate so that instruction-only PRs satisfy all 11 required branch-protection
+      # checks. The shim (required-check-shims.yml) already covers e2e-smoke and
+      # mkdocs-strict for these PRs; this entry covers ruff, pytest, drift,
+      # language-rules, and verify_version_stamps.
+      - '.github/instructions/**'
   push:
     branches:
       - main


### PR DESCRIPTION
## Problem

Instruction-file-only PRs (e.g. #359) deadlock on branch protection. The 5 python-quality job names (ruff, pytest, drift, language-rules, verify_version_stamps) never fire because .github/instructions/** is absent from python-quality.yml's pull_request.paths filter.

Check run status for #359 before this fix:
- ✅ e2e-smoke (shim)
- ✅ mkdocs-strict (shim)
- ✅ gitleaks, dependency-review, Analyze(python), Analyze(javascript)
- ❌ ruff, pytest, drift, FSI language rules, verify_version_stamps — **never fired**

Result: 7/11 required checks → merge blocked.

## Fix

Add .github/instructions/** to python-quality.yml's pull_request.paths.

**No shim change needed.** The mirror rule applies only to workflows that emit 2e-smoke/mkdocs-strict. The shim correctly fires for instruction-only PRs (.github/instructions/** is not in shim's paths-ignore) and covers those two required check names. Adding .github/instructions/** to shim's paths-ignore would remove that coverage and recreate a deadlock.

## After merge

Unblocks #359 (squad review fix: section-8 label "Implementation Guides" → "Implementation Playbooks").

Closes: squad finding F-104