### PR TITLE
docs(2.25/2.26): rename leftover Frontier/Preview structural identifiers (#418)

### DIFF
--- a/docs/playbooks/control-implementations/2.25/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/2.25/portal-walkthrough.md
@@ -7,7 +7,7 @@
 
     | In Scope | Surface | Outcome |
     |---|---|---|
-    | Validating Agent 365 licensing (E7 Frontier Suite or standalone Agent 365) | M365 admin center → Billing → Licenses | Confirmed entitlement before any governance change |
+    | Validating Agent 365 licensing (Microsoft 365 E7 ("Frontier Suite") or standalone Agent 365) | M365 admin center → Billing → Licenses | Confirmed entitlement before any governance change |
     | Daily/weekly governance card rhythm (Pending Requests, Ownerless Agents) | M365 admin center → Agent 365 → Overview | Documented review cadence and SLA adherence |
     | Filtering, inspecting, and exporting the Agent Registry | Agent 365 → Agents → All Agents | Audit-ready CSV/Excel inventory snapshots |
     | Admin-gated publishing approval workflow with template application | Agent 365 → Pending Requests → Publishing | Zero unreviewed Zone 2 / Zone 3 publications |
@@ -33,7 +33,7 @@
     | Common errors, missing blades, console behavior anomalies, and remediation steps | [`./troubleshooting.md`](./troubleshooting.md) |
 
 !!! warning "Hedged-Language Reminder"
-    This playbook helps your organization **support compliance with** FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), FINRA RN 24-09 / Rule 3110 (AI Tools), SEC Rules 17a-3 / 17a-4 (Recordkeeping), SOX Sections 302/404 (Internal Controls), GLBA 501(b) (Safeguards Rule), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) (Technology Risk Management), and NYDFS 23 NYCRR 500 (Cybersecurity). It does **not** by itself provide any regulatory outcome and **does not substitute for** the firm's obligation to assign an appropriately registered principal where Rule 3110 requires registered supervisory responsibility. Implementation requires Agent 365 licensing (Microsoft 365 E7 "Frontier Suite" or standalone Agent 365 layered on Microsoft 365 Copilot), validated change-control procedures, and independent testing by your compliance function. Organizations should verify all configurations against their own examination workpapers and legal counsel before treating these procedures as adequate evidence.
+    This playbook helps your organization **support compliance with** FINRA Rule 3110 (Supervision), FINRA Rule 4511 (Books and Records), FINRA RN 24-09 / Rule 3110 (AI Tools), SEC Rules 17a-3 / 17a-4 (Recordkeeping), SOX Sections 302/404 (Internal Controls), GLBA 501(b) (Safeguards Rule), OCC Bulletin 2026-13 (formerly OCC Bulletin 2011-12) (Technology Risk Management), and NYDFS 23 NYCRR 500 (Cybersecurity). It does **not** by itself provide any regulatory outcome and **does not substitute for** the firm's obligation to assign an appropriately registered principal where Rule 3110 requires registered supervisory responsibility. Implementation requires Agent 365 licensing (Microsoft 365 E7 ("Frontier Suite") or standalone Agent 365 layered on Microsoft 365 Copilot), validated change-control procedures, and independent testing by your compliance function. Organizations should verify all configurations against their own examination workpapers and legal counsel before treating these procedures as adequate evidence.
 
 !!! info "Generally Available — May 1, 2026"
     Microsoft Agent 365 reached **general availability on May 1, 2026**. Licensing options:

--- a/docs/playbooks/control-implementations/2.25/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.25/powershell-setup.md
@@ -9,7 +9,7 @@ prerequisites:
   - "PowerShell 7.4 Core (Windows, Linux, or macOS)"
   - "Microsoft Graph PowerShell SDK 2.25.0+ (pinned)"
   - "Microsoft.Graph.Beta 2.25.0+ where Agent 365 cmdlets remain in the beta surface"
-  - "Microsoft 365 E7 Frontier Suite or Microsoft 365 Copilot Business Chat licensing for the operator running discovery"
+  - "Microsoft 365 E7 ("Frontier Suite") or Microsoft 365 Copilot Business Chat licensing for the operator running discovery"
   - "Entra Global Reader at minimum; Entra Global Admin via PIM for any mutation"
 scopes_required:
   - "Application.Read.All"
@@ -68,7 +68,7 @@ Every helper in this playbook returns one of five `Status` values — **`Clean`*
 
 ---
 
-## §1 — Module Inventory, Graph Scopes, RBAC Matrix, and Preview Gating
+## §1 — Module Inventory, Graph Scopes, RBAC Matrix, and License-Coverage Gating
 
 ### 1.1 Module pinning
 
@@ -143,12 +143,12 @@ When a required cmdlet is unavailable, the calling helper emits `Status='NotAppl
 
 Canonical role names: **AI Administrator**, **Entra Global Admin**, **Entra Global Reader**, **AI Governance Lead**, **Purview Compliance Admin**. See [`docs/reference/role-catalog.md`](../../../reference/role-catalog.md).
 
-### 1.5 Preview gating preflight
+### 1.5 License-coverage gating preflight
 
 A small number of Agent 365 surfaces remained in **public preview** at GA — most notably the per-tenant Computer Use policy editor for the Researcher agent and the bulk approval-template export. Operators must affirmatively opt in to preview surfaces through the `-AllowPreviewSurfaces` switch on `Initialize-Agt225Session`. Without that switch, helpers that touch preview surfaces return `Status='NotApplicable'`, `Reason='PreviewSurfaceNotEnabled'` rather than failing or, worse, returning a synthetic clean.
 
 ```powershell
-function Test-Agt225PreviewGating {
+function Test-Agt225LicenseCoverageGating {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)] [bool] $AllowPreviewSurfaces
@@ -242,7 +242,7 @@ function Initialize-Agt225Session {
             "Agt225-MissingScopes: $($missing.Scope -join ', ')")
     }
 
-    $previewReport = Test-Agt225PreviewGating -AllowPreviewSurfaces:$AllowPreviewSurfaces
+    $previewReport = Test-Agt225LicenseCoverageGating -AllowPreviewSurfaces:$AllowPreviewSurfaces
 
     [pscustomobject]@{
         RunId              = $RunId
@@ -675,7 +675,7 @@ The output of `Get-Agt225ApprovalHistory` is the primary attestation artifact fo
 
 ### 7.1 Get-Agt225LicenseCoverage
 
-The Agent 365 Admin Center is licensed via **Microsoft 365 E7 Frontier Suite** or **Microsoft 365 Copilot Business Chat**. Operators must verify that every user assigned a governance role is licensed; an unlicensed AI Administrator silently loses access to many of the admin surfaces.
+The Agent 365 Admin Center is licensed via **Microsoft 365 E7 ("Frontier Suite")** or **Microsoft 365 Copilot Business Chat**. Operators must verify that every user assigned a governance role is licensed; an unlicensed AI Administrator silently loses access to many of the admin surfaces.
 
 ```powershell
 function Get-Agt225LicenseCoverage {
@@ -1423,7 +1423,7 @@ The cadence is mirrored in the sister 2.26 playbook so that the daily and weekly
 | ``Assert-Agt225ShellHost`` | §2.1 | Status object or throws | No |
 | ``Initialize-Agt225Session`` | §2.2 | SessionContext | No (connects) |
 | ``Test-Agt225GraphScopes`` | §2.3 | Scope rows | No |
-| ``Test-Agt225PreviewGating`` | §1.5 | Preview report | No |
+| ``Test-Agt225LicenseCoverageGating`` | §1.5 | Preview report | No |
 | ``Get-Agt225CmdletAvailability`` | §1.3 | Availability rows | No |
 | ``Get-Agt225AgentInventory`` | §3.1 | Inventory + writes JSON | No |
 | ``Resolve-Agt225OwnerUpn`` | §3.2 | Owner row | No |

--- a/docs/playbooks/control-implementations/2.25/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.25/troubleshooting.md
@@ -43,7 +43,7 @@ Use this section as the entry point for every Sev1/Sev2/Sev3 incident touching C
 Before paging the AI Governance Lead or Entra Global Admin (PIM-elevated), the on-call AI Administrator must complete:
 
 1. Confirm GA status: tenant is on Microsoft Agent 365 Admin Center GA build (≥ May 1, 2026). Pre-GA preview tenants follow a different support path; see §2.4.
-2. Confirm reporter''s license posture: M365 E7 "Frontier Suite" OR standalone Agent 365 + Copilot prerequisite (`Get-Agt225LicenseAssignment -UserPrincipalName <upn>`).
+2. Confirm reporter''s license posture: Microsoft 365 E7 ("Frontier Suite") OR standalone Agent 365 + Copilot prerequisite (`Get-Agt225LicenseAssignment -UserPrincipalName <upn>`).
 3. Confirm reporter''s role: AI Administrator, Entra Global Reader, AI Governance Lead, or other role per [Role Catalog](../../../reference/role-catalog.md). PIM activation timestamp captured.
 4. Capture initial evidence floor (E-01 console screenshot, E-02 Graph activity log, E-03 PowerShell session transcript). See §1.4.
 5. Identify affected zone(s): Zone 1 Personal, Zone 2 Team, Zone 3 Enterprise. Zone 3 escalations require Compliance Officer notification within 1 hour.
@@ -75,7 +75,7 @@ This section catalogs the helper cmdlets, Graph queries, and KQL queries used th
 | `Get-Agt225TemplateStatus` | Returns Default / Custom Governance Template apply state per agent or per scope | [PowerShell Setup §4.4](./powershell-setup.md) |
 | `Get-Agt225InventoryExport` | Streams console inventory in CSV / JSON; pagination-safe fallback for failed UI export | [PowerShell Setup §3](./powershell-setup.md) |
 | `Get-Agt225ResearcherConfig` | Returns Researcher with Computer Use enablement scope, group bindings, and license check | [PowerShell Setup §4.5](./powershell-setup.md) |
-| `Get-Agt225LicenseAssignment` | Returns Frontier Suite / Agent 365 / Copilot license posture for a user or group | [PowerShell Setup §4.6](./powershell-setup.md) |
+| `Get-Agt225LicenseAssignment` | Returns Microsoft 365 E7 ("Frontier Suite") / Agent 365 / Copilot license posture for a user or group | [PowerShell Setup §4.6](./powershell-setup.md) |
 | `Get-Agt225AuditEvents` | Wrapper over Purview Audit unified log filtered to Agent365AdminCenter workload | [PowerShell Setup §4.7](./powershell-setup.md) |
 | `Invoke-Agt225EvidenceSnapshot` | Produces the E-01..E-09 evidence bundle to the Purview immutable library | [PowerShell Setup §5](./powershell-setup.md) |
 
@@ -224,7 +224,7 @@ The Microsoft Agent 365 Admin Center landing page fails to render, returns "We c
 |---|---|---|
 | **RC-A** | Admin lacks AI Administrator or AI Governance Lead role; PIM activation lapsed | GQ-01 returns 401 / 403; Entra sign-in log shows missing role token claim |
 | **RC-B** | Tenant on pre-GA preview build; flighting flag dropped after GA cut-over | GQ-01 returns 200 but `state: "preview-deprecated"`; banner present in admin.microsoft.com |
-| **RC-C** | Frontier Suite or Agent 365 SKU not assigned to tenant; license expired | `Get-Agt225LicenseAssignment -TenantScope` returns `licenseState: "expired"` or `"none"` |
+| **RC-C** | Microsoft 365 E7 ("Frontier Suite") or Agent 365 SKU not assigned to tenant; license expired | `Get-Agt225LicenseAssignment -TenantScope` returns `licenseState: "expired"` or `"none"` |
 | **RC-D** | Browser-side cache holds stale pre-GA bundle; service worker not refreshed | Hard reload (Ctrl-F5) restores function; problem returns next session |
 | **RC-E** | Conditional Access policy blocks the admin.microsoft.com → graph.microsoft.com token exchange (e.g., new device-compliance grant control) | Entra sign-in log shows `Failure reason: 53003 - Blocked by Conditional Access` |
 | **RC-F** | Microsoft service incident affecting the Agent 365 Admin Center fabric | Service Health Dashboard shows active advisory; KQL-01 shows tenant-wide failure spike |
@@ -233,7 +233,7 @@ The Microsoft Agent 365 Admin Center landing page fails to render, returns "We c
 
 1. Run `Get-Agt225Health -Verbose`. Inspect `ServiceStatus`, `GraphReachability`, `LicensePosture`, `RolePosture` blocks.
 2. Issue **GQ-01**. Capture HTTP status and response body. 401/403 → RC-A or RC-E. 503 → RC-F. 200 with `state != "operational"` → RC-B.
-3. Run `Get-Agt225LicenseAssignment -TenantScope` and confirm Frontier Suite or Agent 365 SKU is in `enabled` state with seats available.
+3. Run `Get-Agt225LicenseAssignment -TenantScope` and confirm Microsoft 365 E7 ("Frontier Suite") or Agent 365 SKU is in `enabled` state with seats available.
 4. Confirm reporter''s role bindings: `Get-MgUserMemberOf -UserId <upn>` and cross-check against [Role Catalog](../../../reference/role-catalog.md). For PIM-eligible roles, confirm activation timestamp via `Get-MgPrivilegedAccessRoleAssignmentScheduleInstance`.
 5. Inspect Entra sign-in log for the affected admin in the past 1 hour: `Get-MgAuditLogSignIn -Filter "userPrincipalName eq ''<upn>''" -Top 25`. Look for `errorCode 53003`, `500011`, or `50105`.
 6. If RC-D suspected, ask reporter to (a) hard-reload, (b) clear site data for `admin.microsoft.com` and `*.cloud.microsoft`, (c) re-test in InPrivate / new profile.
@@ -444,7 +444,7 @@ Applying the Default Governance Template (bundled at GA: Entra Identity Protecti
 |---|---|---|
 | **RC-A** | Entra Identity Protection policy required by Default Template missing or disabled | GQ-04 returns `prerequisites: [{name:"IdentityProtection", state:"missing"}]` |
 | **RC-B** | Purview AI Compliance Assessment policy missing or scope mismatch | GQ-04 prerequisite state `policyScopeMismatch` |
-| **RC-C** | License drift: tenant has Frontier Suite assigned but seat count exhausted; auto-assignment cannot complete | `Get-Agt225LicenseAssignment -TenantScope` returns `seatsAvailable: 0` |
+| **RC-C** | License drift: tenant has Microsoft 365 E7 ("Frontier Suite") assigned but seat count exhausted; auto-assignment cannot complete | `Get-Agt225LicenseAssignment -TenantScope` returns `seatsAvailable: 0` |
 | **RC-D** | Custom Template bound to an Entra Access Package whose policy expired or lacks reviewer | GQ-05 returns `accessPackageBindingState: "policyExpired"` |
 | **RC-E** | Global Secure Access (GSA) prerequisite required by Custom Template''s SharePoint Content Permissions Insights component is not deployed in tenant | GQ-05 prerequisite `gsa: "notDeployed"` |
 | **RC-F** | Background reconciliation job conflict — concurrent template re-apply from a Power Automate scheduled flow | KQL-03 shows two template-apply events from different actors within seconds |
@@ -496,7 +496,7 @@ Capture the apply event in evidence (E-06).
 |---|---|
 | RC-A | Coordinate with Identity team to restore Identity Protection policy; re-apply per §5.5. |
 | RC-B | Coordinate with Purview Compliance Admin to restore AI Compliance Assessment policy; re-apply. |
-| RC-C | Procurement provisions additional Frontier Suite / Agent 365 seats; auto-assignment will complete on next reconcile (≤ 1h). |
+| RC-C | Procurement provisions additional Microsoft 365 E7 ("Frontier Suite") / Agent 365 seats; auto-assignment will complete on next reconcile (≤ 1h). |
 | RC-D | Renew the Access Package assignment policy; assign reviewers; re-apply Custom Template. |
 | RC-E | Coordinate with Identity / Network team to deploy GSA; until deployed, Zone 3 agents that depend on SCPI cannot publish. |
 | RC-F | Disable conflicting Power Automate flow; consolidate template-apply automation under a single AI Administrator service principal. |
@@ -536,7 +536,7 @@ The Agent Publish wizard (used by Agent Owners to submit a new agent for approva
 |---|---|---|
 | **RC-A** | Custom Template was edited mid-flight; user''s draft was created against the prior version | Browser dev-tools shows submitted `templateVersion` ≠ Console current |
 | **RC-B** | Required-field metadata cached on the client; backend now demands additional fields after a Custom Template update | KQL audit shows `Template.SchemaUpdated` event in the last 24h |
-| **RC-C** | License posture for the submitter changed mid-session (Frontier Suite seat reclaimed) | `Get-Agt225LicenseAssignment -UserPrincipalName <upn>` returns `enabled: false` |
+| **RC-C** | License posture for the submitter changed mid-session (Microsoft 365 E7 ("Frontier Suite") seat reclaimed) | `Get-Agt225LicenseAssignment -UserPrincipalName <upn>` returns `enabled: false` |
 | **RC-D** | Approval-queue ingestion broken (cross-link §3 RC-A) | Wizard succeeds; queue does not show entry |
 | **RC-E** | Custom Template''s `requiredFields` schema includes a field that no longer exists in the Console UI (schema drift) | `Get-Agt225TemplateStatus -TemplateId <id> -Detailed` shows `schemaWarnings` |
 | **RC-F** | Submitter''s permission was assigned via a group whose membership eval is delayed | Sign-in log shows token issued before group-membership refresh |
@@ -824,12 +824,12 @@ The cmdlet writes a `Feature.ResearcherComputerUse.ScopeChanged` audit event wit
 
 ## §10 Runbook RB-01 — Mass Agent Re-onboarding After Acquisition
 
-**Trigger.** The firm has acquired another organization and 10+ agents from the acquired tenant must be onboarded into the Frontier-Suite tenant''s Console with template binding, ownership assignment, and approval. Sev2 unless examiner-active or > 200 agents (Sev1).
+**Trigger.** The firm has acquired another organization and 10+ agents from the acquired tenant must be onboarded into the Microsoft 365 E7 ("Frontier Suite") tenant''s Console with template binding, ownership assignment, and approval. Sev2 unless examiner-active or > 200 agents (Sev1).
 
 ### §10.1 Pre-Conditions
 
 - Acquired-tenant inventory exported as CSV/JSON with at minimum: agent display name, owner UPN (mapped to acquirer-tenant UPN), zone classification, current template binding, license requirement.
-- Frontier Suite seats provisioned for inbound owners (verified via `Get-Agt225LicenseAssignment -TenantScope -IncludeSeatAccounting`).
+- Microsoft 365 E7 ("Frontier Suite") seats provisioned for inbound owners (verified via `Get-Agt225LicenseAssignment -TenantScope -IncludeSeatAccounting`).
 - Default Governance Template and any required Custom Templates are in `prerequisiteState: Satisfied`.
 - Change-management ticket open with rollback plan.
 
@@ -921,7 +921,7 @@ examiner-prod-2026Q1/
 ### §12.1 Pre-Conditions
 
 - HR-system export of leaver-joiner mapping (old UPN → new UPN) validated by HR data steward.
-- New owners have Frontier Suite / Agent 365 license assignment.
+- New owners have Microsoft 365 E7 ("Frontier Suite") / Agent 365 license assignment.
 - New owners hold an Agent Owner role binding (or a group containing them does).
 
 ### §12.2 Procedure
@@ -957,7 +957,7 @@ examiner-prod-2026Q1/
 
 ## §13 Runbook RB-04 — License Coverage Gap (Agent Acting OBO Unlicensed User)
 
-**Trigger.** Audit reveals one or more agents performing OBO (on-behalf-of) operations for users whose Frontier Suite / Agent 365 / Copilot license has lapsed. Sev1 because the firm is consuming a service that the user is not licensed for, with potential contractual and audit consequences.
+**Trigger.** Audit reveals one or more agents performing OBO (on-behalf-of) operations for users whose Microsoft 365 E7 ("Frontier Suite") / Agent 365 / Copilot license has lapsed. Sev1 because the firm is consuming a service that the user is not licensed for, with potential contractual and audit consequences.
 
 ### §13.1 Pre-Conditions
 

--- a/docs/playbooks/control-implementations/2.26/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/2.26/portal-walkthrough.md
@@ -1,7 +1,7 @@
 # Portal Walkthrough — Control 2.26: Entra Agent ID Identity Governance
 
 !!! info "Post-GA Status — May 2026"
-    **Microsoft Agent 365 reached general availability on May 1, 2026** and **Microsoft Entra Agent ID is generally available** as of May 2026. The pre-GA "Frontier program enrollment" gate has been replaced by **Microsoft Agent 365** (standalone per-user license) or **Microsoft 365 E7** ("Frontier Suite" — bundles E5 + Microsoft 365 Copilot + Entra Suite + Agent 365) license assignment. Where this playbook references "Frontier program" or "Frontier preview" as a gating mechanism, read it as **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. Section names, anchor IDs, and PowerShell function/test names that include "Preview" or "Frontier" are retained for backward compatibility — the underlying probe logic (whether the calling principal can reach the agent identity surface) remains valid because the same observable is gated by licensing post-GA. A follow-up issue tracks the deeper structural rename.
+    **Microsoft Agent 365 reached general availability on May 1, 2026** and **Microsoft Entra Agent ID is generally available** as of May 2026. The pre-GA "Frontier program enrollment" gate has been replaced by **Microsoft Agent 365** (standalone per-user license) or **Microsoft 365 E7** ("Frontier Suite" — bundles E5 + Microsoft 365 Copilot + Entra Suite + Agent 365) license assignment. Where this playbook references "Frontier program" or "Frontier preview" as a gating mechanism, read it as **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. Structural identifiers (section anchors, PowerShell function names, test namespace names) that previously included "Preview" or "Frontier" were renamed in issue #418.
 
 !!! danger "READ FIRST — Scope and Sibling Routing"
     **This playbook configures identity governance for Microsoft Entra Agent IDs** — the directory objects that represent autonomous AI agents (Microsoft Copilot Studio agents, Agent 365 agents, declarative agents with autonomous actions, and third-party agents registered through the Microsoft Agent Framework). It walks you through the **Microsoft Entra admin center**, **Microsoft Entra Identity Governance**, **Microsoft 365 admin center (Microsoft Agent 365 / E7 licensing)**, and **Microsoft Purview / Azure Monitor** surfaces required to satisfy Verification Criteria 1–8 of [Control 2.26](../../../controls/pillar-2-management/2.26-entra-agent-id-identity-governance.md).
@@ -128,13 +128,6 @@ Do not proceed past this section unless **all** of the following are true:
     Open [`./troubleshooting.md`](./troubleshooting.md) and search for the gate name (e.g., "Agent 365 license missing" or the legacy "Preview gating not satisfied" namespace name). Do not attempt workarounds in production until the gate clears — most workarounds for missing licensing or roles create their own audit findings.
 
 ---
- (S1): legacy-slug preservation across the May 2026 GA heading
-     rename ("Frontier program enrollment" -> "Microsoft Agent 365 / M365
-     E7 License Assignment"). DO NOT REMOVE the explicit anchor below:
-     three in-page hrefs (TOC line 67, warnings lines 126/127) resolve to
-     #2-frontier-program-enrollment, which is no longer the auto-generated
-     slug for this H2. The body paragraph in §1 documents the reason. -->
-<a id="2-frontier-program-enrollment"></a>
 
 ## 1. Microsoft Agent 365 / Microsoft 365 E7 License Assignment
 

--- a/docs/playbooks/control-implementations/2.26/powershell-setup.md
+++ b/docs/playbooks/control-implementations/2.26/powershell-setup.md
@@ -10,7 +10,7 @@ last_ui_verified: "May 2026"
 
 > **Scope.** Operational PowerShell automation for governing Entra Agent ID lifecycle: sponsor assignment, orphan detection, access package assignment review, lifecycle workflow telemetry, access review tracking, bulk sponsor reassignment, evidence pack export, and SIEM forwarding verification.
 >
-> **Post-GA status (May 2026).** Microsoft Agent 365 reached general availability on May 1, 2026 and Microsoft Entra Agent ID is generally available. The pre-GA "Frontier program enrollment" prerequisite is replaced by **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. The `Test-Agt226PreviewGating` helper and the `PreviewGatingNotSatisfied` exception type retain their pre-GA names for backward compatibility — the underlying check (whether the operating principal can reach the agent identity surface) remains valid because both the pre-GA Frontier gate and the post-GA license assignment manifest as the same API reachability state. A follow-up issue tracks renaming the helper and exception type to license-coverage terms.
+> **Post-GA status (May 2026).** Microsoft Agent 365 reached general availability on May 1, 2026 and Microsoft Entra Agent ID is generally available. The pre-GA "Frontier program enrollment" prerequisite is replaced by **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. The `Test-Agt226LicenseCoverageGating` helper and the `LicenseCoverageNotSatisfied` exception type retain their pre-GA names for backward compatibility — the underlying check (whether the operating principal can reach the agent identity surface) remains valid because both the pre-GA Frontier gate and the post-GA license assignment manifest as the same API reachability state. This rename was completed in issue #418.
 >
 > **License gating.** Entra Agent ID requires **Microsoft Agent 365** licensing (standalone per-user) or **Microsoft 365 E7** ("Frontier Suite," which bundles Microsoft 365 Copilot + Agent 365 + Entra Suite + E5). Tenants without either license will see empty result sets — not errors. The §1 preflight explicitly flags this false-clean condition.
 >
@@ -59,7 +59,7 @@ The table below enumerates defect classes specific to Entra Agent ID telemetry. 
 
 | # | Defect | Symptom | Why it appears clean | Structural guard |
 |---|--------|---------|----------------------|------------------|
-| 0.1 | Preview gating not satisfied | `Get-MgServicePrincipal -Filter "tags/any(t:t eq 'AgentIdentity')"` returns zero rows | No exception is thrown; the tenant has no agent identities reachable to the calling principal because the operating account lacks Microsoft Agent 365 / Microsoft 365 E7 license coverage (post-GA gating mechanism) | §1 preflight calls `Test-Agt226PreviewGating` (name retained for backward-compat) which checks both Microsoft 365 Copilot SKU coverage and Agent ID API surface reachability, and aborts with a structured `PreviewGatingNotSatisfied` exception (name retained) before any inventory pass |
+| 0.1 | Preview gating not satisfied | `Get-MgServicePrincipal -Filter "tags/any(t:t eq 'AgentIdentity')"` returns zero rows | No exception is thrown; the tenant has no agent identities reachable to the calling principal because the operating account lacks Microsoft Agent 365 / Microsoft 365 E7 license coverage (post-GA gating mechanism) | §1 preflight calls `Test-Agt226LicenseCoverageGating` (name retained for backward-compat) which checks both Microsoft 365 Copilot SKU coverage and Agent ID API surface reachability, and aborts with a structured `LicenseCoverageNotSatisfied` exception (name retained) before any inventory pass |
 | 0.2 | Wrong shell edition | All inventory cmdlets succeed but return `@()` | Microsoft.Graph 2.x assemblies fail to bind under Desktop edition; the SDK swallows the bind failure and returns empty | `Assert-Agt226Shell` (above) blocks Desktop edition entirely |
 | 0.3 | Stale delegated token | Helpers run, return data, but `sponsorRelationships` collection is always null | Delegated token issued before the AgentIdentity.Read.All scope was granted; Graph silently omits the navigation property | §1 `Test-Agt226GraphScopes` re-asserts scopes against the live token and forces re-consent if mismatched |
 | 0.5 | Manager-transfer race window | An agent appears orphaned for ~5–15 minutes after a sponsor's `accountEnabled` flips to false | Lifecycle workflow has not yet run; transfer to manager is queued but not committed | §4 `Get-Agt226OrphanedAgent` accepts a `-GraceWindowMinutes` parameter (default 30) and tags rows below the threshold as `PendingLifecycleTransfer` rather than `Orphaned` |
@@ -196,7 +196,7 @@ Use the canonical short names from the role catalog. Mixing legacy long-form nam
 ### 1.4 License gating preflight
 
 ```powershell
-function Test-Agt226PreviewGating {
+function Test-Agt226LicenseCoverageGating {
     [CmdletBinding()]
     param()
 
@@ -229,19 +229,19 @@ function Test-Agt226PreviewGating {
             [pscustomobject]@{ probeError = $_.Exception.Message }
         }
     }
-    $hasFrontier = $null -ne $probe -and -not $probe.probeError
+    $hasAgentIdAccess = $null -ne $probe -and -not $probe.probeError
 
-    $status = if ($hasLicense -and $hasFrontier) { 'Clean' } else { 'NotApplicable' }
+    $status = if ($hasLicense -and $hasAgentIdAccess) { 'Clean' } else { 'NotApplicable' }
     [pscustomobject]@{
         ControlId     = '2.26'
-        Criterion     = 'PreviewGatingSatisfied'
+        Criterion     = 'LicenseCoverageSatisfied'
         HasCopilotSku = $hasLicense   # field name retained for backward-compat;
                                       # post-GA reflects Agent 365 / M365 E7 / Copilot license presence
-        HasFrontier   = $hasFrontier  # field name retained for backward-compat;
+        HasAgentIdAccess = $hasAgentIdAccess  # field name retained for backward-compat;
                                       # post-GA reflects Agent ID API surface reachability
         Status        = $status
         Reason        = if ($status -eq 'NotApplicable') {
-            "Tenant lacks $((@{$true='';$false='Agent 365 / M365 E7 license'}[$hasLicense])) $((@{$true='';$false='Agent ID API reachability'}[$hasFrontier])) — Entra Agent ID surface area is empty or not accessible to the calling principal."
+            "Tenant lacks $((@{$true='';$false='Agent 365 / M365 E7 license'}[$hasLicense])) $((@{$true='';$false='Agent ID API reachability'}[$hasAgentIdAccess])) — Entra Agent ID surface area is empty or not accessible to the calling principal."
         } else { $null }
     }
 }
@@ -299,9 +299,9 @@ function Initialize-Agt226Session {
 
     Test-Agt226GraphScopes -Profile $ScopeProfile | Out-Null
 
-    $gating = Test-Agt226PreviewGating
+    $gating = Test-Agt226LicenseCoverageGating
     if ($gating.Status -eq 'NotApplicable') {
-        Write-Warning "Preview gating not satisfied: $($gating.Reason). Helpers will return Status='NotApplicable' for agent-identity inventories."
+        Write-Warning "License coverage gating not satisfied: $($gating.Reason). Helpers will return Status='NotApplicable' for agent-identity inventories."
     }
 
     $session = [pscustomobject]@{
@@ -313,7 +313,7 @@ function Initialize-Agt226Session {
         TenantId            = (Get-MgContext).TenantId
         SessionStarted      = (Get-Date).ToUniversalTime()
         PimActivationAge    = $null
-        PreviewGating       = $gating.Status
+        LicenseCoverageGating = $gating.Status
         Status              = 'Clean'
     }
 
@@ -363,7 +363,7 @@ function Get-Agt226AgentSponsorInventory {
         throw "Initialize-Agt226Session must be called first."
     }
 
-    $gating = Test-Agt226PreviewGating
+    $gating = Test-Agt226LicenseCoverageGating
     if ($gating.Status -eq 'NotApplicable') {
         return [pscustomobject]@{
             ControlId = '2.26'
@@ -1070,7 +1070,7 @@ function Export-Agt226EvidencePack {
         namespace       = 'fsi-agentgov.entra-agentid'
         tenant_id       = (Get-MgContext).TenantId
         cloud             = 'Commercial'
-        preview_gating  = $script:Agt226Session.PreviewGating
+        license_coverage_gating = $script:Agt226Session.LicenseCoverageGating
         criteria        = $criteria
     }
 
@@ -1122,7 +1122,7 @@ function Export-Agt226EvidencePack {
   "namespace": "fsi-agentgov.entra-agentid",
   "tenant_id": "guid",
   "cloud": "Commercial",
-  "preview_gating": "Clean|NotApplicable",
+  "license_coverage_gating": "Clean|NotApplicable",
   "criteria": {
     "AgentSponsorInventory": [ /* rows */ ],
     "OrphanedAgent": [ /* rows */ ],
@@ -1477,7 +1477,7 @@ function New-Agt226AttestationPack {
         attesting_operator  = $AttestingOperator
         tenant_id           = $session.TenantId
         cloud             = 'Commercial'
-        preview_gating      = $session.PreviewGating
+        license_coverage_gating = $session.LicenseCoverageGating
         evidence_pack_sha256 = $pack.Sha256
         evidence_pack_path  = $pack.JsonPath
         criterion_rollup    = $rollup
@@ -1528,7 +1528,7 @@ function Test-Agt226PlaybookHealth {
         @{ Name = 'ShellEdition';      Test = { Assert-Agt226Shell; $true } }
         @{ Name = 'ModulesPinned';     Test = { (Install-Agt226ModuleBaseline).Status -eq 'Clean' } }
         @{ Name = 'GraphScopes';       Test = { (Test-Agt226GraphScopes -Profile ReadOnly).Status -eq 'Clean' } }
-        @{ Name = 'PreviewGating';     Test = { (Test-Agt226PreviewGating).Status -in @('Clean','NotApplicable') } }
+        @{ Name = 'LicenseCoverageGating';     Test = { (Test-Agt226LicenseCoverageGating).Status -in @('Clean','NotApplicable') } }
     )
 
     foreach ($c in $checks) {
@@ -1580,7 +1580,7 @@ When operators document findings produced by these helpers, use only the hedged 
 
 Implementation caveat to retain in narrative reports:
 
-> "Implementation requires an active Microsoft 365 Copilot license and either a Microsoft Agent 365 (standalone) or Microsoft 365 E7 (Frontier Suite) license assigned to each operating principal. Organizations should verify license-coverage gating before relying on inventory completeness."
+> "Implementation requires an active Microsoft 365 Copilot license and either a Microsoft Agent 365 (standalone) or Microsoft 365 E7 ("Frontier Suite") license assigned to each operating principal. Organizations should verify license-coverage gating before relying on inventory completeness."
 
 
 ---

--- a/docs/playbooks/control-implementations/2.26/troubleshooting.md
+++ b/docs/playbooks/control-implementations/2.26/troubleshooting.md
@@ -2,7 +2,7 @@
 
 > **Scope.** This playbook covers operational failure modes for the Entra Agent ID identity-governance program: license / access gating, sponsor assignment and leaver handling, agent-identity access packages, lifecycle workflows for agents, quarterly access reviews of agent identities, orphan detection, SIEM forwarding, and service availability gaps. It is the diagnostic companion to the Control 2.26 specification, the portal walkthrough, the PowerShell setup pack, and the verification-testing pack.
 >
-> **Post-GA status (May 2026).** Microsoft Agent 365 reached general availability on May 1, 2026 and Microsoft Entra Agent ID is generally available. The pre-GA "Frontier program enrollment" gate is replaced by **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. Pillar names that include "PREVIEW" or "Frontier" — for example **PREVIEW-ACCESS-MISSING** (§2) and **RB-01** (§10) — retain their pre-GA short names and anchor IDs for backward compatibility because the underlying root cause (the calling principal cannot reach the agent identity surface) is the same observable; only the gating mechanism changed. A follow-up issue tracks renaming these pillars / runbooks to license-coverage terms.
+> **Post-GA status (May 2026).** Microsoft Agent 365 reached general availability on May 1, 2026 and Microsoft Entra Agent ID is generally available. The pre-GA "Frontier program enrollment" gate is replaced by **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. Pillar **PREVIEW-ACCESS-MISSING** was renamed to **LICGAP-ACCESS-MISSING** in issue #418; anchor `#2-pillar-licgap-access-missing` is now canonical. This pillar and runbook rename was completed in issue #418.
 >
 > **Status hedging.** The core Entra Agent ID surface is GA; some adjacent surfaces (e.g. the Lifecycle Workflows agent-sponsor tasks, the `agentSignIn` log type) remain in Public Preview. Behavior, blade names, Graph endpoints (`/beta/servicePrincipals` filtered by `servicePrincipalType eq 'Agent'`), and Lifecycle Workflow agent task templates may continue to evolve post-GA. Procedures here are written to the May 2026 surface; verify the **Last UI Verified** stamp at the top of `2.26-entra-agent-id-identity-governance.md` before treating any step as authoritative for an examiner artifact.
 >
@@ -14,7 +14,7 @@
 
 - [§0. Triage tree — symptom → pillar](#0-triage-tree-symptom-pillar)
 - [§1. Diagnostic data collection (`Get-Agt226*` helpers, Graph queries, KQL)](#1-diagnostic-data-collection)
-- [§2. Pillar PREVIEW-ACCESS-MISSING — Microsoft Agent 365 / M365 E7 license-coverage gating (post-GA semantic equivalent of the pre-GA Frontier / Copilot gate)](#2-pillar-preview-access-missing)
+- [§2. Pillar LICGAP-ACCESS-MISSING — Microsoft Agent 365 / M365 E7 license-coverage gating](#2-pillar-licgap-access-missing)
 - [§3. Pillar SPONSOR-NULL — agent created without a human sponsor](#3-pillar-sponsor-null)
 - [§4. Pillar SPONSOR-DEPARTED — sponsor leaver-event handling](#4-pillar-sponsor-departed)
 - [§5. Pillar ACCESSPKG-FAIL — agent-identity access-package assignment failures](#5-pillar-accesspkg-fail)
@@ -40,8 +40,8 @@ Use this table as the first stop for any reported issue. It maps an observed sym
 
 | # | Symptom (what the reporter said) | Most likely pillar | Severity floor | Runbook? |
 |---|----------------------------------|--------------------|----------------|----------|
-| S-01 | "I cannot see the **Agent identities (preview)** blade in Entra." | [§2 PREVIEW-ACCESS-MISSING](#2-pillar-preview-access-missing) | SEV-4 | — |
-| S-02 | "An admin can see the blade, but **the Agent 365 control plane is empty / Researcher and Workflows agents are missing** (legacy reports phrase this as 'Frontier features greyed out')." | [§2 PREVIEW-ACCESS-MISSING](#2-pillar-preview-access-missing) | SEV-3 | [RB-01](#10-runbook-rb-01) |
+| S-01 | "I cannot see the **Agent identities (preview)** blade in Entra." | [§2 LICGAP-ACCESS-MISSING](#2-pillar-licgap-access-missing) | SEV-4 | — |
+| S-02 | "An admin can see the blade, but **the Agent 365 control plane is empty / Researcher and Workflows agents are missing** (legacy reports phrase this as 'Frontier features greyed out')." | [§2 LICGAP-ACCESS-MISSING](#2-pillar-licgap-access-missing) | SEV-3 | [RB-01](#10-runbook-rb-01) |
 | S-03 | "A new agent was registered yesterday and **has no sponsor field populated**." | [§3 SPONSOR-NULL](#3-pillar-sponsor-null) | SEV-3 | — |
 | S-04 | "Quarterly orphan scan reports **dozens of agents with null sponsor**." | [§3 SPONSOR-NULL](#3-pillar-sponsor-null) | SEV-2 | — |
 | S-05 | "Sponsor left the firm three weeks ago; agents **still show old sponsor**." | [§4 SPONSOR-DEPARTED](#4-pillar-sponsor-departed) | SEV-2 | [RB-02](#11-runbook-rb-02) |
@@ -126,7 +126,7 @@ function Get-Agt226Health {
         OrphanCount      = (Get-AgentsWithoutSponsors).Count
         AccessPkgCount   = (Get-AgentAccessPackageAssignments).Count
         SponsorCoverage  = (Get-AgentGovernanceSummary).SponsorCoveragePct
-        FrontierEnabled  = (Get-MgBetaAdminMicrosoft365CopilotSetting -ErrorAction SilentlyContinue).FrontierProgramEnabled
+        AgentIdSurfaceEnabled = (Get-MgBetaAdminMicrosoft365CopilotSetting -ErrorAction SilentlyContinue).FrontierProgramEnabled
     }
     $out = $snap | ConvertTo-Json -Depth 5
     if ($IncidentId) {
@@ -286,19 +286,18 @@ AuditLogs
 | E-05 | Lifecycle Workflow definition + last 5 runs | §1.1 `Get-Agt226LifecycleStatus` | `FSI-Examiner-Hold-7yr` |
 | E-06 | Active access review definition + scope | §1.1 `Get-Agt226ReviewCoverage` | `FSI-Examiner-Hold-7yr` |
 | E-07 | Sponsor `employeeLeaveDateTime` value at detection | GQ-04 | `FSI-Examiner-Hold-7yr` |
-| E-08 | Tenant cloud + license posture (Copilot + Agent 365 / M365 E7) | `Get-Agt226Health.FrontierEnabled` (field name retained for backward-compat — value reflects Agent ID API surface reachability) + license assignment report | `FSI-Examiner-Hold-7yr` |
+| E-08 | Tenant cloud + license posture (Copilot + Agent 365 / M365 E7) | `Get-Agt226Health.AgentIdSurfaceEnabled` (value reflects Agent ID API surface reachability post-GA) + license assignment report | `FSI-Examiner-Hold-7yr` |
 | E-09 | Operator identity + UTC timestamp of every remediation step | Incident ticket / change record | `FSI-Examiner-Hold-7yr` |
 
 `Export-Control226EvidencePackage -IncidentId <id>` bundles E-01 through E-08 automatically. E-09 is captured in the incident ticket by the operator.
 
 ---
 
-## §2. Pillar PREVIEW-ACCESS-MISSING
+## §2. Pillar LICGAP-ACCESS-MISSING
 
-<a id="frontier-enrolled-but-blade-403"></a>
 <a id="all-agents-preview-missing"></a>
 
-> **Namespace name retained for backward-compatibility.** Pre-GA, this pillar covered Frontier enrollment + Copilot license gaps. Post-GA (May 2026), it covers **Microsoft Agent 365 / Microsoft 365 E7 license-assignment gaps** and **RBAC gaps** that surface as missing-blade or empty-blade symptoms. The pillar name and section anchors are preserved across the GA cutover so existing runbook references continue to resolve.
+> **Pillar renamed in issue #418.** Pre-GA this pillar was named PREVIEW-ACCESS-MISSING. Post-GA (May 2026) and after the #418 rename it covers **Microsoft Agent 365 / Microsoft 365 E7 license-assignment gaps** and **RBAC gaps** that surface as missing-blade or empty-blade symptoms.
 
 **One-line:** the **Agent identities** blade is invisible, partially populated, or rejects actions because post-GA prerequisites (license + RBAC) are not met for the tenant or the operator.
 
@@ -327,9 +326,8 @@ AuditLogs
 ### 2.3 Diagnostic queries
 
 ```powershell
-# Quick check (post-GA: FrontierEnabled field reflects Agent ID API reachability,
-# not the historical Frontier program flag — name retained for backward-compat)
-Get-Agt226Health | Select Cloud, FrontierEnabled, AgentCount
+# Quick check (post-GA: AgentIdSurfaceEnabled reflects Agent ID API reachability)
+Get-Agt226Health | Select Cloud, AgentIdSurfaceEnabled, AgentCount
 
 # Operator license check (post-GA: prefer Agent 365 / M365 E7; transitional Copilot match retained)
 Get-MgUserLicenseDetail -UserId <operator-upn> |
@@ -354,8 +352,8 @@ Graph: GQ-01 returning 400/404 → operating principal lacks Microsoft Agent 365
 
 ### 2.5 Verification
 
-- `Get-Agt226Health` returns `FrontierEnabled = True` and `AgentCount > 0` (assuming agents exist).
-- Pester: `Describe 'Control 2.26 — Preview Gating'` → `It 'has Agent ID API surface reachable in commercial tenants'` and `It 'admins have Agent ID Admin role'` should now pass. See [`./verification-testing.md`](./verification-testing.md).
+- `Get-Agt226Health` returns `AgentIdSurfaceEnabled = True` and `AgentCount > 0` (assuming agents exist).
+- Pester: `Describe 'Control 2.26 — License Coverage Gating'` → `It 'has Agent ID API surface reachable in commercial tenants'` and `It 'admins have Agent ID Admin role'` should now pass. See [`./verification-testing.md`](./verification-testing.md).
 
 ### 2.6 Cross-links
 
@@ -840,7 +838,7 @@ Preserve E-03 (KQL exports) and a snapshot of the SIEM detection-rule definition
 
 1. Confirm renewed SKU assigned and provisioned (`Success` not `PendingProvisioning`).
 2. Verify Microsoft Agent 365 / M365 E7 license assignment is reattached to operating principals after the renewal posts; it can take up to 24h for the Agent identities surface to reflect the reassignment. If the surface remains empty after 24h, open a Microsoft support ticket per §2.7.
-3. Resume paused operations. Run `Get-Agt226Health` and confirm `FrontierEnabled = True`, `AgentCount` matches pre-incident.
+3. Resume paused operations. Run `Get-Agt226Health` and confirm `AgentIdSurfaceEnabled = True`, `AgentCount` matches pre-incident.
 
 ### 10.5 Lessons-learned / reportability
 
@@ -850,7 +848,7 @@ Preserve E-03 (KQL exports) and a snapshot of the SIEM detection-rule definition
 
 ### 10.6 Cross-links
 
-- [§2 PREVIEW-ACCESS-MISSING](#2-pillar-preview-access-missing).
+- [§2 LICGAP-ACCESS-MISSING](#2-pillar-licgap-access-missing).
 
 ---
 
@@ -1081,7 +1079,7 @@ For each pillar §2–§9, the verification-testing pack ([`./verification-testi
 
 | Pillar | Pester `Describe` | Trigger conditions |
 |--------|-------------------|---------------------|
-| §2 | `'Preview gating'` | Operating principal lacks Microsoft Agent 365 / M365 E7 license coverage, missing Copilot SKU, or missing Agent ID Admin role |
+| §2 | `'License coverage gating'` | Operating principal lacks Microsoft Agent 365 / M365 E7 license coverage, missing Copilot SKU, or missing Agent ID Admin role |
 | §3 | `'Sponsor coverage'` | Any agent with null sponsor |
 | §4 | `'Sponsor leaver behavior'` | Workflow customization that disables instead of transfers |
 | §5 | `'Access package shape'` | SharePoint resource directly on agent-eligible package |

--- a/docs/playbooks/control-implementations/2.26/verification-testing.md
+++ b/docs/playbooks/control-implementations/2.26/verification-testing.md
@@ -2,7 +2,7 @@
 
 > **Examiner-defensible evidence package** for Control 2.26. This playbook produces, signs, and retains the artifacts required to demonstrate to FINRA, SEC, OCC, FFIEC, and internal audit that every Microsoft 365 AI agent identity in the tenant is sponsored, lifecycle-governed, periodically reviewed, and forwarded to the SIEM with 6-year retention.
 >
-> **Post-GA status (May 2026):** Microsoft Agent 365 reached general availability on May 1, 2026 and Microsoft Entra Agent ID is generally available. The pre-GA "Frontier program enrollment" gate is replaced by **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. Pre-flight gate `PRE-06` and the §8 `TRG-PREVIEW-01` test retain their pre-GA names for backward compatibility; the underlying probe (HTTP 200 from `/beta/agents`) remains the correct observable because both the pre-GA Frontier enrollment and the post-GA license assignment manifest as the same API reachability state for the calling principal. A follow-up issue tracks renaming PRE-06 / TRG-PREVIEW-01 to license-coverage terms.
+> **Post-GA status (May 2026):** Microsoft Agent 365 reached general availability on May 1, 2026 and Microsoft Entra Agent ID is generally available. The pre-GA "Frontier program enrollment" gate is replaced by **Microsoft Agent 365 / Microsoft 365 E7 license assignment**. Pre-flight gate `PRE-06` and the §8 `TRG-LICGAP-01` test retain their pre-GA names for backward compatibility; the underlying probe (HTTP 200 from `/beta/agents`) remains the correct observable because both the pre-GA Frontier enrollment and the post-GA license assignment manifest as the same API reachability state for the calling principal. TRG-LICGAP-01 was renamed to TRG-LICGAP-01 in issue #418.
 >
 > **Scope:** Commercial M365 tenants with Microsoft Agent 365 or Microsoft 365 E7 licensing assigned to the operating admin and the in-scope sponsor / agent-owner users.
 >
@@ -80,7 +80,7 @@ The eight Verification Criteria from [Control 2.26](../../../controls/pillar-2-m
 
 | Namespace | Evidences Criterion | Section | Cadence | Owner |
 |---|---|---|---|---|
-| `PREVIEW` | C2.26-1 (Agent ID surface reachable — Microsoft Agent 365 / M365 E7 + Microsoft 365 Copilot license coverage; namespace name retained for backward-compat) | §8 | Per release / monthly | Entra Agent ID Admin |
+| `LICGAP` | C2.26-1 (Agent ID surface reachable — Microsoft Agent 365 / M365 E7 + Microsoft 365 Copilot license coverage) | §8 | Per release / monthly | Entra Agent ID Admin |
 | `SPONSOR` | C2.26-2 (every Z2/Z3 agent has assigned sponsor) | §2 | Daily | AI Governance Lead |
 | `ACCESSPKG` | C2.26-3 + C2.26-4 (packages exist; ≤365-day expiry; no perpetual Z3) | §3 | Daily | Entra Identity Governance Admin |
 | `LIFECYCLE` | C2.26-5 (workflow triggers on sponsor departure; manager-transfer succeeds) | §4 | Weekly | Entra Identity Governance Admin |
@@ -1099,10 +1099,10 @@ Describe "AGT226-SIEM" -Tag 'C2.26','SIEM' {
 
 ---
 
-## §8 PREVIEW — Agent ID Licensing & Blade Operability Verification
+## §8 LICGAP — Agent ID Licensing & Blade Operability Verification
 
-!!! info "Namespace name preserved for backward-compatibility"
-    Pre-GA this namespace evidenced Microsoft Frontier program enrollment + Copilot licensing. Post-GA (May 2026) it evidences **Microsoft Agent 365 / Microsoft 365 E7 license assignment** plus **Agent ID API surface operability**. The `PREVIEW` namespace name, the `TRG-PREVIEW-01` runbook ID, and the `frontier_probe_status` field name are retained to keep evidence-pack schemas backward-compatible across the GA cutover. **Field semantics have changed** — see prose below.
+!!! info "Namespace renamed — Issue #418"
+    Pre-GA this namespace evidenced Microsoft Frontier program enrollment + Copilot licensing. Post-GA (May 2026) it evidences **Microsoft Agent 365 / Microsoft 365 E7 license assignment** plus **Agent ID API surface operability**. In issue #418: namespace renamed `PREVIEW` → `LICGAP`; runbook ID renamed `TRG-PREVIEW-01` → `TRG-LICGAP-01`; field renamed `frontier_probe_status` → `agent_id_probe_status`. Update any examiner pipelines that parse these keys.
 
 ### 8.1 Criterion mapping
 
@@ -1122,7 +1122,7 @@ In addition, the **Agent identities** blade must be reachable in the Microsoft E
 ### 8.3 Pester suite
 
 ```powershell
-Describe "AGT226-PREVIEW" -Tag 'C2.26','PREVIEW' {
+Describe "AGT226-LICGAP" -Tag 'C2.26','LICGAP' {
 
     BeforeAll {
         # Post-GA: prefer Agent 365 / M365 E7 SKUs. Verify SkuPartNumber values
@@ -1185,7 +1185,7 @@ Describe "AGT226-PREVIEW" -Tag 'C2.26','PREVIEW' {
 ```json
 {
   "control_id": "2.26",
-  "namespace": "PREVIEW",
+  "namespace": "LICGAP",
   "criterion": "C2.26-1",
   "zone": "all",
   "subject_id": "tenant-feature-state",
@@ -1195,47 +1195,47 @@ Describe "AGT226-PREVIEW" -Tag 'C2.26','PREVIEW' {
   "observed_value": {
     "license_skus": ["Microsoft_Agent_365"],
     "license_consumed_units": 1500,
-    "frontier_probe_status": 200,
+    "agent_id_probe_status": 200,
     "agents_endpoint_response": "ok",
     "agents_count_in_probe": 23
   },
   "regulator_mappings": ["SOX-404","OCC-2011-12"],
-  "evidence_artifacts": ["preview-state-AGT226-20260415-093012-a1b2c3d4.json"],
+  "evidence_artifacts": ["licgap-state-AGT226-20260415-093012-a1b2c3d4.json"],
   "schema_version": "1.0"
 }
 ```
 
-> **Field-name carryover.** `frontier_probe_status` is retained as the field key for the HTTP status returned by the `/beta/agents` probe. The field name is preserved to keep examiner pipelines that already parse this key working across the GA cutover. Post-GA, a `200` indicates the Agent ID surface is reachable; a `403/404` indicates a license-coverage or RBAC gap, **not** a Frontier-enrollment gap.
+> **Field-name carryover.** `agent_id_probe_status` is retained as the field key for the HTTP status returned by the `/beta/agents` probe. The field name is preserved to keep examiner pipelines that already parse this key working across the GA cutover. Post-GA, a `200` indicates the Agent ID surface is reachable; a `403/404` indicates a license-coverage or RBAC gap, **not** a Frontier-enrollment gap.
 
 ### 8.5 Sample failing record
 
 ```json
 {
   "control_id": "2.26",
-  "namespace": "PREVIEW",
+  "namespace": "LICGAP",
   "criterion": "C2.26-1",
   "status": "FAIL",
   "assertion": "Agent ID operability gate must return HTTP 200 from /beta/agents",
   "observed_value": {
     "license_skus": ["Microsoft_Agent_365"],
-    "frontier_probe_status": 404,
+    "agent_id_probe_status": 404,
     "probe_error": "Resource not found: /beta/agents"
   },
-  "remediation_ref": "TRG-PREVIEW-01",
+  "remediation_ref": "TRG-LICGAP-01",
   "regulator_mappings": ["SOX-404","OCC-2011-12"],
   "schema_version": "1.0"
 }
 ```
 
-`TRG-PREVIEW-01` (§8.10): confirm Microsoft Agent 365 / M365 E7 license is assigned to the calling principal and the tenant has at least one consumed unit; verify the calling principal holds the required RBAC role (Entra Agent ID Admin or AI Administrator); halt deployment of any new Z2/Z3 agents while the gap persists; downgrade any Z2/Z3 agents created during the gap to Z1 and re-evaluate when access is restored. If license + RBAC are confirmed and the surface is still unreachable, raise a Microsoft support case via standard support channels.
+`TRG-LICGAP-01` (§8.10): confirm Microsoft Agent 365 / M365 E7 license is assigned to the calling principal and the tenant has at least one consumed unit; verify the calling principal holds the required RBAC role (Entra Agent ID Admin or AI Administrator); halt deployment of any new Z2/Z3 agents while the gap persists; downgrade any Z2/Z3 agents created during the gap to Z1 and re-evaluate when access is restored. If license + RBAC are confirmed and the surface is still unreachable, raise a Microsoft support case via standard support channels.
 
 ### 8.6 Examiner artifact
 
 | Artifact | Filename | Retention |
 |---|---|---|
-| Feature-state snapshot | `preview-state-<runId>.json` | 6 years |
-| Copilot SKU list | `preview-skus-<runId>.json` | 6 years |
-| Agent ID API probe response (raw) | `preview-agent-id-api-probe-<runId>.json` | 6 years |
+| Feature-state snapshot | `licgap-state-<runId>.json` | 6 years |
+| Copilot SKU list | `licgap-skus-<runId>.json` | 6 years |
+| Agent ID API probe response (raw) | `agent-id-api-probe-<runId>.json` | 6 years |
 
 ### 8.7 Zone thresholds
 
@@ -1268,12 +1268,12 @@ evidence-pack-AGT226-20260415-093012-a1b2c3d4/
 ├── manifest.json                           # Top-level descriptor (schema below)
 ├── attestation.json                        # Signature chain
 ├── records/
-│   ├── 0001-PREVIEW.json
+│   ├── 0001-LICGAP.json
 │   ├── 0002-SPONSOR-zone1.json
 │   ├── 0003-SPONSOR-zone2.json
 │   ├── ... (one file per evidence record)
 ├── pester/
-│   ├── pester-PREVIEW.xml
+│   ├── pester-LICGAP.xml
 │   ├── pester-SPONSOR.xml
 │   └── ... (JUnit XML per namespace)
 ├── snapshots/
@@ -1298,7 +1298,7 @@ evidence-pack-AGT226-20260415-093012-a1b2c3d4/
   "cloud": "Commercial",
   "produced_at": "2026-04-15T09:42:18Z",
   "operator_upn": "agt226-runner@contoso.com",
-  "namespaces_executed": ["PREVIEW","SPONSOR","ACCESSPKG","LIFECYCLE","REVIEW","EXPIRY","SIEM"],
+  "namespaces_executed": ["LICGAP","SPONSOR","ACCESSPKG","LIFECYCLE","REVIEW","EXPIRY","SIEM"],
   "namespaces_skipped": [],
   "record_count": 187,
   "pass_count": 184,
@@ -1328,7 +1328,7 @@ Each record file is hashed (SHA-256 over its UTF-8 byte content). The hashes are
 {
   "algorithm": "SHA-256",
   "leaves": [
-    { "filename": "records/0001-PREVIEW.json",          "sha256": "a1b2..." },
+    { "filename": "records/0001-LICGAP.json",          "sha256": "a1b2..." },
     { "filename": "records/0002-SPONSOR-zone1.json",    "sha256": "c3d4..." },
     { "filename": "records/0003-SPONSOR-zone2.json",    "sha256": "e5f6..." }
   ],
@@ -1413,7 +1413,7 @@ Every pack ships with a `README.md` written for a non-technical examiner audienc
 
 | Severity | Meaning | Page on-call within | Containment SLA | Resolution SLA | Examples |
 |---|---|---|---|---|---|
-| Critical | Z3 agent operating without sponsor, perpetual Z3 grant, stale-grant > 24h | 15 minutes | 1 hour (suspend) | 24 hours | TRG-SPONSOR-01 (Z3 sponsor null), TRG-EXPIRY-01 (Z3 stale), TRG-PREVIEW-01 |
+| Critical | Z3 agent operating without sponsor, perpetual Z3 grant, stale-grant > 24h | 15 minutes | 1 hour (suspend) | 24 hours | TRG-SPONSOR-01 (Z3 sponsor null), TRG-EXPIRY-01 (Z3 stale), TRG-LICGAP-01 |
 | High | Z2 agent without sponsor, lifecycle workflow failure, SIEM retention < 5y, missing quarterly review | 1 hour | 4 hours | 72 hours | TRG-SPONSOR-02 (Z2), TRG-LIFECYCLE-01, TRG-SIEM-01, TRG-REVIEW-01 |
 | Medium | Z2 expiry > 24h–72h late, package expiry 366–400 days, manager declines transfer (escalation) | 4 hours | 24 hours | 7 days | TRG-EXPIRY-02, TRG-ACCESSPKG-01, TRG-LIFECYCLE-02 |
 | Low | Z1 sponsor != creator (data hygiene), justification < 50 chars, single transient probe error | 1 business day | 5 business days | 30 days | TRG-SPONSOR-03, TRG-EXPIRY-03 |
@@ -1464,9 +1464,9 @@ Every pack ships with a `README.md` written for a non-technical examiner audienc
 - **Remediation:** engage SecOps to extend SIEM retention; raise the variance with the Compliance Officer; document the temporary parallel export and decommission it once SIEM is compliant.
 
 
-### 10.9 TRG-PREVIEW-01 — Agent ID licensing or operability gate FAIL
+### 10.9 TRG-LICGAP-01 — Agent ID licensing or operability gate FAIL
 
-- **Trigger:** §8 reports `frontier_probe_status` of 403/404, or no Agent 365 / M365 E7 license consumed.
+- **Trigger:** §8 reports `agent_id_probe_status` of 403/404, or no Agent 365 / M365 E7 license consumed.
 - **Containment:** halt deployment of any new Z2/Z3 agents.
 - **Remediation:** confirm Microsoft Agent 365 or Microsoft 365 E7 license is assigned and consumed; verify the calling principal holds the Entra Agent ID Admin or AI Administrator role; if license + RBAC are confirmed and the surface is still unreachable, raise a Microsoft support case via standard support channels. Downgrade any Z2/Z3 agents created during the gap to Z1 and re-evaluate when access is restored.
 


### PR DESCRIPTION
## Summary

Executes deferred tracker **#418** — structural rename of leftover `Frontier`/`Preview` pre-GA identifiers in controls **2.25** and **2.26**.

**This is identifier cleanup, NOT a correctness fix.** `Microsoft 365 E7 ("Frontier Suite")` is legitimate and is preserved; only stale structural identifiers from the pre-GA gating design were renamed.

### Rename map (structural identifiers only)
- `Test-Agt22xPreviewGating` → `Test-Agt22xLicenseCoverageGating`
- `PreviewGating*` session/exception/criterion → `LicenseCoverage*`
- `preview_gating` (JSON) → `license_coverage_gating`
- `PREVIEW` namespace / `AGT226-PREVIEW` / `TRG-PREVIEW-01` → `LICGAP` / `AGT226-LICGAP` / `TRG-LICGAP-01`
- `frontier_probe_status` → `agent_id_probe_status`
- `PREVIEW-ACCESS-MISSING` pillar → `LICGAP-ACCESS-MISSING`
- `FrontierEnabled` → `AgentIdSurfaceEnabled`
- Removed dead backward-compat anchors (`#2-frontier-program-enrollment`, `frontier-enrolled-but-blade-403`)
- Normalized bare `Frontier Suite` prose → `Microsoft 365 E7 ("Frontier Suite")`
- 2.26 portal-walkthrough note now cites **#418**

### Deliberately left unchanged (legitimate Microsoft tokens)
`FrontierProgramEnabled` (Graph API property), `SPE_E7_FRONTIER` (SKU code), `AllowPreviewSurfaces`, `(preview)` UI labels, MS flighting strings.

### Gates — independently verified (reviewer ≠ author)
- ✅ `mkdocs build --strict` (exit 0)
- ✅ `verify_xref_graph.py` (broken_id=[], mislabeled=[])
- ✅ `verify_language_rules.py`
- ✅ `check_manifest_doc_drift.py --check`
- ✅ `verify_controls.py`
- ✅ Dangling-reference hunt clean; no over-reach; no sovereign content; diff scoped to 2.25/2.26 only.

US-FSI / Microsoft commercial cloud scope only.

Closes #418