### PR TITLE
Tech-accuracy: flag undocumented Copilot admin Graph endpoint (scripts audit, OceanSquad#76)

### DIFF
--- a/scripts/governance/Test-ZoneAgentAccess.ps1
+++ b/scripts/governance/Test-ZoneAgentAccess.ps1
@@ -476,7 +476,14 @@ Write-Verbose "Check 1: Agent Access Control Policy (ZAV-01)..."
 
 if ($graphToken) {
     try {
-        # Attempt to read Copilot settings via Graph beta endpoint
+        # NOTE (technical accuracy): This is NOT a documented Microsoft Graph endpoint. The
+        # documented Copilot admin surface is /copilot/admin/settings/limitedMode and
+        # /copilot/admin/policySettings/* (Graph beta) — neither exposes an agent-access policy.
+        # As a result this request does not resolve and the check degrades to manual verification
+        # (the catch/Skip branch). Do NOT repoint this URL to a real endpoint without tenant
+        # validation: a 200 response lacking the assumed properties sets policyValue='Unknown'
+        # and would flip the Zone 3 result to a false 'Fail'. Re-evaluate if/when Microsoft Graph
+        # exposes these Copilot governance settings.
         $copilotSettings = Invoke-GraphApi -Uri "https://graph.microsoft.com/beta/admin/microsoft365/copilot/settings" -Token $graphToken
 
         # Compute evidence hash
@@ -769,8 +776,10 @@ Write-Verbose "Check 3: Deployment Group Configuration (ZAV-03)..."
 
 if ($graphToken) {
     try {
-        # Attempt to read deployment group configuration via Graph beta
-        # This targets the M365 Admin Center Copilot deployment settings
+        # NOTE (technical accuracy): Not a documented Microsoft Graph endpoint (see Check 1).
+        # Copilot deployment-group configuration is not exposed via Graph; this request does not
+        # resolve and the check degrades to the semi-automated/manual path below. Do not repoint
+        # this URL without tenant validation.
         $deploymentConfig = Invoke-GraphApi -Uri "https://graph.microsoft.com/beta/admin/microsoft365/copilot/settings" -Token $graphToken
 
         $c3EvidenceJson = $null
@@ -879,7 +888,9 @@ Write-Verbose "Check 4: Web Search Control (ZAV-04)..."
 
 if ($graphToken) {
     try {
-        # Re-use copilot settings from Check 1 if available, otherwise re-fetch
+        # Re-use copilot settings from Check 1 if available, otherwise re-fetch.
+        # NOTE (technical accuracy): same undocumented endpoint as Check 1 — web-search governance
+        # is not exposed via Microsoft Graph, so this degrades to manual verification.
         if (-not $copilotSettings) {
             $copilotSettings = Invoke-GraphApi -Uri "https://graph.microsoft.com/beta/admin/microsoft365/copilot/settings" -Token $graphToken
         }


### PR DESCRIPTION
## Summary

Run #2 technical-accuracy audit of `scripts/**` and `assessment/collectors/**` (issue judeper/OceanSquad#76), focused on **executable correctness** — cmdlet/CLI names, parameters, module/SDK imports, API endpoints, KQL, and URLs — verified statically against current Microsoft Learn.

**Headline:** the scripts are in good shape. Modules, cmdlets, API versions, KQL, and token handling are current. This PR makes **one surgical, comments-only change** that flags a fabricated Microsoft Graph endpoint, plus a documented set of items I deliberately did **not** change.

## Change in this PR

`scripts/governance/Test-ZoneAgentAccess.ps1` — checks ZAV-01/03/04 call:

```
https://graph.microsoft.com/beta/admin/microsoft365/copilot/settings
```

This is **not** a documented Microsoft Graph endpoint. The documented Copilot admin surface is `/copilot/admin/settings/limitedMode` and `/copilot/admin/policySettings/*` (Graph beta) — none of which exposes the agent-access, deployment-group, or web-search governance properties the script probes for.

### Why flag, not rewrite (flag-over-rewrite)

Repointing the URL to a real endpoint would be **unsafe** and would change assessment outcomes:

- Today the fabricated path does not resolve → the request fails → the check lands in its `catch`/`Skip` branch (manual verification). No false result.
- If repointed to a real `copilotAdminSetting` response that lacks the assumed properties, `policyValue` becomes `'Unknown'`, the code takes the **truthy** branch, and for **Zone 3** that yields **`Fail`** (a false compliance gap) instead of `Skip`.

With no live tenant to validate against, the correct action is to **document the endpoint as undocumented/manual** and leave behavior untouched. The change is **comments-only** — no runtime behavior altered.

## Audit coverage — verified current (no change needed)

- **No deprecated modules.** No `AzureAD`/`MSOnline`; scripts use `Microsoft.Graph.*`, `Az.Accounts`, `Az.OperationalInsights`, and `Microsoft.PowerApps.Administration.PowerShell`.
- **`Get-AzAccessToken`** — `-ResourceUrl` is still current; every call site already handles both plain-string (Az.Accounts 2.x) and `SecureString` (3.x+) `.Token`.
- **Microsoft Graph cmdlets** — `Connect-MgGraph`, `Get-MgIdentityConditionalAccessPolicy`, `Get-MgGroup(Member)`, `Get-MgRoleManagementDirectory*`, `Get-MgServicePrincipal`, `Get-MgOrganization`, `Get-MgUser` — all current.
- **Power Platform Admin cmdlets** — `Get-TenantSettings`, `Get-AdminPowerAppEnvironment(RoleAssignment)`, `Get-AdminFlow` — current.
- **BAP Admin API** — `api.bap.microsoft.com` with `api-version` `2016-11-01` (environments) / `2021-04-01` (bots, permissions, settings) — consistent and valid.
- **Dataverse Web API** — `/api/data/v9.2` with `OData-Version: 4.0` — current.
- **Sentinel KQL** — `OfficeActivity | where OfficeWorkload == "Copilot" or RecordType == "CopilotInteraction"` — confirmed against the Copilot audit schema (`Workload: "Copilot"`, `RecordType: 261` / `CopilotInteraction`).
- **Graph v1.0 SharePoint/sites endpoints** and `Connect-IPPSSession` (Security & Compliance PowerShell) — current.

## Sources (Microsoft Learn)

- Copilot admin settings (Graph): https://learn.microsoft.com/en-us/graph/api/resources/copilotadminsetting — endpoints `/copilot/admin/settings/limitedMode`, `/copilot/admin/policySettings/*`.
- Microsoft 365 Copilot APIs overview: https://learn.microsoft.com/en-us/graph/api/resources/copilot-api-overview
- Audit logs for Copilot and AI apps (`RecordType` 261 / `Workload: Copilot`): https://learn.microsoft.com/en-us/purview/audit-copilot
- `Get-AzAccessToken` (`-ResourceUrl`, `-AsSecureString`): https://learn.microsoft.com/en-us/powershell/module/az.accounts/get-azaccesstoken
- Connect-MgGraph: https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.authentication/connect-mggraph
- Dataverse Web API (v9.2): https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/overview

## Validation

- `pwsh Invoke-ScriptAnalyzer` on the edited file — clean
- `ruff check scripts assessment` — passed
- `pytest scripts assessment/tests` — **426 passed, 1 skipped**
- `verify_controls.py`, `check_manifest_doc_drift.py --check`, `verify_language_rules.py`, `generate_coverage_matrix.py --check` — all OK

## Scope notes

- No regulatory/compliance wording touched (out of scope).
- Skipped all run #1 pending-PR paths.
