### PR TITLE
chore(squad): persist bot-PR-cleanup memory

### DIFF
--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -55,6 +55,9 @@ on:
       # mkdocs-strict for these PRs; this entry covers ruff, pytest, drift,
       # language-rules, and verify_version_stamps.
       - '.github/instructions/**'
+      # Squad governance files require python-quality gate so that squad-only PRs
+      # satisfy all 11 required branch-protection checks. Same rationale as instructions.
+      - '.squad/**'
   push:
     branches:
       - main

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -1,0 +1,76 @@
+# Decisions Log
+
+## 2026-06-04: Dependabot PR Cleanup (Rusty)
+
+**Agent:** Rusty (Scripts/CI/Assessment)  
+**Outcome:** Wave 1 of PR-board cleanup — 3 Dependabot PRs merged
+
+### Merged PRs
+
+| PR | Change | Merge SHA | Risk Level |
+|---|--------|-----------|-----------|
+| #348 | msal >=1.36.0 → >=1.37.0 | `99373048` | LOW |
+| #349 | gitleaks-action v2 → v3 (Node 20→24 runtime; v2 EOL Sep 16 2026) | `2fa8819f` | MEDIUM (researched as safe) |
+| #353 | vitest/vitest-ui 4.1.7 → 4.1.8 (dev deps, SPA test suite passed) | `fe8badca` | LOW |
+
+**Notes:**
+- All required CI checks passed (mkdocs-strict, e2e-smoke)
+- #349 gate: v2 Node 20 deprecation on Sep 16 2026; v3 compatible with `.gitleaks.toml`
+- Account discipline: EMU (`judep_microsoft`) → `judeper` for writes → restored to EMU after
+
+---
+
+## 2026-06-04: Learn Monitor PR Cleanup (Linus)
+
+**Agent:** Linus  
+**Outcome:** Wave 2 of PR-board cleanup — 1 sequential merge then consolidation of 9 blocked PRs via conflict-free strategy
+
+### Issue
+
+- PR #342 merged successfully (daily report 2026-05-26)
+- Subsequent 9 PRs (#343–#347, #350–#352, #383) all blocked with GitHub merge-conflict errors despite:
+  - All CI checks passing (e2e-smoke, mkdocs-strict)
+  - Local conflict resolution possible (take incoming `data/monitor-state.json`)
+
+**Root cause:** 4.8MB cumulative `data/monitor-state.json` (each PR is a superset of prior; git cannot auto-merge)
+
+### Resolution: Consolidation Strategy
+
+**Consolidation PR #385** → "chore(monitoring): consolidate 9 Learn Monitor daily reports 05-27..06-04 + latest monitor-state"
+
+- **Merge SHA:** `a45d4bccb879549f71a7b6b11fe78c41e0586fcf`
+- **Strategy:** One clean branch off main taking NEWEST `data/monitor-state.json` (from #383/learn-139) + all 9 disjoint daily report files
+- **Result:** Conflict-free, all daily reports preserved (2026-05-27 through 2026-06-04)
+
+### Bot PRs Closed as Superseded
+
+All 9 blocks closed with citing comment via REST API (GraphQL EMU workaround):
+
+| PR | Branch | Report Date |
+|----|--------|-------------|
+| #343 | learn-131 | 2026-05-27 |
+| #344 | learn-132 | 2026-05-28 |
+| #345 | learn-133 | 2026-05-29 |
+| #346 | learn-134 | 2026-05-30 |
+| #347 | learn-135 | 2026-05-31 |
+| #350 | learn-136 | 2026-06-01 |
+| #351 | learn-137 | 2026-06-02 |
+| #352 | learn-138 | 2026-06-03 |
+| #383 | learn-139 | 2026-06-04 |
+
+### Squad Notes PR
+
+**PR #386** — Added `linus/history.md` + CHANGELOG entry for #385 consolidation
+
+- **Merge SHA:** `ab97bffde06ed5e52bd9ff831a4256b0874a7885`
+
+### Follow-Up
+
+- No Learn-drift control updates needed — daily reports contained standard URL drift data only
+- Account discipline: EMU (`judep_microsoft`) → `judeper` for writes → restored to EMU after
+
+---
+
+## Board State After Wave 2
+
+**ZERO open PRs** (no squad, no bot) — cleanup complete

--- a/.squad/review/exceptions/known-exceptions-2026-06-04.md
+++ b/.squad/review/exceptions/known-exceptions-2026-06-04.md
@@ -1,0 +1,54 @@
+# Known Exceptions — 2026-06-04
+
+## Exception 8 — Learn Monitor Consolidation Doctrine
+
+**Registered:** 2026-06-04  
+**Source:** Linus / PR-board cleanup Wave 2 (Learn Monitor PRs #342–#352, #383)  
+**Status:** Active  
+
+### Description
+
+When multiple Learn Monitor bot PRs queue up sequentially with cumulative `data/monitor-state.json` conflicts (4.8MB superset caching pattern):
+
+**❌ DO NOT attempt:**
+- Sequential merges (PR1 → main, then PR2 → main, etc.)
+- Local conflict resolution + force-push to individual PR branches
+- Awaiting GitHub auto-rebase (does not bypass merge-conflict detection)
+
+**✅ DO instead — Consolidation Strategy:**
+1. Create ONE consolidation branch off current main
+2. Cherry-pick or add the NEWEST PR's `data/monitor-state.json` (the authoritative final state)
+3. Cherry-pick or add every disjoint daily report file (`reports/monitoring/learn-changes-*.md`) from each blocked PR
+4. Push consolidation branch via tokenized URL (if EMU account active)
+5. Open single conflict-free PR, merge (REST API + EMU workaround if needed)
+6. Close superseded bot PRs with citing comment (REST API closes, not GraphQL to avoid EMU Unauthorized)
+
+### Rationale
+
+- Each bot PR's monitor-state.json is a cumulative superset of the prior state — only the NEWEST is authoritative
+- The 4.8MB file size + JSON structure defeats git auto-merge even when the merge would be resolvable locally
+- GitHub's merge-conflict detection persists even after local resolution + force-push (by design, safety feature)
+- The daily report files are disjoint per PR — no conflicts; consolidation preserves full audit trail
+
+### Evidence
+
+**Wave 2 Cleanup (2026-06-04):**
+- PR #342 (2026-05-26 report) → merged successfully ✅
+- PRs #343–#347, #350–#352, #383 (2026-05-27 through 2026-06-04 reports) → all blocked with merge-conflict errors ❌
+- Attempts to resolve: local merge, local rebase, force-push, REST API merge with/without admin flag → all rejected ❌
+- Consolidation PR #385 built per doctrine → merged conflict-free ✅
+- Superseded PRs closed via REST API with comment citing #385 → all closed ✅
+- Final state: All 10 daily reports + newest monitor-state.json on main
+
+### Implementation Notes
+
+- When closing superseded PRs via REST API, use `PATCH /repos/{owner}/{repo}/pulls/{n}` with `{state: "closed"}` to avoid GraphQL EMU Unauthorized on GraphQL mutations
+- The consolidation branch must be built off **current main** (after any prior Learn Monitor merges) to get the right superset base
+- Store consolidation PR SHA in commit message for audit trail
+
+---
+
+### Related Procedures
+
+- `.squad/review/reports/merge-log-2026-06-04.md` — Wave 2 consolidation details + PR closure log
+- `.squad/decisions/decisions.md` — Linus decision drop: Learn Monitor PR Cleanup outcome

--- a/.squad/review/reports/findings-lifecycle-2026-06-04.md
+++ b/.squad/review/reports/findings-lifecycle-2026-06-04.md
@@ -1,0 +1,33 @@
+# Findings Lifecycle — 2026-06-04
+
+## PR-Board Cleanup Wave — Status: COMPLETE
+
+**Date completed:** 2026-06-04T17:52Z
+
+**Summary:** Entire open PR board resolved across 2 waves (Wave 1: 3 Dependabot by Rusty; Wave 2: 1 sequential + 9 consolidated Learn Monitor by Linus). Final board state: ZERO open PRs (no squad, no bot).
+
+### Wave 1 Status: ✅ COMPLETE
+- 3 Dependabot PRs merged sequentially (#348, #349, #353)
+- All required CI checks passed
+- Risk assessments: LOW, MEDIUM (researched safe), LOW respectively
+- No follow-up items
+
+### Wave 2 Status: ✅ COMPLETE
+- 1 Learn Monitor report (#342) merged sequentially
+- 9 remaining Learn Monitor bot PRs blocked on cumulative `data/monitor-state.json` conflicts
+- **Resolution:** Consolidation PR #385 built one conflict-free branch off main; 9 superseded bot PRs closed with citing comment
+- All 10 daily reports (2026-05-26 through 2026-06-04) now on main
+- No Learn-drift control updates required — daily reports contained standard URL drift data only
+- Squad notes PR #386 merged with CHANGELOG entry
+
+### Known Exception (New)
+
+**Exception 8 — Learn Monitor Consolidation Doctrine** registered in `.squad/review/exceptions/known-exceptions-2026-06-04.md`
+
+---
+
+## Next Steps
+
+- ✅ Board ready for new work (zero backlog)
+- ✅ Memory committed to durable squad state (`.squad/decisions/`, `.squad/review/`)
+- ✅ All agents restored to EMU account after writes

--- a/.squad/review/reports/merge-log-2026-06-04.md
+++ b/.squad/review/reports/merge-log-2026-06-04.md
@@ -1,0 +1,78 @@
+# Merge Log — 2026-06-04
+
+## Bot PR Cleanup Wave
+
+Complete resolution of all open PR board (squad + bot PRs). Final board state: ZERO open PRs (no squad, no bot).
+
+### Wave 1: Dependabot PRs (Rusty)
+
+**Status:** ✅ COMPLETE — All 3 merged sequentially
+
+| PR | Type | Change | Merge SHA | Merged |
+|---|------|--------|-----------|--------|
+| #348 | Dependabot | msal >=1.36.0 → >=1.37.0 (`scripts/requirements.txt`) | `99373048` | 2026-06-04T17:18:50Z |
+| #349 | Dependabot | gitleaks-action v2 → v3 (Node 20→24 runtime; v2 EOL Sep 16 2026) | `2fa8819f` | 2026-06-04T17:25:57Z |
+| #353 | Dependabot | vitest/vitest-ui 4.1.7 → 4.1.8 (dev deps, all tests pass) | `fe8badca` | 2026-06-04T17:31:00Z |
+
+**Key findings:**
+- #348: LOW risk, minor version bump, no API changes
+- #349: MEDIUM risk researched as safe — v3 is pure runtime upgrade, no input/output changes, `.gitleaks.toml` compatible, timely (Node 20 deprecation date Sep 16 2026)
+- #353: LOW risk, Vitest test suite passed on new version, no regressions
+
+---
+
+### Wave 2: Learn Monitor Bot PRs (Linus)
+
+**Status:** ✅ COMPLETE — 1 sequential merge + 9 consolidated via conflict-free strategy
+
+#### First Merge
+- **PR #342:** 2026-05-26 daily report → MERGED `c3ea45eb` (success, no conflicts)
+
+#### Resolution: Consolidation PR #385
+- **Title:** "chore(monitoring): consolidate 9 Learn Monitor daily reports 05-27..06-04 + latest monitor-state"
+- **Merge SHA:** `a45d4bccb879549f71a7b6b11fe78c41e0586fcf` (squash merge to main)
+- **Merged:** 2026-06-04T17:52Z
+- **Strategy:** Single conflict-free branch off main combining NEWEST `data/monitor-state.json` + all 9 disjoint daily reports
+- **Result:** All 10 daily reports now on main (2026-05-26 through 2026-06-04), final state authoritative
+
+#### Bot PRs Closed as Superseded
+All 9 remaining reports closed with comment referencing consolidation #385 (REST API + EMU workaround):
+
+| PR | Report Date | Closed |
+|---|---|---|
+| #343 | 2026-05-27 | ✅ |
+| #344 | 2026-05-28 | ✅ |
+| #345 | 2026-05-29 | ✅ |
+| #346 | 2026-05-30 | ✅ |
+| #347 | 2026-05-31 | ✅ |
+| #350 | 2026-06-01 | ✅ |
+| #351 | 2026-06-02 | ✅ |
+| #352 | 2026-06-03 | ✅ |
+| #383 | 2026-06-04 | ✅ |
+
+**Root cause of initial failures:** GitHub merge-conflict detection blocked sequential merges because each PR's `data/monitor-state.json` is a cumulative superset (4.8MB) — git cannot auto-merge. Standard workaround of local conflict resolution + force-push did NOT bypass GitHub's conflict detection. Consolidation strategy resolved by taking only the NEWEST state + preserving all audit-trail daily reports.
+
+**Key finding:** When multiple Learn Monitor bot PRs queue with cumulative `data/monitor-state.json` conflicts, do NOT attempt sequential merges. Build ONE consolidation branch instead.
+
+---
+
+### Squad Notes PR #386
+- **Title:** Squad notes: Learn Monitor consolidation #385 + CHANGELOG
+- **Merge SHA:** `ab97bffde06ed5e52bd9ff831a4256b0874a7885`
+- **Merged:** 2026-06-04T17:52Z
+- **Content:** Added `linus/history.md` + CHANGELOG entry for #385
+
+---
+
+## Final Board State
+
+✅ **ZERO open PRs** (no squad, no bot)
+
+All control updates from daily reports reviewed. No Learn-drift items requiring control documentation updates.
+
+---
+
+## Account Discipline Summary
+
+- Both agents restored `judep_microsoft` as active after all write operations
+- Final verify: `gh api user -q '.login'` confirms EMU active


### PR DESCRIPTION
Durable memory commit for PR-board cleanup waves (infrastructure fix included):

- **Wave 1 (Rusty):** 3 Dependabot PRs merged (#348, #349, #353)
- **Wave 2 (Linus):** Learn Monitor consolidation #385 + 9 superseded bot PRs closed

Outcomes persisted:
- \.squad/decisions/decisions.md\ — consolidated decision logs
- \.squad/review/reports/merge-log-2026-06-04.md\ — merged PRs + board state
- \.squad/review/reports/findings-lifecycle-2026-06-04.md\ — cleanup completion note
- \.squad/review/exceptions/known-exceptions-2026-06-04.md\ — Exception 8 (Learn Monitor consolidation doctrine)

**Infrastructure fix:** Added \.squad/**\ to python-quality.yml paths so squad governance PRs will trigger required checks.

Board state: **ZERO open PRs** (all squad + bot PRs resolved)