### PR TITLE
docs(observability): correct Agent 365 telemetry claims against current Learn

### DIFF
--- a/docs/playbooks/advanced-implementations/agent-365-observability/alerting-configuration.md
+++ b/docs/playbooks/advanced-implementations/agent-365-observability/alerting-configuration.md
@@ -8,6 +8,11 @@
 
 This guide provides zone-based alerting thresholds and escalation configurations for Agent 365 observability. Alerts are designed to surface operational issues, security events, and compliance concerns based on governance zone requirements.
 
+!!! warning "Schema assumptions in the KQL below"
+    The alert queries in this document target Application Insights `traces` with **FSI-overlay** span / event names (`agent.interaction`, `tool.invocation`, `rai.filter`, `dlp.block`, `access.denied`, `auth.failure`, `sponsor.attestation.check`, `blueprint.promotion`, `config.change`) and a custom dimension `fsi_zone`. None of these are part of the documented Microsoft Agent 365 SDK schema — see [Telemetry schema](index.md#telemetry-schema). They depend on (a) an OpenTelemetry Collector / agent host pipeline that emits these synthetic names, and (b) downstream signals from Microsoft Defender / Microsoft Purview being re-projected into Application Insights. Before deploying, rewrite each query against the actual signal source in your environment (the documented `InvokeAgentScope` / `ExecuteToolScope` / `InferenceScope` / `OutputScope` spans with `gen_ai.*` / `microsoft.*` attributes, or the Defender / Purview tables for security and compliance events).
+
+<!-- NEEDS_HUMAN_REVIEW: Alerts 6–13 (RAI Filter Spike, DLP Block, Access Denial, Auth Failure, Sponsor Attestation Overdue, Orphaned Agent, Blueprint Phase Change, Config Change) all depend on signals NOT documented in the Agent 365 SDK / Microsoft OpenTelemetry Distro schema. The correct sources are most likely Microsoft Defender XDR Advanced Hunting (for RAI and authentication events), Microsoft Purview audit / DLP (for DLP, access, sponsor, and config events), and an internal Blueprint registry. Validate the actual source before enabling these in production. -->
+
 ---
 
 ## Alert Categories
@@ -502,4 +507,4 @@ foreach ($rule in $alertRules) {
 
 ---
 
-*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: June 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/playbooks/advanced-implementations/agent-365-observability/application-insights-workbooks.md
+++ b/docs/playbooks/advanced-implementations/agent-365-observability/application-insights-workbooks.md
@@ -8,6 +8,14 @@
 
 This guide provides Azure Workbook templates for monitoring Agent 365 telemetry. These workbooks support Zone 2 and Zone 3 operational requirements for performance monitoring, compliance tracking, and incident investigation.
 
+!!! warning "Schema assumptions in the KQL below"
+    The KQL queries in this document assume two things that are **not** part of the Microsoft Agent 365 SDK schema and must be added by your pipeline:
+
+    1. A custom dimension `fsi_zone` (and similar `service_name`, `sponsor_id`, `agent_id`, `correlation_id`, etc.) attached to spans either as OpenTelemetry resource attributes in your agent host or by the OpenTelemetry Collector `attributes` processor described in [OpenTelemetry Setup](opentelemetry-setup.md). The Microsoft OpenTelemetry Distro and the legacy Agent 365 Observability SDK do not emit these attributes by default.
+    2. FSI-overlay span / event names such as `agent.interaction`, `topic.triggered`, `fallback.triggered`, `agent.handoff`, `rai.filter`, `dlp.block`, `access.denied`, `auth.failure`, `sponsor.attestation`, and `config.change`. These names are illustrative and **do not** correspond to Microsoft-documented Agent 365 SDK telemetry — see the schema discussion in [the index](index.md#telemetry-schema). The documented Agent 365 spans use `gen_ai.*` and `microsoft.*` attributes on `InvokeAgentScope` / `ExecuteToolScope` / `InferenceScope` / `OutputScope`. Before using the security and compliance workbook in production, rewrite the queries against the actual signal source (for example, Microsoft Defender XDR Advanced Hunting for RAI / threat events, Microsoft Purview audit search for DLP events).
+
+<!-- NEEDS_HUMAN_REVIEW: The Security & Compliance workbook in particular depends on signals that Learn locates in Defender and Purview rather than the Agent 365 SDK. Before deploying, confirm the actual source table/columns in your tenant and rewrite the KQL to read from there (for example, AdvancedHunting / DLPEvents tables) rather than Application Insights traces. -->
+
 ---
 
 ## Workbook Gallery
@@ -435,4 +443,4 @@ foreach ($wb in $workbooks) {
 
 ---
 
-*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: June 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/playbooks/advanced-implementations/agent-365-observability/index.md
+++ b/docs/playbooks/advanced-implementations/agent-365-observability/index.md
@@ -1,16 +1,28 @@
 # Agent 365 Observability Implementation Guide
 
-**Last Updated:** May 2026
+**Last Updated:** June 2026
 **Version:** v1.6.2
 
 ---
 
 ## Overview
 
-This playbook provides implementation guidance for Microsoft Agent 365 SDK observability features, enabling enterprise-grade telemetry capture for AI agents. The observability framework supports Microsoft Copilot Studio custom-engine agents and Microsoft-built agents, with declarative agents primarily relying on native telemetry surfaces. ([Agent types](https://learn.microsoft.com/microsoft-365/copilot/extensibility/agents-overview#choose-what-type-of-agent-to-build))
+This playbook provides implementation guidance for capturing Microsoft Agent 365 telemetry in an FSI-governed environment. Microsoft documents two distinct telemetry paths ([Agent observability](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability), [Observability integration for Copilot Studio](https://learn.microsoft.com/microsoft-agent-365/builder/observability)):
 
-!!! note "Preview Features"
-    Agent 365 SDK observability features are in preview. Telemetry schemas and configuration options may change before general availability.
+| Agent type | How telemetry is emitted | Action required |
+|------------|--------------------------|-----------------|
+| **Copilot Studio agents** | Automatic — the platform runtime emits OpenTelemetry-compliant spans to the Agent 365 observability backend with no SDK code required | No code; verify telemetry appears in Microsoft 365 admin center, Defender, and Purview |
+| **Declarative agents** | Automatic ("supported out of the box. No SDK implementation required" per Learn) | No code; same admin surfaces as above |
+| **Custom-engine agents** | Manual instrumentation via the Microsoft OpenTelemetry Distro (or the legacy Agent 365 Observability SDK) | Install packages and call the distro's enable function in the agent host |
+| **Agent 365-enabled agents** | Manual instrumentation via the Microsoft OpenTelemetry Distro (or the legacy Agent 365 Observability SDK) | Install packages and call the distro's enable function in the agent host |
+
+This playbook focuses on the FSI overlay (zone-based retention, SIEM/Sentinel export, App Insights workbooks, and regulatory retention mapping) that wraps either telemetry path.
+
+!!! note "Status and SDK direction"
+    Per Learn, the recommended path for new manual instrumentation is the **[Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry)** — a single distribution that powers Agent 365, Microsoft Foundry, and Azure Monitor. The legacy Agent 365 Observability SDK "continues to work without breaking changes," and per-language migration guides are linked from Learn. SDK packages are pre-1.0 today (for example, Python `microsoft-agents-a365-observability-core` at `0.3.x`, Node `@microsoft/agents-a365-observability` at `0.2.0-preview.1`, .NET `Microsoft.Agents.A365.Observability.Runtime` at `0.3-beta`); pin versions and review the Learn migration guides before upgrading. <!-- NEEDS_HUMAN_REVIEW: Microsoft Learn does not publish an explicit "Preview" or "GA" status label for the Agent 365 Observability surface as a whole; treat the pre-1.0 package versions as the practical maturity signal. -->
+
+!!! note "What Copilot Studio captures automatically"
+    Per Learn, Copilot Studio currently emits **Invoke agent**, **Output message**, and **Execute tool** spans for authenticated, single-tenant sessions only. Multi-tenant agents, unauthenticated sessions, and agents with names longer than 42 characters are excluded; large message and tool fields are truncated. Plan FSI evidence collection accordingly. ([Source](https://learn.microsoft.com/microsoft-agent-365/builder/observability))
 
 ---
 
@@ -31,14 +43,21 @@ This playbook provides implementation guidance for Microsoft Agent 365 SDK obser
 ```mermaid
 flowchart TB
     subgraph "Agent Layer"
-        A[Copilot Studio Agent] -->|SDK| B[Agent 365 Telemetry]
-        C[M365 Built-in Agent] -->|Native| B
+        A[Copilot Studio Agent] -->|Automatic| B[Agent 365 Telemetry Backend]
+        C[Declarative Agent] -->|Automatic| B
+        N[Custom-engine / Agent 365-enabled Agent] -->|Microsoft OpenTelemetry Distro| B
     end
 
-    subgraph "Collection Layer"
-        B --> D[OpenTelemetry Collector]
+    subgraph "FSI Export Layer (optional, customer-owned)"
+        N -->|OTLP or direct exporter| D[OpenTelemetry Collector]
         D --> E[Application Insights]
         D --> F[Azure Monitor Logs]
+    end
+
+    subgraph "Microsoft Surfaces"
+        B --> P[Microsoft 365 admin center]
+        B --> Q[Microsoft Defender]
+        B --> R[Microsoft Purview]
     end
 
     subgraph "Analysis Layer"
@@ -59,42 +78,48 @@ flowchart TB
 
 ---
 
-## Telemetry Signal Categories
+## Telemetry Schema
 
-### Performance Signals
+### Documented Agent 365 scopes (manual instrumentation)
 
-| Signal | Description | FSI Use Case |
-|--------|-------------|--------------|
-| `agent.response.latency` | End-to-end response time | SLA monitoring, user experience |
-| `agent.response.success` | Success/failure ratio | Reliability tracking |
-| `agent.tool.duration` | Tool/connector call duration | Performance optimization |
-| `agent.token.usage` | Token consumption per interaction | Cost allocation |
+Per [Agent observability](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability), the Microsoft OpenTelemetry Distro (and the legacy Agent 365 Observability SDK) emit spans organized into four scopes. The attribute names below are taken directly from the Learn "Validate for store publishing" section.
 
-### Interaction Signals
+| Scope | Purpose | Selected required attributes |
+|-------|---------|-------------------------------|
+| `InvokeAgentScope` | Wraps an end-to-end agent invocation | `gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.operation.name`, `gen_ai.conversation.id`, `gen_ai.input.messages`, `gen_ai.output.messages`, `microsoft.a365.agent.blueprint.id`, `microsoft.tenant.id`, `microsoft.channel.name`, `user.id`, `user.email`, `client.address` |
+| `ExecuteToolScope` | Tool / connector call inside an invocation | `gen_ai.tool.name`, `gen_ai.tool.type`, `gen_ai.tool.call.id`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`, plus the agent-identity attributes above |
+| `InferenceScope` | LLM call(s) inside an invocation | `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`, plus agent identity |
+| `OutputScope` | Asynchronous agent output when the parent scope cannot capture it inline | `gen_ai.output.messages`, agent identity, conversation identity |
 
-| Signal | Description | FSI Use Case |
-|--------|-------------|--------------|
-| `agent.interaction.count` | Interaction volume | Usage analytics |
-| `agent.topic.triggered` | Topic activation patterns | Intent analysis |
-| `agent.fallback.triggered` | Fallback topic usage | Quality monitoring |
-| `agent.handoff.count` | Human handoff frequency | Supervision metrics |
+Latency is the inherent span duration of each scope. The `error.type` attribute is optional on every scope and is the documented success/failure indicator.
 
-### Security Signals
+### Copilot Studio automatic spans
 
-| Signal | Description | FSI Use Case |
-|--------|-------------|--------------|
-| `agent.rai.filter.triggered` | RAI content filter activations | Safety monitoring |
-| `agent.dlp.block` | DLP policy blocks | Data protection evidence |
-| `agent.auth.failure` | Authentication failures | Security monitoring |
-| `agent.access.denied` | Authorization denials | Access governance |
+Per [Observability integration for Copilot Studio](https://learn.microsoft.com/microsoft-agent-365/builder/observability), Copilot Studio emits three event types automatically using OpenTelemetry generative-AI semantic conventions:
 
-### Governance Signals
+| Span name | Purpose | Selected attributes |
+|-----------|---------|---------------------|
+| `InvokeAgent` | Agent invocation start | `gen_ai.operation.name = invoke_agent`, `gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.agent.type = CopilotStudio`, `gen_ai.conversation.id`, `gen_ai.input.messages`, `tenant.id` |
+| `OutputMessages` | Agent response | `gen_ai.operation.name = output_messages`, `gen_ai.output.messages`, agent and conversation identity |
+| `ExecuteTool` | Connector / action invocation | `gen_ai.operation.name = execute_tool`, `gen_ai.tool.name`, `gen_ai.tool.arguments`, `gen_ai.tool.call.id`, `gen_ai.tool.type` |
 
-| Signal | Description | FSI Use Case |
-|--------|-------------|--------------|
-| `agent.blueprint.phase` | Current lifecycle phase | Change tracking |
-| `agent.sponsor.status` | Sponsorship validation | Accountability |
-| `agent.config.change` | Configuration modifications | Audit trail |
+Copilot Studio attribute names use a slightly different prefix scheme than the manual-instrumentation scopes (for example, `gen_ai.agent.applicationid` and `gen_ai.agent.platformid` rather than `microsoft.a365.agent.platform.id`). When you query telemetry from both populations, account for both naming styles.
+
+### FSI projections (illustrative, not a Microsoft schema)
+
+The metric names below are convenient FSI shorthand. They are **not** documented Agent 365 telemetry fields. To use them you must derive them at query time from the documented scopes above, or add them via an OpenTelemetry Collector `attributes` processor as shown in [OpenTelemetry Setup](opentelemetry-setup.md).
+
+| Projection | Derived from | FSI use case |
+|------------|--------------|--------------|
+| Response latency (P50/P95/P99) | `InvokeAgentScope` span duration | SLA monitoring |
+| Success / failure ratio | `error.type` presence on `InvokeAgentScope` | Reliability tracking |
+| Tool call duration | `ExecuteToolScope` span duration grouped by `gen_ai.tool.name` | Performance optimization |
+| Token usage | `gen_ai.usage.input_tokens` + `gen_ai.usage.output_tokens` on `InferenceScope` | Cost allocation |
+| Interaction volume | Count of `InvokeAgentScope` (or Copilot Studio `InvokeAgent`) spans | Usage analytics |
+
+<!-- NEEDS_HUMAN_REVIEW: Signals previously listed in this section as "agent.topic.triggered", "agent.fallback.triggered", "agent.handoff.count", "agent.rai.filter.triggered", "agent.dlp.block", "agent.auth.failure", "agent.access.denied", "agent.blueprint.phase", "agent.sponsor.status", and "agent.config.change" are NOT documented in Microsoft Learn for the Agent 365 SDK / Microsoft OpenTelemetry Distro. RAI, DLP, authentication, and access-control events surface through Microsoft Defender and Microsoft Purview (referenced from the Agent 365 admin surface) rather than as named SDK telemetry fields. Lifecycle (Blueprint phase / sponsor status / config change) is an FSI-overlay concern that must be emitted by the agent application itself or sourced from a separate audit pipeline. Before promoting any of these to a production signal, confirm the exact emission point with the Agent 365 product team or the relevant Defender/Purview admin-surface documentation. -->
+
+The KQL examples in [Application Insights Workbooks](application-insights-workbooks.md) and [Alerting Configuration](alerting-configuration.md) use illustrative span names and custom dimensions (for example, `fsi_zone`) that are added by the OTel Collector pipeline in this playbook, not by the Agent 365 SDK.
 
 ---
 
@@ -113,12 +138,17 @@ flowchart TB
 
 ### By Agent Type
 
-| Agent Type | Native Telemetry | SDK Required | Custom Signals |
-|------------|------------------|--------------|----------------|
-| Declarative agent | ✓ (UAL) | No | Limited |
-| Copilot Studio custom-engine agent | ✓ (UAL) | Recommended | Full support |
-| Microsoft-built agent (Researcher, etc.) | ✓ (UAL) | No | Limited |
-| Blueprint-registered | ✓ | Yes | Full support |
+Per [Agent observability](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability) "Supported agents":
+
+| Agent Type | Microsoft-emitted telemetry | Manual SDK instrumentation | Custom attributes for FSI overlay |
+|------------|------------------------------|----------------------------|------------------------------------|
+| Declarative agent | Automatic (Agent 365 backend; "supported out of the box. No SDK implementation required") | No | Limited — additional FSI dimensions cannot be added at the agent |
+| Copilot Studio agent | Automatic (Agent 365 backend; spans listed above) | No | Limited — additional FSI dimensions must be projected at query time or attached downstream via the Collector |
+| Custom-engine agent | None until SDK is wired in | Yes — Microsoft OpenTelemetry Distro (preferred) or legacy SDK | Full — add via OpenTelemetry resource attributes and Collector processors |
+| Agent 365-enabled agent | None until SDK is wired in | Yes — Microsoft OpenTelemetry Distro (preferred) or legacy SDK | Full — add via OpenTelemetry resource attributes and Collector processors |
+
+<!-- NEEDS_HUMAN_REVIEW: Microsoft 365 Unified Audit Log (UAL) covers tenant-level admin and activity events. The Learn observability articles do not assert that every Agent 365 telemetry signal is mirrored to UAL; FSI teams that depend on UAL evidence should validate coverage in their tenant before relying on it. -->
+
 
 ---
 
@@ -142,34 +172,48 @@ $connectionString = $appInsights.ConnectionString
 Set-AzKeyVaultSecret -VaultName "kv-agent-governance" -Name "AppInsightsConnection" -SecretValue (ConvertTo-SecureString $connectionString -AsPlainText -Force)
 ```
 
-### 2. Configure Agent SDK (Preview)
+### 2. Enable telemetry export from a custom-engine or Agent 365-enabled agent
 
-For Copilot Studio custom-engine agents with SDK observability:
+Skip this step for Copilot Studio or declarative agents — they emit telemetry automatically (verify in Microsoft 365 admin center).
 
-```javascript
-// Agent SDK configuration (preview)
-const agentConfig = {
-  observability: {
-    enabled: true,
-    connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
-    signals: {
-      performance: true,
-      interactions: true,
-      security: true,
-      governance: true
-    },
-    sampling: {
-      rate: 1.0,  // 100% for Zone 3
-      excludeHealthChecks: true
-    },
-    enrichment: {
-      zone: "Zone3",
-      blueprintId: process.env.BLUEPRINT_ID,
-      sponsorId: process.env.SPONSOR_ID
-    }
-  }
-};
+For Node.js custom-engine agents, install and enable the [Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry):
+
+```bash
+npm install @microsoft/opentelemetry
 ```
+
+```typescript
+// Call this as early as possible in the agent host entry point so
+// instrumentations can patch libraries before they're loaded.
+import { useMicrosoftOpenTelemetry, AgenticTokenCacheInstance } from '@microsoft/opentelemetry';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+
+useMicrosoftOpenTelemetry({
+  resource: resourceFromAttributes({
+    'service.name': process.env.AGENT_NAME ?? 'fsi-agent',
+    'service.version': process.env.AGENT_VERSION ?? '0.0.0',
+    // FSI overlay attributes flow through as resource attributes on every span.
+    'fsi.zone': process.env.GOVERNANCE_ZONE,
+    'fsi.blueprint.id': process.env.BLUEPRINT_ID,
+    'fsi.sponsor.id': process.env.SPONSOR_ID,
+  }),
+  azureMonitor: {
+    enabled: Boolean(process.env.APPLICATIONINSIGHTS_CONNECTION_STRING),
+  },
+  a365: {
+    enabled: process.env.ENABLE_A365_OBSERVABILITY_EXPORTER !== 'false',
+    tokenResolver: (agentId, tenantId) =>
+      AgenticTokenCacheInstance.getObservabilityToken(agentId, tenantId) ?? '',
+  },
+});
+```
+
+The Microsoft OpenTelemetry Distro exports directly to Azure Monitor and to the Agent 365 backend; a separate OpenTelemetry Collector is **only** required when you need to fan out to additional sinks (for example, Splunk, Datadog, or WORM file storage). See [OpenTelemetry Setup](opentelemetry-setup.md) for the Collector pattern.
+
+For Python and .NET equivalents, see the corresponding tabs in the Learn doc and the per-language migration guides linked from the [Observability SDK overview](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability).
+
+<!-- NEEDS_HUMAN_REVIEW: The `AgenticTokenCacheInstance` helper is documented as the recommended pattern for agents using the @microsoft/agents-hosting package. For agent hosts that don't use that package, a custom token resolver is required; see the "Token resolver" and "Manual token resolver" sections in Learn before adopting in production. -->
+
 
 ### 3. Create Workbooks
 
@@ -214,34 +258,34 @@ Set up zone-based alerting thresholds:
 
 ---
 
-## Correlation ID Tracing
+## Trace correlation
 
-### Cross-System Correlation
+### Cross-System correlation
 
-The Agent 365 SDK generates correlation IDs that flow through:
+Agent 365 telemetry uses standard OpenTelemetry trace IDs and span IDs, plus baggage attributes that propagate identifiers across services. Per Learn ([Baggage attributes](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability#baggage-attributes)), the SDK supports automatic baggage population from `TurnContext`, carrying caller, agent, tenant, channel, and conversation details. The OpenTelemetry trace context (`traceparent` / `tracestate` HTTP headers) connects spans across:
 
-1. **User Request** → Copilot interaction
-2. **Agent Processing** → Agent 365 telemetry
-3. **Tool Invocation** → Connector/API calls
-4. **Audit Logging** → Purview UAL
-5. **Security Events** → Sentinel
+1. **User request** — Copilot interaction
+2. **Agent processing** — `InvokeAgentScope` (or Copilot Studio `InvokeAgent`)
+3. **Tool invocation** — `ExecuteToolScope` (or Copilot Studio `ExecuteTool`) with `gen_ai.tool.call.id`
+4. **Inference** — `InferenceScope`
+5. **Downstream audit** — Microsoft 365 Unified Audit Log (UAL) entries can be joined on tenant and time, but UAL does not currently carry the OpenTelemetry trace ID. <!-- NEEDS_HUMAN_REVIEW: Confirm whether any Defender/Purview event taxonomy carries the OTel trace ID; the Learn observability articles do not explicitly assert this. -->
 
-### Correlation Query Example
+### Correlation query example
 
 ```kql
-// Trace complete interaction path
-let correlationId = "abc123-correlation-id";
+// Trace a complete interaction path using the OpenTelemetry trace ID.
+// In Application Insights, the OTel trace ID surfaces as `operation_Id`.
+let traceId = "abc123-trace-id";
 
 // Application Insights traces
 let aiTraces = traces
 | where timestamp > ago(24h)
-| where customDimensions.correlationId == correlationId
+| where operation_Id == traceId
 | project timestamp, Source = "AppInsights", Operation = operation_Name, Details = message;
 
-// Purview audit events
+// Purview audit events (best-effort join on tenant and time window)
 let auditEvents = OfficeActivity
 | where TimeGenerated > ago(24h)
-| where CorrelationId == correlationId
 | project timestamp = TimeGenerated, Source = "UAL", Operation = Operation, Details = tostring(AuditData);
 
 // Combine
@@ -264,11 +308,13 @@ union aiTraces, auditEvents
 
 ## Related Resources
 
-- [Microsoft Learn: Agent 365 Observability (Preview)](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability)
-- [Microsoft Learn: Application Insights Overview](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
+- [Microsoft Learn: Agent observability (SDK overview)](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability)
+- [Microsoft Learn: Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry)
+- [Microsoft Learn: Observability integration for Copilot Studio](https://learn.microsoft.com/microsoft-agent-365/builder/observability)
+- [Microsoft Learn: Application Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
 - [Microsoft Learn: OpenTelemetry in Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-overview)
 - [Agent Audit Event Taxonomy](../../../reference/agent-audit-event-taxonomy.md)
 
 ---
 
-*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: June 2026 | Version: v1.6.2 | UI Verification Status: Current*

--- a/docs/playbooks/advanced-implementations/agent-365-observability/opentelemetry-setup.md
+++ b/docs/playbooks/advanced-implementations/agent-365-observability/opentelemetry-setup.md
@@ -6,7 +6,10 @@
 
 ## Overview
 
-This guide covers OpenTelemetry Collector configuration for capturing and exporting Agent 365 telemetry to multiple destinations including Application Insights, Azure Monitor, and third-party SIEM systems.
+This guide covers OpenTelemetry Collector configuration for **fan-out export** of Agent 365 telemetry to multiple destinations (Application Insights, Azure Monitor, third-party SIEM systems, WORM file storage).
+
+!!! note "Direct export vs. Collector fan-out"
+    Per [Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry), a custom-engine or Agent 365-enabled agent that calls `useMicrosoftOpenTelemetry()` (Node.js) / `use_microsoft_opentelemetry()` (Python) / `UseMicrosoftOpenTelemetry()` (.NET) can export **directly** to Azure Monitor, the Agent 365 backend, or any OTLP-compatible endpoint — no separate Collector is required. Deploy the OpenTelemetry Collector pattern in this guide when you need fan-out (for example, simultaneous export to Sentinel, Splunk, Datadog, and WORM storage) or when policy requires a customer-controlled egress point. Copilot Studio agents and declarative agents do **not** emit OTLP that you can intercept — their telemetry is delivered directly to the Agent 365 backend.
 
 ---
 
@@ -14,8 +17,10 @@ This guide covers OpenTelemetry Collector configuration for capturing and export
 
 ```mermaid
 flowchart LR
-    A[Agent 365 SDK] -->|OTLP| B[OTel Collector]
-    B -->|Azure Monitor Exporter| C[Application Insights]
+    A[Custom-engine / Agent 365-enabled Agent<br/>Microsoft OpenTelemetry Distro] -->|OTLP| B[OTel Collector]
+    A -.->|Direct exporter alternative| C[Application Insights]
+    A -.->|Direct exporter alternative| Z[Agent 365 backend]
+    B -->|Azure Monitor Exporter| C
     B -->|Azure Monitor Exporter| D[Log Analytics]
     B -->|OTLP Exporter| E[Splunk/Datadog]
     B -->|File Exporter| F[WORM Storage]
@@ -325,15 +330,26 @@ exporters:
 
 ---
 
-## Step 4: Agent SDK Integration
+## Step 4: Agent SDK integration
 
-### Copilot Studio Agent Configuration
+### Custom-engine / Agent 365-enabled agent — preferred Microsoft path
 
-Configure the Agent 365 SDK to export telemetry:
+The Microsoft-recommended way to emit OTLP that this Collector can ingest is to call the [Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry) from your agent host. The distro can export directly to Azure Monitor and to the Agent 365 backend; pointing it at this Collector via OTLP is an additional fan-out destination, not a replacement for the distro.
+
+See [Quick Start → Enable telemetry export](index.md#2-enable-telemetry-export-from-a-custom-engine-or-agent-365-enabled-agent) for the minimum `useMicrosoftOpenTelemetry()` call.
+
+### Generic OpenTelemetry SDK example (non-Agent-365 backends)
+
+If you are exporting only to a non-Microsoft OTLP backend, you can use the upstream OpenTelemetry SDKs directly. The example below is illustrative — it does **not** wire in Agent 365 export; for that, use the Microsoft OpenTelemetry Distro path above.
+
+### Copilot Studio agents
+
+Copilot Studio agents emit telemetry automatically into the Agent 365 backend (see [Observability integration for Copilot Studio](https://learn.microsoft.com/microsoft-agent-365/builder/observability)). They do not expose an OTLP endpoint that you can point at this Collector. Use the Microsoft 365 admin center, Defender, and Purview surfaces to consume that telemetry; this Collector pattern applies only to the custom-engine / Agent 365-enabled cases above.
 
 ```javascript
-// ILLUSTRATIVE PSEUDOCODE - Verify against current Microsoft documentation
-// Last verified: January 2026 | Status: Preview
+// ILLUSTRATIVE — generic OpenTelemetry pattern, NOT Microsoft Agent 365 export.
+// For Agent 365 export, use useMicrosoftOpenTelemetry() from @microsoft/opentelemetry.
+// Last verified against the Microsoft OpenTelemetry Distro article: June 2026.
 
 // agent-telemetry-config.js
 const { NodeSDK } = require('@opentelemetry/sdk-node');
@@ -360,7 +376,9 @@ const sdk = new NodeSDK({
   })
 });
 
-// Custom spans for agent operations
+// Custom spans below are illustrative FSI naming. The documented Agent 365 spans
+// are InvokeAgentScope / ExecuteToolScope / InferenceScope / OutputScope — emitted
+// for you by the Microsoft OpenTelemetry Distro, not by these custom helpers.
 const tracer = sdk.trace.getTracer('agent-365-telemetry');
 
 function instrumentAgentInteraction(interactionId, userId) {
@@ -396,13 +414,16 @@ function instrumentAgentInteraction(interactionId, userId) {
 module.exports = { sdk, instrumentAgentInteraction };
 ```
 
-### PowerShell Agent Instrumentation
+### PowerShell agent instrumentation
 
-For PowerShell-based agents:
+<!-- NEEDS_HUMAN_REVIEW: The Microsoft OpenTelemetry Distro is documented for .NET, Node.js, and Python only (Learn: "The distro supports .NET, Node.js, and Python"). The Agent 365 Observability SDK also publishes packages only for those three languages. The PowerShell helper below is a hand-rolled OTLP/HTTP client, not a Microsoft-supported instrumentation path. Use only for PowerShell-hosted utilities outside the agent runtime, or wrap your PowerShell logic in a .NET host and use Microsoft.OpenTelemetry. -->
+
+For PowerShell-based utilities outside the agent runtime, you can emit OTLP/HTTP directly:
 
 ```powershell
-# ILLUSTRATIVE PSEUDOCODE - Verify against current Microsoft documentation
-# Last verified: January 2026 | Status: Preview
+# ILLUSTRATIVE — hand-rolled OTLP/HTTP client. Microsoft does not ship a
+# PowerShell observability SDK. Verify schema and authentication against the
+# current OTLP specification before relying on this in production.
 
 # Agent telemetry helper functions
 function Initialize-AgentTelemetry {
@@ -562,8 +583,9 @@ service:
 - [Overview](index.md) - Observability architecture
 - [Application Insights Workbooks](application-insights-workbooks.md) - Dashboard templates
 - [Alerting Configuration](alerting-configuration.md) - Alert rules
-- [Microsoft Learn: OpenTelemetry in Azure](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-overview)
+- [Microsoft Learn: Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry)
+- [Microsoft Learn: OpenTelemetry in Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-overview)
 
 ---
 
-*Updated: May 2026 | Version: v1.6.2 | UI Verification Status: Current*
+*Updated: June 2026 | Version: v1.6.2 | UI Verification Status: Current*


### PR DESCRIPTION
## Audit summary

Audited the four files in `docs/playbooks/advanced-implementations/agent-365-observability/` against current Microsoft Learn:
- [Agent observability (SDK overview)](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability)
- [Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry)
- [Observability integration for Copilot Studio](https://learn.microsoft.com/microsoft-agent-365/builder/observability)

Surgical corrections to the FSI Agent 365 Observability playbook (4 files). Preserves zone-based retention, SIEM/Sentinel export, App Insights workbooks, and regulatory retention mapping. **Do not merge** until the `NEEDS_HUMAN_REVIEW` items below are triaged.

## Preview-vs-GA determination

Neither the [Agent observability](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability) doc nor the [Microsoft OpenTelemetry Distro](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/microsoft-opentelemetry) doc carries an explicit "Preview" or "GA" label. The SDK doc states: _"The existing approach described in this article continues to work without breaking changes."_ The Copilot Studio observability doc describes automatic emission in present tense (admin center, Defender, Purview surfaces) with no preview disclaimer. Package versions are the only objective maturity signal (Python `0.3.x`, Node `0.2.0-preview.1`, .NET `0.3-beta`). The playbook's previous blanket `"Preview Features ... may change before general availability"` claim was therefore not supported by Learn and has been replaced with a Learn-grounded "Status and SDK direction" callout. Flagged as `NEEDS_HUMAN_REVIEW` because the absence of an explicit Learn status label is itself a judgment call.

## Drift table (claim → Learn says → fix)

| # | File | Claim (before) | Learn says | Correction (after) |
|---|------|-----------------|------------|---------------------|
| 1 | index.md | `!!! note "Preview Features"` — "SDK observability features are in preview. Telemetry schemas and configuration options may change before general availability." | No explicit Preview/GA label anywhere in the SDK or Distro article; SDK doc says existing approach "continues to work without breaking changes"; Copilot Studio doc describes automatic emission as live. | Replaced with `!!! note "Status and SDK direction"` citing the Microsoft OpenTelemetry Distro as the recommended path and listing the actual SDK package versions. |
| 2 | index.md | Overview: "supports Copilot Studio custom-engine agents and Microsoft-built agents, with declarative agents primarily relying on native telemetry surfaces." | Learn distinguishes (a) automatic telemetry for Copilot Studio agents AND declarative agents, (b) manual SDK instrumentation for custom-engine + Agent 365-enabled agents. | Rewrote Overview with a 4-row "Agent type / How telemetry is emitted / Action required" table and a separate callout describing what Copilot Studio captures automatically. |
| 3 | index.md | Architecture mermaid: `Copilot Studio Agent -->|SDK| Agent 365 Telemetry`; "Collection Layer" only via App Insights. | Copilot Studio emits telemetry automatically (no SDK); Microsoft surfaces are M365 admin center, Defender, Purview. | Updated arrow labels (Automatic vs Distro), added "Microsoft Surfaces" subgraph, kept the FSI export layer as customer-owned overlay. |
| 4 | index.md | "Telemetry Signal Categories" tables with invented metric names: `agent.response.latency`, `agent.response.success`, `agent.tool.duration`, `agent.token.usage`, `agent.interaction.count`, `agent.topic.triggered`, `agent.fallback.triggered`, `agent.handoff.count`, `agent.rai.filter.triggered`, `agent.dlp.block`, `agent.auth.failure`, `agent.access.denied`, `agent.blueprint.phase`, `agent.sponsor.status`, `agent.config.change`. | Documented schema is scope-based: `InvokeAgentScope`, `ExecuteToolScope`, `InferenceScope`, `OutputScope`, with `gen_ai.*` / `microsoft.a365.*` / `microsoft.*` attributes (e.g., `gen_ai.agent.id`, `gen_ai.tool.name`, `gen_ai.usage.input_tokens`, `microsoft.tenant.id`). Latency = inherent span duration; success/failure = `error.type` presence. RAI/DLP/auth signals surface via Defender/Purview, not as Agent 365 SDK fields. | Replaced with: (a) "Documented Agent 365 scopes" table from Learn's "Validate for store publishing" section, (b) "Copilot Studio automatic spans" table from the Copilot Studio doc, (c) "FSI projections (illustrative, not a Microsoft schema)" table showing how each FSI metric is derived. Added `NEEDS_HUMAN_REVIEW` for the unverifiable signals. |
| 5 | index.md | "Configure Agent SDK (Preview)" JS snippet: invented `const agentConfig = { observability: { enabled, connectionString, signals: {...}, sampling: {...}, enrichment: {...} } }` | The real API is `useMicrosoftOpenTelemetry({ resource, azureMonitor, a365: { enabled, tokenResolver } })` from `@microsoft/opentelemetry`, or `ObservabilityManager` from the legacy `@microsoft/agents-a365-observability`. No `agentConfig.observability` object exists in Learn. | Replaced with the documented `useMicrosoftOpenTelemetry(...)` minimal example, including `AgenticTokenCacheInstance` as Learn shows. Added FSI overlay attributes via the standard OpenTelemetry `resource` parameter. |
| 6 | index.md | "By Agent Type" table: "Copilot Studio custom-engine agent / SDK Required: Recommended"; "Microsoft-built agent / SDK Required: No"; "Blueprint-registered / SDK Required: Yes". | Learn's three categories are: declarative (automatic, no SDK), custom-engine (SDK required), Agent 365-enabled (SDK required); Copilot Studio agents are automatic, NOT SDK-required. "Microsoft-built", "Blueprint-registered" are not Learn terms. | Rewrote table to match Learn categories with explicit "Microsoft-emitted telemetry" / "Manual SDK instrumentation" / "Custom attributes for FSI overlay" columns. Flagged the UAL coverage assumption with `NEEDS_HUMAN_REVIEW`. |
| 7 | index.md | "Correlation ID Tracing" — "The Agent 365 SDK generates correlation IDs that flow through..." | Learn describes standard OpenTelemetry trace/span IDs plus baggage propagation; there is no Agent 365-specific "correlation ID" construct. | Renamed section "Trace correlation"; rewrote to use OpenTelemetry trace IDs and baggage attributes; cited Learn's "Baggage attributes" section; flagged UAL→OTel-trace-ID linkage with `NEEDS_HUMAN_REVIEW`. |
| 8 | opentelemetry-setup.md | Architecture diagram positions OTel Collector as the only path between SDK and App Insights. | Microsoft OpenTelemetry Distro exports directly to Azure Monitor, Agent 365 backend, or any OTLP endpoint. Collector is an optional fan-out. | Added "Direct export vs. Collector fan-out" callout. Updated mermaid to show direct exporter alternatives and renamed source node to "Microsoft OpenTelemetry Distro". |
| 9 | opentelemetry-setup.md | "Step 4: Agent SDK Integration / Copilot Studio Agent Configuration" presented generic upstream `@opentelemetry/sdk-node` code as if it were the way to instrument a Copilot Studio agent. | Copilot Studio agents do NOT expose an OTLP endpoint that you can configure; their telemetry goes directly to the Agent 365 backend. | Renamed sub-sections, added explicit "Copilot Studio agents" note pointing readers to the Microsoft 365 admin center / Defender / Purview surfaces. Marked the upstream-OTel example as ILLUSTRATIVE for non-Microsoft OTLP backends and pointed readers to the Microsoft Distro path for Agent 365 export. |
| 10 | opentelemetry-setup.md | "PowerShell Agent Instrumentation" presented hand-rolled OTLP/HTTP JSON as a Microsoft-supported language path. | Microsoft OpenTelemetry Distro and the Agent 365 Observability SDK both document only .NET, Node.js, and Python. PowerShell is not a Microsoft-supported observability target. | Kept the helper as illustrative, added `NEEDS_HUMAN_REVIEW` flag explaining the gap, and recommended wrapping PowerShell logic in a .NET host that uses `Microsoft.OpenTelemetry`. |
| 11 | application-insights-workbooks.md | KQL queries reference `name == 'agent.interaction'`, `customDimensions.agent_response_latency_ms`, `name == 'rai.filter'`, `name == 'dlp.block'`, `customDimensions.fsi_zone`, etc., implying these are Agent 365 SDK fields. | None of those span/event names or custom dimensions are in the documented Agent 365 schema. They are FSI-overlay additions that must be projected by the Collector pipeline. RAI/DLP signals live in Defender/Purview. | Added a `!!! warning "Schema assumptions"` callout at the top explaining the two assumptions (custom-dimension injection and illustrative names). Flagged the Security & Compliance workbook with `NEEDS_HUMAN_REVIEW`. KQL query bodies left intact so the FSI projection pattern is preserved. |
| 12 | alerting-configuration.md | Alert queries reference the same invented span/event names and custom dimensions. | Same as #11. | Added the same top-of-page `!!! warning` and `NEEDS_HUMAN_REVIEW` flag (specifically calling out alerts 6–13: RAI, DLP, access, auth, sponsor, orphaned-agent, blueprint, config). |
| 13 | all 4 files | `Updated: May 2026` per-file stamps. | Audit date 2026-06-07. | Bumped to `Updated: June 2026` for content actually verified. (Framework version `v1.6.2` unchanged — matches `VERSION` file.) |

## NEEDS_HUMAN_REVIEW items inserted

| # | File | Section | Why |
|---|------|---------|-----|
| 1 | index.md | "Status and SDK direction" callout | Learn does not publish an explicit Preview/GA status label for the Agent 365 Observability surface as a whole. The pre-1.0 package versions are the only objective maturity signal. Product team should confirm the right framing. |
| 2 | index.md | "Telemetry Schema" — FSI projections | Signal names previously listed as documented (`agent.topic.triggered`, `agent.fallback.triggered`, `agent.handoff.count`, `agent.rai.filter.triggered`, `agent.dlp.block`, `agent.auth.failure`, `agent.access.denied`, `agent.blueprint.phase`, `agent.sponsor.status`, `agent.config.change`) are not in the documented Agent 365 SDK / Distro schema. RAI/DLP/auth signals surface via Defender/Purview, not the SDK. Need confirmation from the Agent 365 product team on the actual emission point before any of these are promoted to a production alert source. |
| 3 | index.md | "By Agent Type" table | The playbook previously asserted that every Agent 365 telemetry signal flows into the M365 Unified Audit Log. The Learn observability articles do not assert universal UAL coverage; FSI teams should validate in their tenant. |
| 4 | index.md | "Trace correlation" — Purview/UAL join | Learn does not explicitly state that the Microsoft 365 Unified Audit Log carries the OpenTelemetry trace ID. The KQL example falls back to a tenant + time-window join; the product team should confirm if a direct trace-ID join is available in any Defender/Purview event table. |
| 5 | index.md | Quick Start Step 2 — token resolver | `AgenticTokenCacheInstance` is documented for agents using the `@microsoft/agents-hosting` package. Agents on a different host need a custom token resolver per the Learn "Manual token resolver" section. |
| 6 | opentelemetry-setup.md | PowerShell instrumentation | Microsoft OpenTelemetry Distro lists only .NET, Node.js, and Python. The PowerShell OTLP/HTTP helper is not a Microsoft-supported instrumentation path. |
| 7 | application-insights-workbooks.md | Schema-assumptions callout | The Security & Compliance workbook depends on RAI/DLP/auth signals that Learn locates in Defender and Purview; queries should be rewritten against those source tables before production use. |
| 8 | alerting-configuration.md | Schema-assumptions callout | Alerts 6–13 depend on FSI-projected span names not present in the Agent 365 SDK schema. The actual sources are most likely Defender XDR Advanced Hunting (RAI, auth) and Purview audit (DLP, access, sponsor, config). |

## Deliberately kept

- **All FSI overlay concepts**: zone-based retention (30 days / 90 days / 7+ years), SIEM/Sentinel export pipeline, Application Insights workbook patterns, KQL projection patterns, regulatory retention mapping (FINRA 4511, SEC 17a-3/4, SOX 404, GLBA), escalation matrix.
- **OpenTelemetry Collector configuration**: remains valid as a fan-out pattern for multi-sink scenarios (Sentinel + Splunk + WORM). The change is to **frame** it accurately — Collector is optional, not the only ingestion path.
- **Workbook + alert query bodies**: useful as templates for FSI teams once the dependencies (custom-dimension injection + correct upstream source) are wired in. Surfaced via callouts and `NEEDS_HUMAN_REVIEW` flags so consumers know they must adapt before production use.
- **PowerShell helper code**: useful for non-runtime utilities; flagged so it is not mistaken for a Microsoft-supported SDK.
- **Integration with existing controls** (1.7 Audit Logging, 3.2 Usage Analytics, 3.9 Sentinel Integration, 1.8 Runtime Protection) — control references are still accurate.

## Gates

| Gate | Result |
|------|--------|
| `python scripts/verify_language_rules.py` | ✅ No prohibited language. |
| `python scripts/verify_version_stamps.py --check` | ✅ 9/9 OK, 0 drift. |
| `python scripts/verify_xref_graph.py` | ✅ 530 files, 6087 refs, 0 broken, 0 mislabeled. |
| `python scripts/verify_doc_links.py` (after `mkdocs build --strict`) | ✅ 688 pages, no broken internal links. |
| `python scripts/verify_commercial_scope.py` | ✅ No government / sovereign-cloud content. |
| `python scripts/verify_learn_url_health.py --state-file data/monitor-state.json` | ✅ 293 URLs, none returning 404/410/451. (Two new Learn URLs added in this PR — `microsoft-opentelemetry` and `builder/observability` — were verified live via `microsoft_docs_fetch` during the audit; they will be added to monitor coverage on the next probe run.) |
| `mkdocs build --strict` | ✅ Documentation built in 82.36 seconds. |

## Files changed

- `docs/playbooks/advanced-implementations/agent-365-observability/index.md` (significant rewrite)
- `docs/playbooks/advanced-implementations/agent-365-observability/opentelemetry-setup.md` (architecture framing + SDK section + PowerShell flag)
- `docs/playbooks/advanced-implementations/agent-365-observability/application-insights-workbooks.md` (top-of-page warning + footer)
- `docs/playbooks/advanced-implementations/agent-365-observability/alerting-configuration.md` (top-of-page warning + footer)
