### PR TITLE
Add shared commercial-cloud scope rule (CI gate) + remove gov-cloud reference

### DIFF
--- a/.github/instructions/commercial-scope.instructions.md
+++ b/.github/instructions/commercial-scope.instructions.md
@@ -1,0 +1,60 @@
+---
+applyTo: "docs/**/*.md,**/README.md,**/AGENTS.md,assessment/**/*.json,solutions/**/*.md,site-docs/**/*.md"
+---
+
+# Commercial-Cloud Scope Rule  (COMMON — identical in all four FSI repos)
+
+> **Scope policy.** FSI-AgentGov, FSI-CopilotGov, FSI-AgentGov-Solutions and
+> FSI-CopilotGov-Solutions are scoped to **US commercial-cloud Microsoft 365 only**.
+> Government and sovereign clouds — **GCC, GCC High, DoD, Azure Government, GovCloud,
+> and other sovereign clouds** — are **out of scope** and must not be documented,
+> evaluated, or given operational guidance in forward-facing content.
+
+## Why
+Carrying gov-cloud guidance means continuously tracking a *separate* feature-parity
+and availability surface (which Microsoft changes independently of commercial cloud).
+That is ongoing maintenance the project deliberately does not take on. One scope
+statement + this automated gate replaces dozens of per-feature gov-cloud caveats.
+
+## What is prohibited (in forward-facing docs + published assessment data)
+Any mention that documents, evaluates, or instructs for government/sovereign clouds:
+
+| Prohibited term | Examples that FAIL |
+|---|---|
+| `GCC`, `GCC High` | "For GCC tenants, verify default-off…", "GCC High parity gap…" |
+| `DoD` | "…in Commercial / GCC High / DoD tenants" |
+| `sovereign` (cloud) | "Sovereign-cloud parity confirmed…", "sovereign-cloud compensating control" |
+| `government cloud`, `GovCloud`, `Azure Government` | "available in government cloud" |
+| gov endpoints (`purview.microsoft.us`, `*.office365.us`, `*.microsoftonline.us`) | "use purview.microsoft.us for GCC High" |
+
+## What is NOT in scope of this rule (intentionally not scanned)
+- **Functional code** (`*.ps1`, `*.py`, `*.psm1`, `*.js`) — gov-endpoint handling there is
+  functionality, not tracked guidance. (Terminology hygiene is a separate concern.)
+- **Inert historical records** — `CHANGELOG*`, `reports/**` (monitoring logs),
+  `releases/**`, `tests/**` & fixtures, `templates/**`, `.squad/**`, `research/**`,
+  `*.schema.json` (residency enums), `*-lock.json`, `*.backup`, `*.migrated`,
+  monitor-state files. These need no maintenance and rewriting them is pure churn.
+
+## The required scope disclaimer (add once per repo, e.g. `docs/SCOPE.md` or in the README)
+> **Cloud scope.** This content targets **US commercial-cloud Microsoft 365**.
+> Government and sovereign clouds (GCC, GCC High, DoD, and other sovereign clouds)
+> are **out of scope**; verify gov-cloud applicability independently with Microsoft.
+
+The disclaimer file (`SCOPE.md` / `disclaimer.md`) and this rule file are the only
+places allowed to name the terms — the linter excludes them automatically.
+
+## Legitimate exceptions
+If a single mention is genuinely required (rare), add an opt-out marker on the file:
+
+```
+<!-- commercial-scope: allow reason: "glossary definition of the GCC acronym" -->
+```
+
+## Enforcement
+`scripts/verify_commercial_scope.py` runs in CI (`.github/workflows/commercial-scope.yml`)
+on every PR and on push to `main`. It fails the build (exit 1) if any forward-facing
+file introduces government/sovereign-cloud content. Run it locally before pushing:
+
+```
+python scripts/verify_commercial_scope.py
+```

--- a/.github/workflows/commercial-scope.yml
+++ b/.github/workflows/commercial-scope.yml
@@ -1,0 +1,33 @@
+name: commercial-scope
+
+# COMMON RULE (identical in all four FSI repos): fail CI if forward-facing
+# documentation or published assessment data introduces government / sovereign
+# cloud (GCC / GCC High / DoD / Azure Government / sovereign) content. These repos
+# are scoped to US commercial-cloud Microsoft 365 only.
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "**/*.json"
+      - "scripts/verify_commercial_scope.py"
+      - ".github/workflows/commercial-scope.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "**/*.json"
+
+permissions:
+  contents: read
+
+jobs:
+  commercial-scope:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify commercial-cloud scope (no GCC / GCC High / DoD / sovereign)
+        run: python scripts/verify_commercial_scope.py

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 > **New to this framework? [Start Here](docs/start-here.md)** — understand what FSI-AgentGov covers, why it exists, and where to begin.
 
-> ⚠️ **Scope:** This framework is designed exclusively for **US financial institutions** using **Microsoft 365 AI agents** (Microsoft Copilot Studio, Agent Builder). Non-US regulations (EU AI Act, GDPR, DORA) and non-M365 AI platforms are out of scope.
+> ⚠️ **Scope:** This framework is designed exclusively for **US financial institutions** using **Microsoft 365 AI agents** (Microsoft Copilot Studio, Agent Builder). Non-US regulations (EU AI Act, GDPR, DORA) and non-M365 AI platforms are out of scope. See **[Cloud Scope](SCOPE.md)**.
 
 > **Important:** This framework is provided for informational purposes only and does not constitute legal, regulatory, or compliance advice. See [Disclaimer](docs/disclaimer.md) for full details.
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,5 @@
+# Cloud Scope
+
+**This content targets US commercial-cloud Microsoft 365.**
+
+Government and sovereign clouds — including GCC, GCC High, DoD, Azure Government, and other sovereign clouds — are **out of scope**. Feature availability, parity, and configuration for government/sovereign clouds are not tracked in this repository; verify gov-cloud applicability independently with Microsoft.

--- a/docs/playbooks/control-implementations/1.7/portal-walkthrough.md
+++ b/docs/playbooks/control-implementations/1.7/portal-walkthrough.md
@@ -543,7 +543,7 @@ All artifacts: SHA-256 hashed at capture time; copied to the §10 immutable blob
 ## §13 — Implementation Notes
 
 Implementation notes for US financial-services commercial tenants:
-- **Azure immutable blob storage** is available in Azure Government; the **Cohasset attestation** and SEC 17a-4(f) coverage statement should be re-verified at vendor cadence (annually) and stored alongside the §11 evidence pack.
+- **Azure immutable blob storage**: the **Cohasset attestation** and SEC 17a-4(f) coverage statement should be re-verified at vendor cadence (annually) and stored alongside the §11 evidence pack.
 
 ---
 

--- a/scripts/verify_commercial_scope.py
+++ b/scripts/verify_commercial_scope.py
@@ -1,0 +1,224 @@
+"""Commercial-Cloud Scope Linter  (COMMON RULE — identical across all four FSI repos)
+
+Purpose
+-------
+These frameworks/solutions are scoped to **US commercial-cloud Microsoft 365 only**.
+Government / sovereign clouds (GCC, GCC High, DoD, Azure Government, and other
+sovereign clouds) are intentionally **out of scope** so the team does not carry the
+ongoing burden of tracking gov-cloud feature parity and availability.
+
+This linter fails CI if forward-facing content (documentation + published assessment
+data) introduces government/sovereign-cloud guidance. It does NOT scan functional code
+or inert historical records (changelogs, monitoring reports, fixtures, state files).
+
+The single canonical place that is *allowed* to name these terms is the scope
+disclaimer (see commercial-scope.instructions.md), plus any file that carries an
+explicit, reasoned opt-out marker:
+
+    <!-- commercial-scope: allow reason: "why this mention is legitimate" -->
+
+Exit codes:
+  0 — clean (no government/sovereign-cloud content in forward-facing files)
+  1 — violations found
+
+Usage:
+  python scripts/verify_commercial_scope.py            # scan repo from CWD
+  python scripts/verify_commercial_scope.py --root DIR # scan a specific root
+  python scripts/verify_commercial_scope.py FILE...    # scan specific files (CI on changed files)
+  python scripts/verify_commercial_scope.py --list     # list scannable files and exit
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path, PurePosixPath
+
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+
+# --------------------------------------------------------------------------- #
+# Banned government / sovereign-cloud patterns (case-insensitive unless noted)
+# --------------------------------------------------------------------------- #
+BANNED_PATTERNS = [
+    (re.compile(r"\bGCC\s*High\b", re.IGNORECASE), "GCC High"),
+    (re.compile(r"\bGCC\b", re.IGNORECASE), "GCC"),
+    (re.compile(r"\bDoD\b"), "DoD"),  # case-sensitive: avoids matching inside other words
+    (re.compile(r"\bsovereign\b", re.IGNORECASE), "sovereign (cloud)"),
+    (re.compile(r"\bgovernment\s+cloud(s)?\b", re.IGNORECASE), "government cloud"),
+    (re.compile(r"\bGovCloud\b", re.IGNORECASE), "GovCloud"),
+    (re.compile(r"\bAzure\s+Government\b", re.IGNORECASE), "Azure Government"),
+    (re.compile(r"\bpurview\.microsoft\.us\b", re.IGNORECASE), "purview.microsoft.us (gov endpoint)"),
+    (re.compile(r"\b[\w.-]+\.(?:office365|microsoftonline)\.us\b", re.IGNORECASE),
+     "US-gov cloud endpoint"),
+]
+
+# Only these content types are scanned. Functional code (.ps1/.py/.psm1/.js) is NOT
+# scanned — gov-endpoint handling in code is functionality, not tracked guidance.
+SCANNED_EXTENSIONS = {".md", ".json"}
+
+# Path segments (any depth) that mark inert/historical/non-published content — skipped.
+EXCLUDED_DIR_SEGMENTS = {
+    ".git", ".github", "node_modules", "__pycache__", ".squad",
+    "site",            # mkdocs build output
+    "reports",         # monitoring / learn-change logs (factual history)
+    "releases",        # changelog archives
+    "templates",       # scaffolding templates may carry placeholder enums
+    "tests", "test", "fixtures", "__fixtures__",
+    "research",        # internal working notes, not published guidance
+    "artifacts-review",
+    "orchestration-log",
+}
+
+# Filename globs that are inert/historical — skipped.
+EXCLUDED_FILE_GLOBS = [
+    "CHANGELOG*", "*.migrated", "*.backup",
+    "monitor-state*.json", "*-lock.json", "package-lock.json",
+    "*.schema.json",   # schema enums legitimately enumerate residency values
+]
+
+# Specific files allowed to NAME the banned terms (the canonical disclaimer + this rule).
+EXCLUDED_BASENAMES = {
+    "commercial-scope.instructions.md",
+    "verify_commercial_scope.py",
+    "SCOPE.md",
+    "disclaimer.md",
+}
+
+OPT_OUT = re.compile(
+    r"<!--\s*commercial-scope:\s*allow\s+reason:\s*[\"'](.+?)[\"']\s*-->",
+    re.IGNORECASE,
+)
+
+
+def _has_excluded_segment(path: PurePosixPath) -> bool:
+    return any(seg in EXCLUDED_DIR_SEGMENTS for seg in path.parts)
+
+
+def _matches_excluded_glob(path: PurePosixPath) -> bool:
+    name = path.name
+    return any(path.match(g) or PurePosixPath(name).match(g) for g in EXCLUDED_FILE_GLOBS)
+
+
+def is_scannable(path: Path, root: Path) -> bool:
+    if path.suffix.lower() not in SCANNED_EXTENSIONS:
+        return False
+    if path.name in EXCLUDED_BASENAMES:
+        return False
+    rel = PurePosixPath(path.relative_to(root).as_posix())
+    if _has_excluded_segment(rel):
+        return False
+    if _matches_excluded_glob(rel):
+        return False
+    return True
+
+
+def _git_tracked_files(root: Path) -> list[Path] | None:
+    """Return committed (tracked) files, or None if not a git repo / git unavailable.
+
+    Gating tracked files only is the correct CI semantic: we enforce on what is
+    committed, and git-ignored build artifacts (e.g. a generated assessment-data.json)
+    never cause false positives.
+    """
+    import subprocess
+    try:
+        res = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            capture_output=True, check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    names = res.stdout.decode("utf-8", "replace").split("\0")
+    return [root / n for n in names if n]
+
+
+def iter_files(root: Path, file_args: list[str] | None) -> list[Path]:
+    if file_args:
+        out = []
+        for f in file_args:
+            p = Path(f)
+            if p.suffix.lower() in SCANNED_EXTENSIONS and p.exists():
+                out.append(p.resolve())
+        return out
+    tracked = _git_tracked_files(root)
+    if tracked is not None:
+        return sorted(p for p in tracked if p.is_file() and is_scannable(p, root))
+    return sorted(p for p in root.rglob("*") if p.is_file() and is_scannable(p, root))
+
+
+def scan_file(path: Path) -> tuple[list[tuple[int, str, str]], str | None]:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return [], None
+    opt = OPT_OUT.search(content)
+    if opt:
+        return [], opt.group(1)
+    violations: list[tuple[int, str, str]] = []
+    for n, line in enumerate(content.splitlines(), start=1):
+        for pattern, label in BANNED_PATTERNS:
+            if pattern.search(line):
+                violations.append((n, label, line.strip()[:160]))
+                break
+    return violations, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Commercial-cloud scope linter")
+    ap.add_argument("--root", default=".", help="repo root to scan (default: CWD)")
+    ap.add_argument("--list", action="store_true", help="list scannable files and exit")
+    ap.add_argument("files", nargs="*", help="specific files to scan (optional)")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    files = iter_files(root, args.files or None)
+
+    if args.list:
+        for f in files:
+            print(f.relative_to(root) if f.is_relative_to(root) else f)
+        print(f"\n{len(files)} scannable file(s).")
+        return 0
+
+    print("=" * 64)
+    print("COMMERCIAL-CLOUD SCOPE VALIDATION (no GCC / GCC High / DoD / sovereign)")
+    print("=" * 64)
+    print(f"\nScanning {len(files)} forward-facing file(s) under {root}...\n")
+
+    total = 0
+    files_hit = 0
+    opt_outs: list[tuple[Path, str]] = []
+    for path in files:
+        violations, opt_reason = scan_file(path)
+        if opt_reason:
+            opt_outs.append((path, opt_reason))
+            continue
+        if violations:
+            files_hit += 1
+            rel = path.relative_to(root) if path.is_relative_to(root) else path
+            print(f"\u274c {rel}")
+            for ln, label, text in violations:
+                print(f"   Line {ln}: [{label}]")
+                print(f"   > {text}")
+            total += len(violations)
+
+    if opt_outs:
+        print("\n" + "-" * 64)
+        print("OPT-OUTS (allowed mentions, for review)")
+        for path, reason in opt_outs:
+            rel = path.relative_to(root) if path.is_relative_to(root) else path
+            print(f"\u26a0\ufe0f  {rel}  —  {reason}")
+
+    print("\n" + "=" * 64)
+    if total == 0:
+        print("\u2705 No government/sovereign-cloud content in forward-facing files.")
+        return 0
+    print(f"\u274c {total} government/sovereign-cloud mention(s) in {files_hit} file(s).")
+    print("   Policy: these repos are US commercial-cloud M365 only. Remove the")
+    print("   gov-cloud guidance, or (if a mention is genuinely required) add:")
+    print('   <!-- commercial-scope: allow reason: "..." -->')
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
installs verify_commercial_scope.py + commercial-scope.yml CI gate + commercial-scope.instructions.md + SCOPE.md disclaimer; removes the single Azure Government mention in 1.7 portal-walkthrough; this is the common rule now shared across all 4 FSI repos so gov-cloud content can't be reintroduced