### PR TITLE
ci: port dependency-CVE + SAST scanning from FSI-CopilotGov (parity P1)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,101 @@
+name: Security Scan
+
+# Runs supply-chain (pip-audit, npm audit) and SAST (bandit) checks across
+# AgentGov's Python tooling and SPA test bundle.
+#
+# PSScriptAnalyzer is already handled by powershell-quality.yml — not duplicated here.
+#
+# Ported from FSI-CopilotGov security-scan.yml; adapted to AgentGov's paths:
+#   - pip-audit: scripts/requirements.txt + assessment/requirements.txt
+#   - bandit:    scripts/, assessment/engine/, assessment/manifest/ (tests excluded)
+#   - npm audit: package.json (all deps are devDependencies — omit-dev would be a no-op)
+#
+# BLOCKING vs REPORT-ONLY (adoption PR 2026-06-07):
+#   BLOCKING:     pip-audit (both req files were clean on local run)
+#   REPORT-ONLY:  bandit — pre-existing findings need triage (see TODO comments below)
+#   REPORT-ONLY:  npm audit — xlsx devDep has HIGH vuln, no upstream fix available
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 10 * * 1"  # weekly Monday 10:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  python-audit:
+    name: pip-audit + bandit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install scanning tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-audit bandit
+
+      - name: pip-audit — scripts/requirements.txt
+        # BLOCKING: clean on local run 2026-06-07 (0 known vulnerabilities).
+        # --strict falls back to non-strict when pip-audit cannot resolve all packages
+        # (e.g. private indexes); non-strict still fails on found CVEs.
+        run: |
+          pip-audit -r scripts/requirements.txt --strict --progress-spinner=off \
+            || pip-audit -r scripts/requirements.txt --progress-spinner=off
+
+      - name: pip-audit — assessment/requirements.txt
+        # BLOCKING: clean on local run 2026-06-07 (0 known vulnerabilities).
+        run: |
+          pip-audit -r assessment/requirements.txt --strict --progress-spinner=off \
+            || pip-audit -r assessment/requirements.txt --progress-spinner=off
+
+      - name: Bandit (Python SAST)
+        # REPORT-ONLY (continue-on-error: true) — pre-existing findings as of 2026-06-07:
+        #   B324 HIGH/HIGH  scripts/check_temp.py:21
+        #     hashlib.md5() used for security — CWE-327. Should use SHA-256 or
+        #     pass usedforsecurity=False if this is a cache key only.
+        #   B310 MED/HIGH   scripts/refresh_solutions_lock.py:58
+        #     urllib.request.urlopen() — audit for allowed URL schemes (CWE-22).
+        #   B701 HIGH/HIGH  assessment/engine/report.py:858
+        #     jinja2 Environment without autoescape=True — CWE-94 (XSS risk).
+        #   B701 HIGH/HIGH  assessment/engine/report.py:864
+        #     jinja2 Environment without autoescape=True — CWE-94 (XSS risk).
+        # TODO: triage each finding above, then remove continue-on-error to make blocking.
+        continue-on-error: true
+        run: |
+          bandit -r scripts assessment/engine assessment/manifest \
+            --severity-level medium \
+            --confidence-level medium \
+            -x scripts/test_,assessment/tests \
+            -f txt
+
+  npm-audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Install
+        run: npm ci || npm install
+      - name: Audit (high severity gate)
+        # REPORT-ONLY (continue-on-error: true) — pre-existing finding as of 2026-06-07:
+        #   xlsx (SheetJS) HIGH — Prototype Pollution (GHSA-4r6h-8v6p-xvw6)
+        #                        + ReDoS (GHSA-5pgg-2g8v-p4x9). No fix available upstream.
+        #   xlsx is a devDependency used only in tests; does not ship to production.
+        #   All package.json deps are devDependencies, so --omit=dev would audit 0 packages.
+        # TODO: evaluate replacing xlsx with a maintained alternative (e.g. exceljs),
+        #       then remove continue-on-error to make this step blocking.
+        continue-on-error: true
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary

Closes the gap where FSI-AgentGov had **no dependency-CVE or SAST scanning** while its sibling FSI-CopilotGov had a proven `security-scan.yml` (pip-audit + bandit + npm audit). Ported and adapted that workflow to AgentGov's actual file surfaces.

AgentGov has the larger live-API surface (BAP Admin, Microsoft Graph, CAA), making this the highest-value standardization in the parity set.

**PSScriptAnalyzer is intentionally excluded** — it already runs in `powershell-quality.yml` and duplicating it here would create noise.

---

## Scanners added

| Scanner | Surface covered | Status |
|---|---|---|
| `pip-audit` (scripts deps) | `scripts/requirements.txt` | ✅ BLOCKING |
| `pip-audit` (assessment deps) | `assessment/requirements.txt` | ✅ BLOCKING |
| `bandit` (Python SAST) | `scripts/`, `assessment/engine/`, `assessment/manifest/` (tests excluded) | ⚠️ REPORT-ONLY (see findings) |
| `npm audit` | `package.json` (all devDependencies) | ⚠️ REPORT-ONLY (see findings) |

---

## Local run results (2026-06-07)

### pip-audit — CLEAN (both files)
```
scripts/requirements.txt:     No known vulnerabilities found
assessment/requirements.txt:  No known vulnerabilities found
```
→ Both steps are **BLOCKING**.

### bandit — PRE-EXISTING FINDINGS (4 issues, `continue-on-error: true`)

```
B324 HIGH/HIGH   scripts/check_temp.py:21
  hashlib.md5() used for security — CWE-327
  hashlib.md5(path.read_bytes()).hexdigest()
  Fix: use SHA-256, or pass usedforsecurity=False if this is a content-hash only.

B310 MED/HIGH    scripts/refresh_solutions_lock.py:58
  urllib.request.urlopen() — audit URL scheme allowlist — CWE-22
  with urllib.request.urlopen(req, timeout=timeout) as resp

B701 HIGH/HIGH   assessment/engine/report.py:858
  jinja2 Environment without autoescape=True — CWE-94 (XSS risk in rendered output)
  env = Environment(keep_trailing_newline=True)

B701 HIGH/HIGH   assessment/engine/report.py:864
  jinja2 Environment without autoescape=True — CWE-94
  env = Environment(keep_trailing_newline=True)
```
**Triage notes:** The jinja2 findings (B701) are the highest risk — if any user-controlled data flows into the templates, XSS is possible. The MD5 finding (B324) depends on whether the hash is used as a security check or just as a cache key. Recommend reviewing all four before removing `continue-on-error`.

### npm audit — PRE-EXISTING FINDING (1 HIGH, `continue-on-error: true`)

```
xlsx (SheetJS)  HIGH
  Prototype Pollution — GHSA-4r6h-8v6p-xvw6
  ReDoS           — GHSA-5pgg-2g8v-p4x9
  No fix available upstream.
```
`xlsx` is a devDependency used only in test helpers; does not ship to production. All `package.json` deps are devDependencies — `--omit=dev` was intentionally omitted here (it would audit zero packages). Recommend evaluating a replacement (e.g. `exceljs`) before removing `continue-on-error`.

---

## Adaptation notes vs CopilotGov source

- **No PSScriptAnalyzer job**: AgentGov already has `powershell-quality.yml` for this.
- **Python version**: `3.11` (matches all existing AgentGov Python workflows; CopilotGov uses `3.12`).
- **Action versions**: `checkout@v5`, `setup-python@v6`, `setup-node@v6` (matches AgentGov's existing pinning; CopilotGov uses `checkout@v6`).
- **pip-audit split**: Two separate steps, one per requirements file (scripts + assessment), rather than a single step against one combined file.
- **bandit scope**: `scripts/ assessment/engine/ assessment/manifest/` — excludes `scripts/test_*.py` and `assessment/tests/`.
- **npm audit scope**: Full audit (no `--omit=dev`) because all dependencies are devDependencies — `--omit=dev` would silently audit zero packages.

---

## Source repo status

✅ `C:\dev\FSI-CopilotGov` was **not modified**. Read-only access only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>