### PR TITLE
fix(ci): author monitor PRs with GitHub App token so CI runs (#447/#448)

### DIFF
--- a/.github/workflows/learn-monitor.yml
+++ b/.github/workflows/learn-monitor.yml
@@ -93,12 +93,20 @@ jobs:
             echo "create_pr=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.should_create_pr.outputs.create_pr == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         id: create_pr
         if: steps.should_create_pr.outputs.create_pr == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: |
             Learn Monitor: Update Microsoft Learn documentation tracking
 

--- a/.github/workflows/regulatory-monitoring.yml
+++ b/.github/workflows/regulatory-monitoring.yml
@@ -65,12 +65,20 @@ jobs:
             fi
           fi
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.monitor.outputs.exit_code == '1'
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         id: create_pr
         if: steps.monitor.outputs.exit_code == '1'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: |
             Monitoring: Regulatory changes detected
 


### PR DESCRIPTION
Monitor PRs were created with GITHUB_TOKEN, which never triggers CI -> required checks never ran -> PRs permanently blocked (compounded by enforce_admins). Now mints a scoped fsi-monitor-bot App token and uses it for create-pull-request, so monitor PRs get checks. App perms: Contents + Pull requests R/W. Resolves the going-forward half of #447/#448.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>