### PR TITLE
Remove residual sovereign-cloud guidance + Azure AD->Entra in script comments

### DIFF
--- a/scripts/asard_zone_rules.py
+++ b/scripts/asard_zone_rules.py
@@ -205,7 +205,7 @@ def parse_sharing_principals(principals_json: str) -> Dict[str, Any]:
 
             {
                 "individuals": [],        # user principal names / IDs
-                "security_groups": [],    # Azure AD group object IDs
+                "security_groups": [],    # Microsoft Entra ID group object IDs
                 "has_everyone": False,
                 "has_public": False,
                 "has_organization": False,
@@ -291,7 +291,7 @@ def evaluate_zone_compliance(
     parsed_principals : dict
         Output from ``parse_sharing_principals()``.
     approved_groups : list[str] | None
-        Azure AD group IDs approved for this zone (Zone 3 only).
+        Microsoft Entra ID group IDs approved for this zone (Zone 3 only).
         If *None* for Zone 3, skip approved group check (log warning).
 
     Returns
@@ -415,7 +415,7 @@ def get_approved_groups_for_zone(zone: int, client: Any) -> List[str]:
     Returns
     -------
     list[str]
-        Azure AD security group object IDs approved for the zone.
+        Microsoft Entra ID security group object IDs approved for the zone.
         Empty list if no records found or on error.
     """
     try:

--- a/scripts/create_asard_dataverse_schema.py
+++ b/scripts/create_asard_dataverse_schema.py
@@ -352,7 +352,7 @@ def seed_default_policy(client: CAAClient, dry_run: bool = False) -> None:
     """Insert template approved group policy records for each zone.
 
     These are documentation placeholders — admins must populate with
-    actual Azure AD security group IDs for their organization.
+    actual Microsoft Entra ID security group IDs for their organization.
     """
     entity_set = "fsi_approvedsecuritygrouppolicies"
 

--- a/scripts/governance/Set-InactivityTimeout.ps1
+++ b/scripts/governance/Set-InactivityTimeout.ps1
@@ -8,7 +8,7 @@
     durations for US financial services governance zones.
 
     Execution flow:
-    1. Authenticate via Azure AD (Get-AzAccessToken)
+    1. Authenticate via Microsoft Entra ID (Get-AzAccessToken)
     2. GET current privacy settings for the target environment
     3. PATCH inactivity timeout configuration (enable + set durations)
     4. Re-GET settings to verify the PATCH was applied correctly
@@ -142,7 +142,7 @@ Write-Host   "╚═════════════════════
 function Get-BapApiToken {
     <#
     .SYNOPSIS
-        Acquires a BAP Admin API access token via Azure AD.
+        Acquires a BAP Admin API access token via Microsoft Entra ID.
     #>
     [CmdletBinding()]
     param()

--- a/scripts/governance/register-plugin.ps1
+++ b/scripts/governance/register-plugin.ps1
@@ -36,7 +36,7 @@
 .EXAMPLE
     .\register-plugin.ps1 -DataverseUrl https://org.crm.dynamics.com -AssemblyPath ./bin/Release/ValidateMimeTypePlugin.dll
 
-    Registers the plugin assembly and step using Azure AD token from Az.Accounts.
+    Registers the plugin assembly and step using Microsoft Entra ID token from Az.Accounts.
 
 .EXAMPLE
     .\register-plugin.ps1 -DataverseUrl https://org.crm.dynamics.com -AssemblyPath ./bin/Release/ValidateMimeTypePlugin.dll -WhatIf

--- a/scripts/governance/test-plugin.ps1
+++ b/scripts/governance/test-plugin.ps1
@@ -34,7 +34,7 @@
 .EXAMPLE
     .\test-plugin.ps1 -DataverseUrl https://org.crm.dynamics.com
 
-    Runs all integration tests using Azure AD token from Az.Accounts.
+    Runs all integration tests using Microsoft Entra ID token from Az.Accounts.
 
 .EXAMPLE
     .\test-plugin.ps1 -DataverseUrl https://org.crm.dynamics.com -SkipCleanup

--- a/scripts/remediate_agent_sharing.py
+++ b/scripts/remediate_agent_sharing.py
@@ -87,7 +87,7 @@ def build_permission_object(
     Parameters
     ----------
     group_id : str
-        Azure AD group GUID.
+        Microsoft Entra ID group GUID.
     group_name : str
         Display name for the group.
     role_name : str, optional
@@ -129,7 +129,7 @@ def get_group_name_from_policy(
     Parameters
     ----------
     group_id : str
-        Azure AD group GUID.
+        Microsoft Entra ID group GUID.
     dataverse_client : CAAClient
         Dataverse client instance.
 

--- a/tests/e2e/fixtures/render-expectations.json
+++ b/tests/e2e/fixtures/render-expectations.json
@@ -4186,12 +4186,6 @@
       "expected_diagram_links": [],
       "expected_asset_links": []
     },
-    "/reference/sovereign-cloud-parity-matrix/": {
-      "source_md": "docs/reference/sovereign-cloud-parity-matrix.md",
-      "expected_mermaid_count": 0,
-      "expected_diagram_links": [],
-      "expected_asset_links": []
-    },
     "/reference/versioning-and-support/": {
       "source_md": "docs/reference/versioning-and-support.md",
       "expected_mermaid_count": 0,


### PR DESCRIPTION
## What / Why

**Task A - Sovereign-cloud residual cleanup**
docs/javascripts/assessment-data.json is git-ignored (generated); source markdown files were already cleaned by prior removal waves - GCC/DoD/sovereign grep returns ZERO matches in source. No source edits were needed.

Residual removed: stale /reference/sovereign-cloud-parity-matrix/ entry in tests/e2e/fixtures/render-expectations.json - its source_md (docs/reference/sovereign-cloud-parity-matrix.md) was deleted in a prior wave, leaving a broken fixture reference.

**Task B - Azure AD to Microsoft Entra ID in code comments/docstrings (10 sites)**

- scripts/asard_zone_rules.py:208 - '# Azure AD group object IDs' to '# Microsoft Entra ID group object IDs'
- scripts/asard_zone_rules.py:294 - 'Azure AD group IDs approved for this zone' to 'Microsoft Entra ID group IDs...'
- scripts/asard_zone_rules.py:418 - 'Azure AD security group object IDs' to 'Microsoft Entra ID security group object IDs'
- scripts/governance/Set-InactivityTimeout.ps1:11 - 'Authenticate via Azure AD' to 'Authenticate via Microsoft Entra ID'
- scripts/governance/Set-InactivityTimeout.ps1:145 - 'access token via Azure AD' to 'access token via Microsoft Entra ID'
- scripts/governance/register-plugin.ps1:39 - 'using Azure AD token' to 'using Microsoft Entra ID token'
- scripts/remediate_agent_sharing.py:90 - 'Azure AD group GUID.' to 'Microsoft Entra ID group GUID.'
- scripts/remediate_agent_sharing.py:132 - 'Azure AD group GUID.' to 'Microsoft Entra ID group GUID.'
- scripts/create_asard_dataverse_schema.py:355 - docstring: 'actual Azure AD security group IDs' to 'actual Microsoft Entra ID security group IDs'
- scripts/governance/test-plugin.ps1:37 - '.EXAMPLE comment: using Azure AD token' to 'using Microsoft Entra ID token'

Exempt (untouched): Two fsi_purpose strings in create_asard_dataverse_schema.py (lines 373, 382) are literal Dataverse field values, not code comments.

## Validation gates

All gates passed (exit 0):
- verify_controls.py PASS
- verify_language_rules.py PASS
- verify_xref_graph.py PASS
- verify_version_stamps.py PASS (report-only mode)

Note: Stale 'Last Verified' dates on nist-ai-rmf-crosswalk.md and opentelemetry-setup.md intentionally NOT auto-bumped - bumping would assert un-done verification work.