### PR TITLE
docs(labs): correct Copilot Studio agent-creation nav in ELM lab (#77 tech-accuracy)

### DIFF
--- a/docs/playbooks/advanced-implementations/environment-lifecycle-management/labs.md
+++ b/docs/playbooks/advanced-implementations/environment-lifecycle-management/labs.md
@@ -292,15 +292,15 @@ Build the conversational intake agent that collects environment requests.
 
 1. Navigate to **copilotstudio.microsoft.com**
 2. In the top-right corner, verify your **environment** matches Lab 1 (click the environment name to switch if needed)
-3. From the left navigation, select **Copilots**
-4. Select **+ New copilot** > **New copilot**
-5. In the creation wizard:
-   - **Name:** Environment Request Agent
-   - **Description:** Collects and processes Power Platform environment provisioning requests
+3. From the left navigation, select **Agents**
+4. Select the down arrow next to **Create blank agent**, then select **Advanced create** (this lets you set the primary language, solution, and schema name up front)
+5. Configure:
    - **Language:** English (United States)
    - **Solution:** (Optional) Select a solution if using ALM
-6. Select **Create**
-7. Wait for the agent to be created (this may take 1-2 minutes)
+6. Select **Confirm and create** and wait for the agent to be provisioned (this may take 1-2 minutes)
+7. On the agent's **Overview** page, select **Edit** in the **Details** section to set:
+   - **Name:** Environment Request Agent
+   - **Description:** Collects and processes Power Platform environment provisioning requests
 
 ### Step 2.2: Configure Authentication
 


### PR DESCRIPTION
## Summary
Tech-accuracy audit (issue #77, run #2) of in-scope lab/portal-walkthrough materials for executable/portal-step correctness against current Microsoft Learn guidance. Scope: `docs/playbooks/**/labs.md` and `docs/playbooks/**/portal-walkthrough.md` (excluding the run #1 pending-PR files).

This PR is intentionally **surgical**: most embedded commands (Microsoft Graph PowerShell `Get-Mg*` cmdlets, `Microsoft.PowerApps.Administration.PowerShell` cmdlets, Graph REST `serviceAnnouncement/messages`, `ServiceMessage.Read.All` permission, portal URLs like `security.microsoft.com` / `purview.microsoft.com` / `entra.microsoft.com`) were verified **correct/current** and left unchanged.

## Change (1 file)
**`environment-lifecycle-management/labs.md` — Lab 2, Step 2.1 (Create New Agent)**
The Copilot Studio agent-creation navigation used retired Power Virtual Agents-era terminology:
- `select **Copilots**` → `select **Agents**` (current left-nav page name)
- `Select **+ New copilot** > **New copilot**` → `Create blank agent` / **Advanced create** (current creation flow)
- Name/Description are now set on the **Overview** page (**Details > Edit**) after provisioning, matching the current experience.

## Flag-over-rewrite notes (left as-is on purpose)
- `1.14` and `3.6` portal-walkthroughs already hedge "Copilots/Agents (varies by rollout)" — defensible, not changed.
- Step 2.2/2.3 Copilot Studio sub-steps (Settings > Security; Topics) were not certain enough to change.

## Sources
- Quickstart: Create and deploy an agent — https://learn.microsoft.com/en-us/microsoft-copilot-studio/fundamentals-get-started
- Create and delete agents (Agents page, Create blank agent, Advanced create, Overview > Details > Edit) — https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-first-bot

## Validation
- `mkdocs build --strict` — green (built in ~87s)

Resolves work for judeper/OceanSquad#77.