### PR TITLE
docs(1.9): clarify content-retention vs audit-log-retention licensing scope (resolves #405)

### DIFF
--- a/docs/controls/pillar-1-security/1.9-data-retention-and-deletion-policies.md
+++ b/docs/controls/pillar-1-security/1.9-data-retention-and-deletion-policies.md
@@ -75,6 +75,7 @@ This control combines four Microsoft Purview surfaces and one Power Platform sur
 - Note: Disposition review applies to retention-label-driven retention on Exchange / SharePoint / OneDrive content. **Copilot interaction and Dataverse transcript retention use policy-based controls without reviewer-driven disposition** — plan defensible deletion evidence accordingly.
 - Stand up a documented **legal-hold intake process** with eDiscovery (Standard or Premium) so litigation preservation can be applied within hours of a triggering event.
 - Configure extended **audit log retention** for deletion events (see Control 1.7); the audit trail of disposition is itself a record.
+- **Content retention vs. audit log retention licensing:** data retention durations under this control (Data Lifecycle Management retention labels and policies) are governed by the organization's E5 or Purview entitlement and do not require the per-user 10-Year Audit Log Retention add-on; that add-on applies only to Unified Audit Log retention beyond one year under Control 1.7.
 - Implement **storage tiering** to satisfy the "readily/easily accessible" requirement (see table below) without paying hot-tier prices for years 3+.
 
 ### Storage Tier Requirements ("Readily/Easily Accessible")


### PR DESCRIPTION
Resolves escalation #405 (FND-P1-B-008).

**Finding:** The escalation conflated two distinct Microsoft licensing surfaces. Control 1.9 governs **content retention** via Purview Data Lifecycle Management (retention labels/policies, `Set-RetentionCompliancePolicy`), which is covered by E5/Purview entitlement and does **not** require the per-user **10-Year Audit Log Retention add-on**. That add-on applies only to **Unified Audit Log retention** beyond one year (`New-UnifiedAuditLogRetentionPolicy`), which is **Control 1.7's** domain.

**Resolution:** No tenant test required — Microsoft Learn resolves this unambiguously. Added one clarifying bullet to Control 1.9 distinguishing the two surfaces. Control 1.7 already documents the add-on requirement correctly.

**Authority:** https://learn.microsoft.com/purview/audit-log-retention-policies

**Gates:** language rules ✅ · xref ✅ · mkdocs --strict ✅