### PR TITLE
Verification (#98): deprecated-term sweep + Learn currency check + mkdocs --strict

### DIFF
--- a/assessment/collectors/Collect-Graph.ps1
+++ b/assessment/collectors/Collect-Graph.ps1
@@ -15,7 +15,7 @@
       - Invoke-SharingAudit.ps1 — cross-tenant access pattern for principal classification
 
 .PARAMETER TenantId
-    Mandatory. Azure AD tenant ID.
+    Mandatory. Microsoft Entra tenant ID.
 
 .PARAMETER AuthMode
     Mandatory. Authentication mode: Interactive or ServicePrincipal.

--- a/assessment/collectors/Collect-PPAC.ps1
+++ b/assessment/collectors/Collect-PPAC.ps1
@@ -17,7 +17,7 @@
       - Invoke-HardeningBaselineCheck.ps1 (tenant settings, environment security checks)
 
 .PARAMETER TenantId
-    Mandatory. Azure AD tenant ID.
+    Mandatory. Microsoft Entra tenant ID.
 
 .PARAMETER AuthMode
     Mandatory. Authentication mode: Interactive or ServicePrincipal.

--- a/assessment/collectors/Collect-Purview.ps1
+++ b/assessment/collectors/Collect-Purview.ps1
@@ -16,7 +16,7 @@
       - FsiMimeControl.psm1 — MIME type compliance evaluation patterns
 
 .PARAMETER TenantId
-    Mandatory. Azure AD tenant ID.
+    Mandatory. Microsoft Entra tenant ID.
 
 .PARAMETER AuthMode
     Mandatory. Authentication mode: Interactive or ServicePrincipal.

--- a/assessment/collectors/Collect-Sentinel.ps1
+++ b/assessment/collectors/Collect-Sentinel.ps1
@@ -15,7 +15,7 @@
       - Invoke-HardeningBaselineCheck.ps1 — multi-control baseline check structure
 
 .PARAMETER TenantId
-    Mandatory. Azure AD tenant ID.
+    Mandatory. Microsoft Entra tenant ID.
 
 .PARAMETER AuthMode
     Mandatory. Authentication mode: Interactive or ServicePrincipal.

--- a/assessment/collectors/Collect-SharePoint.ps1
+++ b/assessment/collectors/Collect-SharePoint.ps1
@@ -15,7 +15,7 @@
       - restrict-agent-publishing.ps1 — security group validation patterns
 
 .PARAMETER TenantId
-    Mandatory. Azure AD tenant ID.
+    Mandatory. Microsoft Entra tenant ID.
 
 .PARAMETER AuthMode
     Mandatory. Authentication mode: Interactive or ServicePrincipal.

--- a/docs/playbooks/control-implementations/1.26/troubleshooting.md
+++ b/docs/playbooks/control-implementations/1.26/troubleshooting.md
@@ -45,9 +45,9 @@ This is documented Microsoft platform behaviour, not a configuration error.
 1. Confirm the user holds **AI Administrator**, **Power Platform Admin**, or **Environment Maker + agent ownership**
 2. Read-only roles (e.g., **Environment Reader**) see agent settings without the Security panel toggles
 
-### Cause: Agent version below v8 or environment feature flag disabled
+### Cause: Capability not yet rolled out to the environment or feature flag disabled
 
-1. Open *Copilot Studio → \[Agent\] → Settings → Details* and confirm the agent runtime version
+1. Open *Copilot Studio → \[Agent\] → Settings → Details* and confirm the agent is on the current published runtime — Copilot Studio is a continuously updated service with no discrete version gate, so a missing toggle reflects feature rollout rather than a numbered release
 2. Open *PPAC → Environments → \[Environment\] → Settings → Features* and confirm Copilot features are enabled
 3. If the toggle is missing across every agent in the environment, check tenant-level feature rollout — the per-agent File Upload toggle has rolled out progressively by region
 

--- a/scripts/create_asard_dataverse_schema.py
+++ b/scripts/create_asard_dataverse_schema.py
@@ -370,7 +370,7 @@ def seed_default_policy(client: CAAClient, dry_run: bool = False) -> None:
             "fsi_group_name": "Zone 2 — Team Collaboration (Named Groups)",
             "fsi_zone": 2,
             "fsi_group_id": "00000000-0000-0000-0000-000000000000",
-            "fsi_purpose": "Template record. Replace with actual Azure AD security group IDs "
+            "fsi_purpose": "Template record. Replace with actual Microsoft Entra security group IDs "
                            "approved by team managers for Zone 2 collaboration.",
             "fsi_is_active": False,
             "fsi_added_by": "ASARD Schema Deployment",
@@ -379,7 +379,7 @@ def seed_default_policy(client: CAAClient, dry_run: bool = False) -> None:
             "fsi_group_name": "Zone 3 — Enterprise Approved Security Group",
             "fsi_zone": 3,
             "fsi_group_id": "00000000-0000-0000-0000-000000000000",
-            "fsi_purpose": "Template record. Replace with actual Azure AD security group IDs "
+            "fsi_purpose": "Template record. Replace with actual Microsoft Entra security group IDs "
                            "pre-approved by enterprise security for Zone 3 managed agents.",
             "fsi_is_active": False,
             "fsi_added_by": "ASARD Schema Deployment",


### PR DESCRIPTION
## Summary

Verification pass for **OceanSquad #98** — deprecated-term grep sweep + `mkdocs build --strict` + Microsoft Learn currency check over FSI-AgentGov, following the #96 docs corrections.

**Result:** Sweep is exhaustive and clean. 8 mechanical deprecated-term hits fixed (3 logical changes). All 6 currency-verify items confirmed or annotated against Microsoft Learn (verified **2026-06-12**). `mkdocs build --strict` passes with **zero warnings**.

---

## 1. Deprecated-term grep sweep (all 312 playbooks + controls + scripts)

| Term swept | Result |
|---|---|
| `powervirtualagents` (namespace) | **0 namespace hits.** Only literal SPN-name `"PowerVirtualAgents"` inside a KQL `has_any` detection filter (`3.9/troubleshooting.md:122`) — **retained**: it matches a live service-principal display value; renaming would reduce detection coverage. |
| `Get-MsolUser` / `MSOnline` | **0 stale cmdlet hits.** `Get-MsolUser` already fixed in #96. `MSOnline` appears only as descriptive "MSOnline module is retired" prose — correct. |
| `Get-AzureAD*` / `AzureAD` module | All hits are **intentional**: Control 1.2 documents `AzureAD` as a *deprecated fallback* with loud warnings; `asard-deployment-guide.md` describes the deprecation date; `PrivilegedAccess.Read.AzureAD` is a real Graph scope; `Get-AzureADMS*` appears as a labeled legacy one-liner. No stale usages. |
| `Azure AD` (legacy portal name) | **7 mechanical hits fixed** (see below). Remaining hits retained: KQL data-value literals (`AppDisplayName == "Azure AD PIM"`), the repo-health-check prompts that *quote* the term to flag it, `Entra (Azure AD)` clarifier phrasing, and the deprecation-link in `asard-deployment-guide.md`. |
| `MCAS` | All retained — every hit is either "Defender for Cloud Apps (formerly MCAS)" phrasing or a literal Sentinel connector identifier (`McasEnabled`). |
| `Microsoft 365 Defender` | **Retained as intentional.** Hits are (a) "Microsoft Defender XDR (formerly Microsoft 365 Defender)" phrasing, (b) literal KQL `ProductName`/provider data-values (`has "Microsoft 365 Defender"`), and (c) the **current** Defender portal settings-node literally named "Microsoft 365 Defender". Mechanical renaming would break KQL matches — flagged for docs owner rather than auto-changed. |
| `Office 365 Security & Compliance` / `protection.office.com` | **0 stale hits.** Only appears in `1.19/troubleshooting.md:727` instructing admins to use `purview.microsoft.com` and *not* the legacy URLs — correct. |
| `Power Virtual Agents` | All retained — "formerly Power Virtual Agents" phrasing, legacy-SPN display-name literals + stable AppIds, the actual Power Automate trigger label "When Power Virtual Agents calls a flow", and classic-bot distinctions. |
| `AIAgentInfo` / `AgentInfo` (advanced-hunting table) | **0 hits for the issue''s singular spelling.** Framework correctly uses the **plural** `AgentsInfo` / `AIAgentsInfo` (see currency item 5). |
| `Copilot Studio vN` / `"v8"` | **1 mechanical hit fixed** (`1.26/troubleshooting.md`). The other 2 `v8` hits are correct: 1.26 control text explicitly says Copilot Studio has *no* v8-style versioning; `1.16` cites "CIS Controls v8" (a real standard). |

### Mechanical fixes applied (this PR)
1. **`docs/playbooks/control-implementations/1.26/troubleshooting.md`** — replaced the cause heading "Agent version below v8" + "confirm the agent runtime version" with feature-rollout phrasing. The stale "v8" version-gate directly contradicted Control 1.26''s own statement that Copilot Studio is a continuously-updated service with no discrete version numbers.
2. **`assessment/collectors/Collect-{Graph,PPAC,Purview,Sentinel,SharePoint}.ps1`** (5 files) — `Azure AD tenant ID` -> `Microsoft Entra tenant ID` in the `.SYNOPSIS`/param help.
3. **`scripts/create_asard_dataverse_schema.py`** (2 seed records) — `Azure AD security group IDs` -> `Microsoft Entra security group IDs`.

---

## 2. Currency verification (via `microsoft-learn` MCP — verified 2026-06-12)

| # | Item | Verdict | Source |
|---|---|---|---|
| 1 | Defender agent-security -> Agent 365 **July 1, 2026** gating (1.8/1.21/1.24) | ✅ **Confirmed** | [Transition Copilot Studio and Foundry agent security to Microsoft Agent 365](https://learn.microsoft.com/defender-xdr/security-for-ai/transition-agent-security-to-agent-365) |
| 2 | **W365A** GA status & region (1.7/1.20/1.29/2.25) | ✅ **Confirmed GA** (week of June 1, 2026); region availability appropriately hedged ("verify per tenant"). Cloud PC pools for Copilot Studio computer-use noted as Preview. | [What''s new in Windows 365 for Agents](https://learn.microsoft.com/windows-365/agents/whats-new) · [Intro](https://learn.microsoft.com/windows-365/agents/introduction-windows-365-for-agents) |
| 3 | **Entra Agent ID** GA + "AgenticUser" casing (2.26) | ✅ **GA April 2026 confirmed.** "AgenticUser" `userType` casing **already annotated** in `framework/agent-identity-architecture.md` as could-not-confirm (verified 2026-06-12) — Learn uses "agent user"/"agent identity". Correct handling. | [Entra releases & announcements](https://learn.microsoft.com/en-us/entra/fundamentals/whats-new) · [Agent ID what''s new](https://learn.microsoft.com/en-us/entra/agent-id/whats-new-agent-id) |
| 4 | **Copilot/AI-app retention** policy split location (1.9/4.3) | ✅ **Confirmed.** Framework correctly uses the separated locations **Microsoft Copilot experiences / Enterprise AI apps / Other AI apps** under Purview DLM > Policies, split from Teams chats. | [Retention for Copilot & AI apps](https://learn.microsoft.com/en-us/purview/retention-policies-copilot) |
| 5 | **Advanced-hunting table** name | ✅ **Confirmed `AgentsInfo`** (plural), transitioning from **`AIAgentsInfo`**, the latter accessible until **July 1, 2026**. Framework `1.21:47` is correct. **The issue''s expected `AgentInfo`/`AIAgentInfo` (singular) is a misspelling** — the authoritative Learn table is plural. | [`AgentsInfo` table (Preview)](https://learn.microsoft.com/en-us/defender-xdr/advanced-hunting-agentsinfo-table) |
| 6 | **4.8/4.9 license-matrix gap** | ✅ **Closed.** Both controls now present in `docs/reference/license-requirements.md` Pillar-4 matrix (4.8 = SAM + M365 E5/Purview Suite; 4.9 = M365 E5/Purview Suite). | n/a (in-repo) |

**Minor observation (non-blocking, P2):** the License Summary table row at `license-requirements.md:18` lists SAM for `4.1–4.6` but omits `4.8`, while the detailed Pillar-4 matrix (line 191) correctly maps 4.8 to SAM. Cosmetic summary/detail inconsistency — flagged for the docs owner, not changed here.

---

## 3. Build gate

- `mkdocs build --strict` → **PASS, zero warnings** (built in ~249s).
- `python scripts/verify_language_rules.py` → PASS (no prohibited language).
- `python scripts/verify_controls.py` → PASS.
- `ruff check scripts assessment` → PASS.

No broken links/anchors surfaced by `--strict`.

---

## Acceptance criteria
- [x] Grep sweep complete; report in this PR; all mechanical deprecated-term hits fixed.
- [x] Currency verify-list items 1–6 confirmed or annotated (label + date 2026-06-12).
- [x] `mkdocs build --strict` passes clean.
- [x] PR description includes the grep report and the Learn URLs used for verification.

Closes OceanSquad#98 (tracked in `judeper/OceanSquad`).
