### PR TITLE
fix(framework/agent-identity-architecture): replace fabricated CA JSON with Graph-beta-verified payloads (#360)

### DIFF
--- a/docs/framework/agent-identity-architecture.md
+++ b/docs/framework/agent-identity-architecture.md
@@ -218,17 +218,24 @@ Entra Agent ID extends Conditional Access to agent identities, enabling risk-bas
 
 #### Policy Example 1: Block High-Risk Agent Identities
 
-!!! warning "Illustrative example — not Graph-API-ready"
-    The JSON below uses illustrative field names that align with the Conditional Access for Agents UI ("All agent identities", agent risk levels) but **do not match the published Microsoft Graph schema as of June 2026**. Risk-based blocking of agent identities is exposed in the beta Graph API as `agentIdRiskLevels` (a top-level string collection on `conditions`); JSON targeting of "All agent identities" / agent identity blueprints is currently a UI-level concept not yet documented in the public Graph schema. Configure via the Conditional Access UI per the [Conditional Access for agents](https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id) guide until Microsoft publishes the policy-conditions JSON shape.
+!!! note "Beta Graph API — subject to change"
+    The JSON below targets the **`/beta` Microsoft Graph endpoint**: `POST https://graph.microsoft.com/beta/identity/conditionalAccess/policies`. Beta APIs are not supported for production and the schema may change. Validated against MS Learn on 2026-06-04. See [Conditional Access for agents](https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id) and [Create conditionalAccessPolicy (beta)](https://learn.microsoft.com/en-us/graph/api/conditionalaccessroot-post-policies?view=graph-rest-beta) for the authoritative reference.
 
 ```json
 {
   "displayName": "Block high-risk agent identities",
-  "state": "enabled",
+  "state": "enabledForReportingButNotEnforced",
   "conditions": {
-    "users": { "includeAgents": "all" },
-    "applications": { "includeApplications": ["All"] },
-    "agentRisk": { "riskLevels": ["high"] }
+    "clientApplications": {
+      "includeAgentIdServicePrincipals": ["All"],
+      "excludeAgentIdServicePrincipals": [],
+      "agentIdServicePrincipalFilter": null
+    },
+    "applications": {
+      "includeApplications": ["All"],
+      "excludeApplications": []
+    },
+    "agentIdRiskLevels": "high"
   },
   "grantControls": {
     "operator": "AND",
@@ -239,32 +246,28 @@ Entra Agent ID extends Conditional Access to agent identities, enabling risk-bas
 
 #### Policy Example 2: Allow Only Approved Agents Using Custom Security Attributes
 
-!!! warning "Illustrative example — not Graph-API-ready"
-    The JSON below uses illustrative field names that align with the Conditional Access for Agents UI ("All agent identities", agent risk levels) but **do not match the published Microsoft Graph schema as of June 2026**. Risk-based blocking of agent identities is exposed in the beta Graph API as `agentIdRiskLevels` (a top-level string collection on `conditions`); JSON targeting of "All agent identities" / agent identity blueprints is currently a UI-level concept not yet documented in the public Graph schema. Configure via the Conditional Access UI per the [Conditional Access for agents](https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id) guide until Microsoft publishes the policy-conditions JSON shape.
+!!! note "Beta Graph API — subject to change"
+    The JSON below targets the **`/beta` Microsoft Graph endpoint**: `POST https://graph.microsoft.com/beta/identity/conditionalAccess/policies`. Beta APIs are not supported for production and the schema may change. Validated against MS Learn on 2026-06-04. See [Conditional Access for agents](https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id) and [Create conditionalAccessPolicy (beta)](https://learn.microsoft.com/en-us/graph/api/conditionalaccessroot-post-policies?view=graph-rest-beta) for the authoritative reference.
 
 ```json
 {
   "displayName": "Allow only HR-approved agents to access HR resources",
-  "state": "enabled",
+  "state": "enabledForReportingButNotEnforced",
   "conditions": {
-    "users": {
-      "includeAgents": "all",
-      "excludeAgents": {
-        "attributeFilter": {
-          "attribute": "AgentApprovalStatus",
-          "operator": "Contains",
-          "value": "HR_Approved"
-        }
+    "clientApplications": {
+      "includeAgentIdServicePrincipals": ["All"],
+      "excludeAgentIdServicePrincipals": [],
+      "agentIdServicePrincipalFilter": {
+        "mode": "exclude",
+        "rule": "CustomSecurityAttribute.AgentAttributes_AgentApprovalStatus -eq \"HR_Approved\""
       }
     },
     "applications": {
       "includeApplications": ["All"],
-      "excludeApplications": {
-        "attributeFilter": {
-          "attribute": "Department",
-          "operator": "Contains",
-          "value": "HR"
-        }
+      "excludeApplications": [],
+      "applicationFilter": {
+        "mode": "exclude",
+        "rule": "CustomSecurityAttribute.ResourceAttributes_Department -eq \"HR\""
       }
     }
   },


### PR DESCRIPTION
## Summary

Replaces the two fabricated Conditional Access policy JSON examples in docs/framework/agent-identity-architecture.md with payloads verified against the Microsoft Graph **beta** Conditional Access schema as published on Microsoft Learn on **2026-06-04**.

The previous blocks were guarded by a heavy `illustrative example — not Graph-API-ready` warning. Independent re-verification by Saul (FSI-AgentGov review squad, opus-4.7-high) refuted the prior verifier's claim that `All agent identities` had no published Graph schema — it does, just not on `conditionalAccessUsers`. The blocks are now schema-correct, so the strong disclaimer has been replaced with a lighter `Beta Graph API — subject to change` note linking to the agent-id Learn page.

## Three corrections applied

1. **Risk blocking wire format** — `agentIdRiskLevels` is a single flag-enum **string** (e.g., `"high"`, multi-select `"medium,high"`), NOT a nested `agentRisk` object and NOT a JSON array. The fabricated `"agentRisk": { "riskLevels": ["high"] }` shape has been removed.
2. **Agent-identity targeting** — lives on `conditionalAccessClientApplications` as `includeAgentIdServicePrincipals` / `excludeAgentIdServicePrincipals` / `agentIdServicePrincipalFilter` (beta), with the `"All"` sentinel demonstrated by official MS Learn POST examples. The fabricated `users.includeAgents` / `users.excludeAgents` shape has been removed (those properties do not exist on `conditionalAccessUsers`).
3. **Application attribute filtering** — `excludeApplications.attributeFilter` is fabricated. Replaced with the sibling `applicationFilter` (with `"mode": "include" | "exclude"`) on `applications`, matching the MS Learn negative-allowlist pattern.

Both examples now start in `enabledForReportingButNotEnforced` (report-only) per MS Learn's standard rollout pattern.

## Evidence

Full verifier verdict with quoted MS Learn schema text: `.squad/decisions/inbox/saul-360-graph-reverify.md`.

Authoritative sources (all MS Learn, fetched 2026-06-04):

- `conditionalAccessConditionSet` (beta): https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessconditionset?view=graph-rest-beta
- `conditionalAccessClientApplications` (beta): https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessclientapplications?view=graph-rest-beta
- `conditionalAccessApplications` (beta): https://learn.microsoft.com/en-us/graph/api/resources/conditionalaccessapplications?view=graph-rest-beta
- `Create conditionalAccessPolicy` (beta), Examples 5 & 6: https://learn.microsoft.com/en-us/graph/api/conditionalaccessroot-post-policies?view=graph-rest-beta
- `Conditional Access for agents`: https://learn.microsoft.com/en-us/entra/identity/conditional-access/agent-id
- `Recommended policies for autonomous agents`: https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-autonomous-agents

## Beta caveat

The corrected JSON targets the `/beta` Microsoft Graph endpoint. Beta APIs are not supported for production and the schema may change — the in-doc admonition reflects this.

## Local validation

- `mkdocs build --strict` — passed (0 errors, 0 warnings)
- `python scripts/verify_controls.py` — passed
- `python scripts/verify_language_rules.py` — passed (no prohibited language)

## Reviewer lockout

Per maintainer instruction, Linus is locked out of this artifact (his original mapping F-20260603-003 was refuted by the verifier). This PR is authored by Danny (lead) directly.

Closes #360

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>